### PR TITLE
Fix osf serializer

### DIFF
--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -30,13 +30,10 @@ export default DS.JSONAPISerializer.extend({
         return this._super(modelClass, resourceHash);
     },
 
-    keyForAttribute(key, method) {
-        if (method === 'deserialize') {
-            return Ember.String.underscore(key);
-        } else if (method === 'serialize') {
-            return Ember.String.camelize(key);
-        }
+    keyForAttribute(key) {
+        return Ember.String.underscore(key);
     },
+
     keyForRelationship(key) {
         return Ember.String.underscore(key);
     },


### PR DESCRIPTION
## Ticket
None

# Purpose
Fix `keyForAttribute`, which was incorrectly camelCasing the API payload -- h/t @abought 

# Notes for Reviewers
Fixing serialization/deserialization revealed an issue on the Node model where ember sends null values for optional fields (e.g. `templatedFrom`) instead of omitting them from the payload.

### Routes Added/Updated
None


