### PR TITLE
Fix serialization errors (not thoroughly tested)

### DIFF
--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -30,12 +30,8 @@ export default DS.JSONAPISerializer.extend({
         return this._super(modelClass, resourceHash);
     },
 
-    keyForAttribute(key, method) {
-        if (method === 'deserialize') {
-            return Ember.String.underscore(key);
-        } else if (method === 'serialize') {
-            return Ember.String.camelize(key);
-        }
+    keyForAttribute(key) {
+        return Ember.String.underscore(key);
     },
     keyForRelationship(key) {
         return Ember.String.underscore(key);

--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -42,5 +42,16 @@ export default DS.JSONAPISerializer.extend({
         // Don't send relationships to the server; this can lead to 500 errors.
         delete serialized.data.relationships;
         return serialized;
+    },
+
+    serializeAttribute(snapshot, json, key, attribute) {
+        // In certain cases, a field may be omitted from the server payload, but have a value (undefined)
+        // when serialized from the model. (eg node.template_from)
+        // Omit fields with a value of undefined before sending to the server. (but still allow null to be sent)
+        let val = snapshot.attr(key);
+        if (val !== undefined) {
+            this._super(...arguments);
+        }
     }
+
 });

--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -45,7 +45,7 @@ export default DS.JSONAPISerializer.extend({
         return serialized;
     },
 
-    serializeAttribute(snapshot, json, key, attribute) {
+    serializeAttribute(snapshot, json, key, attribute) {  // jshint ignore:line
         // In certain cases, a field may be omitted from the server payload, but have a value (undefined)
         // when serialized from the model. (eg node.template_from)
         // Omit fields with a value of undefined before sending to the server. (but still allow null to be sent)


### PR DESCRIPTION
## Ticket
none (sorry)

# Purpose
Possibly fix an error where models failed to save, because they were trying to save invalid values to the server. Also incorporates #27.

In certain cases, DRF will exclude fields (like `template_from`) from the payload if they are undefined. When ember serializes the fields in the model, it may include a value of `undefined` for that empty field, which leads to a 400 error (eg null value not allowed for field)

This candidate fix simply refuses to serialize an attribute if the value is undefined.

https://github.com/emberjs/data/blob/v2.5.1/addon/serializers/json-api.js#L410

# Notes for Reviewers
This is an experimental fix, but has not been thoroughly tested. Use at your own risk. It appears to work for null and false values, as well as truthy.

The right way to confirm this would probably be to write more unit tests once mirage is ready.

### Routes Added/Updated
None. However, this changes the base OSF apiv2 serializer in ways that will affect all pages. Try this on models with `mixedCase` field names, eg Nodes. (`template_from` / `templateFrom`)