### PR TITLE
[Ready] Feature/node contrib management [EOSF-38]

### DIFF
--- a/addon/adapters/contributor.js
+++ b/addon/adapters/contributor.js
@@ -1,4 +1,11 @@
 import OsfAdapter from './osf-adapter';
 
 export default OsfAdapter.extend({
+    buildURL(_, __, snap) {
+        // Modifies URL from /contributors to nodes/<nodeId>/contributors/ to match APIv2 route for creating contributors.
+        var base = this._super(...arguments);
+        var ar = base.split('/');
+        ar.splice(4, 0, 'nodes/' + snap._attributes.nodeId);
+        return ar.join('/');
+    }
 });

--- a/addon/models/contributor.js
+++ b/addon/models/contributor.js
@@ -5,5 +5,6 @@ import OsfModel from '../mixins/osf-model';
 export default DS.Model.extend(OsfModel, {
     bibliographic: DS.attr('boolean'),
     permission: DS.attr('string'),
-    users: DS.hasMany('user')
+    users: DS.hasMany('user'),
+    nodeId: DS.attr('string')
 });

--- a/addon/serializers/contributor.js
+++ b/addon/serializers/contributor.js
@@ -1,4 +1,17 @@
 import OsfSerializer from './osf-serializer';
 
 export default OsfSerializer.extend({
+    serialize: function(snapshot, options) {
+        // Restore relationships to serialized data
+        var serialized = this._super(snapshot, options);
+        serialized.data.relationships = {
+            users: {
+                data: {
+                    id: serialized.data.id,
+                    type: 'users'
+                }
+            }
+        };
+        return serialized;
+    },
 });

--- a/addon/serializers/contributor.js
+++ b/addon/serializers/contributor.js
@@ -4,6 +4,7 @@ export default OsfSerializer.extend({
     serialize: function(snapshot, options) {
         // Restore relationships to serialized data
         var serialized = this._super(snapshot, options);
+        // APIv2 expects contributor information to be nested under relationships.
         serialized.data.relationships = {
             users: {
                 data: {

--- a/package.json
+++ b/package.json
@@ -1,93 +1,95 @@
 {
-    "name": "ember-osf",
-    "version": "0.0.1",
-    "description": "Ember Data models for the OSF APIv2",
-    "directories": {
-        "doc": "doc",
-        "test": "tests"
-    },
-    "scripts": {
-        "build": "ember build",
-        "start": "ember server",
-        "test": "ember test",
-        "check-style": "./node_modules/jscs/bin/jscs ."
-    },
-    "repository": "",
-    "engines": {
-        "node": ">= 0.10.0"
-    },
-    "author": "",
-    "license": "MIT",
-    "devDependencies": {
-        "broccoli-asset-rev": "^2.2.0",
-        "chalk": "^1.1.3",
-        "ember-a11y": "0.1.8",
-        "ember-a11y-testing": "0.0.5",
-        "ember-ajax": "0.7.1",
-        "ember-cli": "^2.4.3",
-        "ember-cli-app-version": "^1.0.0",
-        "ember-cli-bootstrap-sassy": "0.5.3",
-        "ember-cli-dependency-checker": "^1.2.0",
-        "ember-cli-inject-live-reload": "^1.3.1",
-        "ember-cli-mirage": "0.1.13",
-        "ember-cli-qunit": "^1.2.1",
-        "ember-cli-release": "0.2.8",
-        "ember-cli-sass": "5.3.1",
-        "ember-cli-sri": "^2.0.0",
-        "ember-cli-template-lint": "0.4.7",
-        "ember-cli-uglify": "^1.2.0",
-        "ember-component-css": "0.1.9",
-        "ember-data": "^2.3.0",
-        "ember-disable-prototype-extensions": "^1.0.0",
-        "ember-disable-proxy-controllers": "^1.0.1",
-        "ember-export-application-global": "^1.0.4",
-        "ember-i18n": "4.2.1",
-        "ember-load-initializers": "0.5.1",
-        "ember-resolver": "2.0.3",
-        "ember-sinon": "0.5.0",
-        "ember-sinon-qunit": "1.3.1",
-        "jscs": "^3.0.3",
-        "loader": "2.1.0",
-        "loader.js": "4.0.3",
-        "moment": "^2.13.0"
-    },
-    "keywords": [
-        "ember-addon"
+  "name": "ember-osf",
+  "version": "0.0.1",
+  "description": "Ember Data models for the OSF APIv2",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "ember build",
+    "start": "ember server",
+    "test": "ember test",
+    "check-style": "./node_modules/jscs/bin/jscs ."
+  },
+  "repository": "",
+  "engines": {
+    "node": ">= 0.10.0"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "broccoli-asset-rev": "^2.2.0",
+    "chalk": "^1.1.3",
+    "ember-a11y": "0.1.8",
+    "ember-a11y-testing": "0.0.5",
+    "ember-ajax": "0.7.1",
+    "ember-cli": "^2.4.3",
+    "ember-cli-app-version": "^1.0.0",
+    "ember-cli-bootstrap-sassy": "0.5.3",
+    "ember-cli-dependency-checker": "^1.2.0",
+    "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-mirage": "0.1.13",
+    "ember-cli-qunit": "^1.2.1",
+    "ember-cli-release": "0.2.8",
+    "ember-cli-sass": "5.3.1",
+    "ember-cli-sri": "^2.0.0",
+    "ember-cli-template-lint": "0.4.7",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-component-css": "0.1.9",
+    "ember-data": "^2.3.0",
+    "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-disable-proxy-controllers": "^1.0.1",
+    "ember-export-application-global": "^1.0.4",
+    "ember-i18n": "4.2.1",
+    "ember-load-initializers": "0.5.1",
+    "ember-radio-button": "1.0.7",
+    "ember-resolver": "2.0.3",
+    "ember-sinon": "0.5.0",
+    "ember-sinon-qunit": "1.3.1",
+    "jscs": "^3.0.3",
+    "loader": "2.1.0",
+    "loader.js": "4.0.3",
+    "moment": "^2.13.0"
+  },
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+    "config": "^1.20.1",
+    "ember-cli-babel": "^5.1.5",
+    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-moment-shim": "1.1.0",
+    "ember-cli-node-assets": "^0.1.3",
+    "ember-get-config": "0.0.2",
+    "ember-moment": "6.1.0",
+    "ember-radio-buttons": "^4.0.1",
+    "ember-simple-auth": "1.1.0-beta.5",
+    "js-yaml": "^3.6.0"
+  },
+  "ember-addon": {
+    "configPath": "tests/dummy/config"
+  },
+  "jscsConfig": {
+    "preset": "airbnb",
+    "excludeFiles": [
+      "bower_components",
+      "dist",
+      "tmp",
+      "vendor",
+      "app/locales",
+      "tests/unit",
+      "tests/integration",
+      "tests/helpers",
+      "tests/dummy/app/mirage"
     ],
-    "dependencies": {
-        "config": "^1.20.1",
-        "ember-cli-babel": "^5.1.5",
-        "ember-cli-htmlbars": "^1.0.1",
-        "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-        "ember-cli-moment-shim": "1.1.0",
-        "ember-cli-node-assets": "^0.1.3",
-        "ember-get-config": "0.0.2",
-        "ember-moment": "6.1.0",
-        "ember-simple-auth": "1.1.0-beta.5",
-        "js-yaml": "^3.6.0"
-    },
-    "ember-addon": {
-        "configPath": "tests/dummy/config"
-    },
-    "jscsConfig": {
-        "preset": "airbnb",
-        "excludeFiles": [
-            "bower_components",
-            "dist",
-            "tmp",
-            "vendor",
-            "app/locales",
-            "tests/unit",
-            "tests/integration",
-            "tests/helpers",
-            "tests/dummy/app/mirage"
-        ],
-        "requireSpacesInAnonymousFunctionExpression": false,
-        "requireTrailingComma": false,
-        "disallowTrailingComma": false,
-        "requirePaddingNewLinesAfterBlocks": false,
-        "validateIndentation": 4,
-        "requirePaddingNewLinesBeforeLineComments": false,
-        "maximumLineLength": false
-    }
+    "requireSpacesInAnonymousFunctionExpression": false,
+    "requireTrailingComma": false,
+    "disallowTrailingComma": false,
+    "requirePaddingNewLinesAfterBlocks": false,
+    "validateIndentation": 4,
+    "requirePaddingNewLinesBeforeLineComments": false,
+    "maximumLineLength": false
+  }
 }

--- a/tests/dummy/app/controllers/nodes/detail.js
+++ b/tests/dummy/app/controllers/nodes/detail.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+    editedPermissions: {},
+    editedBibliographic: {},
+    actions: {
+        permissionChange(permission) {
+            // Adds updated permissions for a certain contributor
+            var p = permission.split(' ');
+            var permissions = p[0];
+            var contributorId = p[1];
+            this.editedPermissions[contributorId] = permissions;
+        },
+        bibliographicChange(target) {
+            // Adds updated bibliographic info for a certain contributor
+            var bibliographic = target.checked;
+            var contributorId = target.value;
+            this.editedBibliographic[contributorId] = bibliographic;
+        }
+    }
+});

--- a/tests/dummy/app/helpers/bibliographic-helper.js
+++ b/tests/dummy/app/helpers/bibliographic-helper.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export function bibliographicHelper(params) {
+    // checks if bibliographic is true or false
+    if (params[0]) {
+        return 'checked';
+    }
+    return null;
+}
+
+export default Ember.Helper.helper(bibliographicHelper);

--- a/tests/dummy/app/helpers/permission-helper.js
+++ b/tests/dummy/app/helpers/permission-helper.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export function permissionHelper(params) {
+    if (params[0] === params[1]) {
+        return 'selected';
+    }
+    return null;
+}
+
+export default Ember.Helper.helper(permissionHelper);

--- a/tests/dummy/app/routes/nodes/detail.js
+++ b/tests/dummy/app/routes/nodes/detail.js
@@ -64,13 +64,22 @@ export default Ember.Route.extend({
             }
         }
     },
-    canRemoveContributor(contribRemoving, contribMap) {
-        /** Contributor can only be removed if there is at least one other contributor
-        with admin permissions, and at least one other bibliographic contributor **/
+
+    generateContributorMap(contributors) {
+        // Maps all node contributors to format {contribID: {permission: "read|write|admin", bibliographic: "true|false"}}
+        var contribMap = contributors.content.currentState.reduce(function(newMap, contrib) {
+            newMap[contrib.id] = { permission: contrib._data.permission, bibliographic: contrib._data.bibliographic };
+            return newMap;
+        }, {});
+        return contribMap;
+    },
+    canModifyContributor(contribRemoving, contribMap) {
+        /** Checks to see if contributor(s) can be updated/removed. Contributor can only be updated/removed
+        if there is at least one other contributor with admin permissions, and at least one other bibliographic contributor **/
         var bibliographic = false;
         var admin = false;
         for (var contribId in contribMap) {
-            if (contribId === contribRemoving.id) {
+            if (contribRemoving && contribId === contribRemoving.id) {
                 continue;
             } else {
                 if (contribMap[contribId].bibliographic) {

--- a/tests/dummy/app/routes/nodes/detail.js
+++ b/tests/dummy/app/routes/nodes/detail.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+
     model(params) {
         return this.store.findRecord('node', params.node_id);
     },
@@ -32,10 +33,65 @@ export default Ember.Route.extend({
                     nodeId: node.id
                 });
                 contributor.save();
+                console.log('Contributor added.');
             } else {
                 console.log('You do not have permissions to add contributors');
             }
+        },
+        deleteContributor(contrib) {
+            var node = this.modelFor(this.routeName);
+            contrib.setProperties({ nodeId: node.id });
+            let user = this.modelFor('application');
+
+            var contribMap = node.get('contributors').content.currentState.reduce(function(newMap, contrib) {
+                newMap[contrib.id] = { permission: contrib._data.permission, bibliographic: contrib._data.bibliographic };
+                return newMap;
+            }, {});
+
+            if (node.get('currentUserPermissions').indexOf('admin') !== -1) {
+                this.attemptContributorRemoval(contrib, contribMap, node);
+            } else {
+                // Non-admins can only attempt to remove themselves as contributors
+                if (contrib.id === user.id) {
+                    this.attemptContributorRemoval(contrib, contribMap, node);
+                } else {
+                    console.log('Non-admins cannot delete other contributors.');
+                }
+            }
+        }
+    },
+    canRemoveContributor(contribRemoving, contribMap) {
+        /** Contributor can only be removed if there is at least one other contributor
+        with admin permissions, and at least one other bibliographic contributor **/
+        var bibliographic = false;
+        var admin = false;
+        for (var contribId in contribMap) {
+            if (contribId === contribRemoving.id) {
+                continue;
+            } else {
+                if (contribMap[contribId].bibliographic) {
+                    bibliographic = true;
+                }
+                if (contribMap[contribId].permission === 'admin') {
+                    admin = true;
+                }
+            }
+        }
+        if (bibliographic && admin) {
+            return true;
+        }
+        return false;
+    },
+
+    attemptContributorRemoval(contrib, contribMap, node) {
+        if (this.canRemoveContributor(contrib, contribMap)) {
+            node.get('contributors').removeObject(contrib);
+            contrib.deleteRecord();
+            node.save();
+            contrib.save();
+            console.log('Contributor removed.');
+        } else {
+            console.log('Cannot remove contributor');
         }
     }
-
 });

--- a/tests/dummy/app/routes/nodes/detail.js
+++ b/tests/dummy/app/routes/nodes/detail.js
@@ -46,31 +46,22 @@ export default Ember.Route.extend({
             var node = this.modelFor(this.routeName);
             var contribMap = this.generateContributorMap(node.get('contributors'));
             let user = this.modelFor('application');
-            var firstPerm;
-            var firstBib;
 
             for (var contrib in editedPermissions) {
                 contribMap[contrib].permission = editedPermissions[contrib];
-                if (editedPermissions[contrib]) {
-                    firstPerm = contrib;
-                }
             }
 
             for (var c in editedBibliographic) {
                 contribMap[c].bibliographic = editedBibliographic[c];
-                if (editedBibliographic[c]) {
-                    firstBib = c;
-                }
             }
 
             if (node.get('currentUserPermissions').indexOf('admin') !== -1) {
-                this.attemptContributorsUpdate(contribMap, node, editedPermissions, editedBibliographic,
-                  firstPerm, firstBib);
+                this.attemptContributorsUpdate(contribMap, node, editedPermissions, editedBibliographic);
             } else {
                 // Non-admins can only attempt to remove themselves as contributors
                 if (contrib.id === user.id) {
                     this.attemptContributorsUpdate(contribMap, node, editedPermissions,
-                      editedBibliographic, firstPerm, firstBib);
+                      editedBibliographic);
                 } else {
                     console.log('Non-admins cannot update other contributors.');
                 }
@@ -128,25 +119,13 @@ export default Ember.Route.extend({
         return false;
     },
 
-    attemptContributorsUpdate(contribMap, node, editedPermissions, editedBibliographic,
-      firstPerm, firstBib) {
+    attemptContributorsUpdate(contribMap, node, editedPermissions, editedBibliographic) {
         if (this.canModifyContributor(null, contribMap)) {
-            if (firstPerm) {
-                this.modifyPermissions(firstPerm, node, editedPermissions);
-            }
-            if (firstBib) {
-                this.modifyBibliographic(firstBib, node, editedBibliographic);
-            }
-
             for (var contrib in editedPermissions) {
-                if (contrib !== firstPerm) {
-                    this.modifyPermissions(contrib, node, editedPermissions);
-                }
+                this.modifyPermissions(contrib, node, editedPermissions);
             }
             for (var c in editedBibliographic) {
-                if (c !== firstBib) {
-                    this.modifyBibliographic(c, node, editedBibliographic);
-                }
+                this.modifyBibliographic(c, node, editedBibliographic);
             }
             node.save();
             console.log('Contributor(s) updated.');

--- a/tests/dummy/app/routes/nodes/detail.js
+++ b/tests/dummy/app/routes/nodes/detail.js
@@ -96,8 +96,32 @@ export default Ember.Route.extend({
         return false;
     },
 
+    attemptContributorsUpdate(contribMap, node, editedPermissions, editedBibliographic) {
+        if (this.canModifyContributor(null, contribMap)) {
+            for (var contrib in editedPermissions) {
+                this.store.findRecord('contributor', contrib).then(function(contributor) {
+                    contributor.set('nodeId', node.id);
+                    contributor.set('permission', editedPermissions[contrib]);
+                    contributor.save();
+                });
+            }
+            for (var c in editedBibliographic) {
+                this.store.findRecord('contributor', c).then(function(contributor) {
+                    debugger
+                    contributor.set('nodeId', node.id);
+                    contributor.set('bibliographic', editedBibliographic[c]);
+                    contributor.save();
+                });
+            }
+            node.save();
+            console.log('Contributor(s) updated.');
+        } else {
+            console.log('Cannot update contributor(s)');
+        }
+    },
+
     attemptContributorRemoval(contrib, contribMap, node) {
-        if (this.canRemoveContributor(contrib, contribMap)) {
+        if (this.canModifyContributor(contrib, contribMap)) {
             node.get('contributors').removeObject(contrib);
             contrib.deleteRecord();
             node.save();

--- a/tests/dummy/app/routes/nodes/detail.js
+++ b/tests/dummy/app/routes/nodes/detail.js
@@ -76,11 +76,11 @@ export default Ember.Route.extend({
             var contribMap = this.generateContributorMap(node.get('contributors'));
 
             if (node.get('currentUserPermissions').indexOf('admin') !== -1) {
-                this.attemptContributorRemoval(contrib, contribMap, node);
+                this.attemptContributorRemoval(contrib, contribMap);
             } else {
                 // Non-admins can only attempt to remove themselves as contributors
                 if (contrib.id === user.id) {
-                    this.attemptContributorRemoval(contrib, contribMap, node);
+                    this.attemptContributorRemoval(contrib, contribMap);
                 } else {
                     console.log('Non-admins cannot delete other contributors.');
                 }
@@ -150,7 +150,7 @@ export default Ember.Route.extend({
         });
     },
 
-    attemptContributorRemoval(contrib, contribMap, node) {
+    attemptContributorRemoval(contrib, contribMap) {
         if (this.canModifyContributor(contrib, contribMap)) {
             contrib.deleteRecord();
             contrib.save();

--- a/tests/dummy/app/routes/nodes/detail.js
+++ b/tests/dummy/app/routes/nodes/detail.js
@@ -42,25 +42,35 @@ export default Ember.Route.extend({
                 console.log('User ID must be specified.');
             }
         },
-        updateContributors(editedPermissions, editedBibliographic) {
+        updateContributors(editedPermissions, editedBibliographic, firstPerm, firstBib) {
             var node = this.modelFor(this.routeName);
             var contribMap = this.generateContributorMap(node.get('contributors'));
             let user = this.modelFor('application');
+            var firstPerm;
+            var firstBib;
 
             for (var contrib in editedPermissions) {
                 contribMap[contrib].permission = editedPermissions[contrib];
+                if (editedPermissions[contrib]) {
+                    firstPerm = contrib;
+                }
             }
 
             for (var c in editedBibliographic) {
                 contribMap[c].bibliographic = editedBibliographic[c];
+                if (editedBibliographic[c]) {
+                    firstBib = c;
+                }
             }
 
             if (node.get('currentUserPermissions').indexOf('admin') !== -1) {
-                this.attemptContributorsUpdate(contribMap, node, editedPermissions, editedBibliographic);
+                this.attemptContributorsUpdate(contribMap, node, editedPermissions, editedBibliographic,
+                  firstPerm, firstBib);
             } else {
                 // Non-admins can only attempt to remove themselves as contributors
                 if (contrib.id === user.id) {
-                    this.attemptContributorsUpdate(contribMap, node);
+                    this.attemptContributorsUpdate(contribMap, node, editedPermissions,
+                      editedBibliographic, firstPerm, firstBib);
                 } else {
                     console.log('Non-admins cannot update other contributors.');
                 }
@@ -118,28 +128,48 @@ export default Ember.Route.extend({
         return false;
     },
 
-    attemptContributorsUpdate(contribMap, node, editedPermissions, editedBibliographic) {
+    attemptContributorsUpdate(contribMap, node, editedPermissions, editedBibliographic,
+      firstPerm, firstBib) {
+        debugger;
         if (this.canModifyContributor(null, contribMap)) {
+            if (firstPerm) {
+              this.modifyPermissions(firstPerm, node, editedPermissions);
+            }
+            if (firstBib) {
+                this.modifyBibliographic(firstBib, node, editedBibliographic)
+            }
+
             for (var contrib in editedPermissions) {
-                this.store.findRecord('contributor', contrib).then(function(contributor) {
-                    contributor.set('nodeId', node.id);
-                    contributor.set('permission', editedPermissions[contrib]);
-                    contributor.save();
-                });
+                if (contrib !== firstPerm) {
+                    this.modifyPermissions(contrib, node, editedPermissions);
+                }
             }
             for (var c in editedBibliographic) {
-                this.store.findRecord('contributor', c).then(function(contributor) {
-                    debugger
-                    contributor.set('nodeId', node.id);
-                    contributor.set('bibliographic', editedBibliographic[c]);
-                    contributor.save();
-                });
+                if (c !== firstBib) {
+                    this.modifyBibliographic(c, node, editedBibliographic);
+                }
             }
             node.save();
             console.log('Contributor(s) updated.');
         } else {
             console.log('Cannot update contributor(s)');
         }
+    },
+
+    modifyPermissions(contrib, node, editedPermissions) {
+        this.store.findRecord('contributor', contrib).then(function(contributor) {
+            contributor.set('nodeId', node.id);
+            contributor.set('permission', editedPermissions[contrib]);
+            contributor.save();
+        });
+    },
+
+    modifyBibliographic(contrib, node, editedBibliographic) {
+        this.store.findRecord('contributor', contrib).then(function(contributor) {
+            contributor.set('nodeId', node.id);
+            contributor.set('bibliographic', editedBibliographic[contrib]);
+            contributor.save();
+        });
     },
 
     attemptContributorRemoval(contrib, contribMap, node) {

--- a/tests/dummy/app/routes/nodes/detail.js
+++ b/tests/dummy/app/routes/nodes/detail.js
@@ -21,6 +21,20 @@ export default Ember.Route.extend({
             } else {
                 console.log('You do not have permissions to edit this node');
             }
+        },
+        addContributor(contribId, permission, bibliographic) {
+            var node = this.modelFor(this.routeName);
+            if (node.get('currentUserPermissions').indexOf('admin') !== -1) {
+                var contributor = this.store.createRecord('contributor', {
+                    id: contribId,
+                    permission: permission,
+                    bibliographic: bibliographic,
+                    nodeId: node.id
+                });
+                contributor.save();
+            } else {
+                console.log('You do not have permissions to add contributors');
+            }
         }
     }
 

--- a/tests/dummy/app/routes/nodes/detail.js
+++ b/tests/dummy/app/routes/nodes/detail.js
@@ -42,7 +42,7 @@ export default Ember.Route.extend({
                 console.log('User ID must be specified.');
             }
         },
-        updateContributors(editedPermissions, editedBibliographic, firstPerm, firstBib) {
+        updateContributors(editedPermissions, editedBibliographic) {
             var node = this.modelFor(this.routeName);
             var contribMap = this.generateContributorMap(node.get('contributors'));
             let user = this.modelFor('application');
@@ -130,13 +130,12 @@ export default Ember.Route.extend({
 
     attemptContributorsUpdate(contribMap, node, editedPermissions, editedBibliographic,
       firstPerm, firstBib) {
-        debugger;
         if (this.canModifyContributor(null, contribMap)) {
             if (firstPerm) {
-              this.modifyPermissions(firstPerm, node, editedPermissions);
+                this.modifyPermissions(firstPerm, node, editedPermissions);
             }
             if (firstBib) {
-                this.modifyBibliographic(firstBib, node, editedBibliographic)
+                this.modifyBibliographic(firstBib, node, editedBibliographic);
             }
 
             for (var contrib in editedPermissions) {

--- a/tests/dummy/app/routes/nodes/detail.js
+++ b/tests/dummy/app/routes/nodes/detail.js
@@ -152,9 +152,7 @@ export default Ember.Route.extend({
 
     attemptContributorRemoval(contrib, contribMap, node) {
         if (this.canModifyContributor(contrib, contribMap)) {
-            node.get('contributors').removeObject(contrib);
             contrib.deleteRecord();
-            node.save();
             contrib.save();
             console.log('Contributor removed.');
         } else {

--- a/tests/dummy/app/routes/nodes/detail.js
+++ b/tests/dummy/app/routes/nodes/detail.js
@@ -25,17 +25,21 @@ export default Ember.Route.extend({
         },
         addContributor(contribId, permission, bibliographic) {
             var node = this.modelFor(this.routeName);
-            if (node.get('currentUserPermissions').indexOf('admin') !== -1) {
-                var contributor = this.store.createRecord('contributor', {
-                    id: contribId,
-                    permission: permission,
-                    bibliographic: bibliographic,
-                    nodeId: node.id
-                });
-                contributor.save();
-                console.log('Contributor added.');
+            if (contribId) {
+                if (node.get('currentUserPermissions').indexOf('admin') !== -1) {
+                    var contributor = this.store.createRecord('contributor', {
+                        id: contribId,
+                        permission: permission,
+                        bibliographic: bibliographic,
+                        nodeId: node.id
+                    });
+                    contributor.save();
+                    console.log('Contributor added.');
+                } else {
+                    console.log('You do not have permissions to add contributors');
+                }
             } else {
-                console.log('You do not have permissions to add contributors');
+                console.log('User ID must be specified.');
             }
         },
         deleteContributor(contrib) {

--- a/tests/dummy/app/templates/nodes/detail.hbs
+++ b/tests/dummy/app/templates/nodes/detail.hbs
@@ -15,6 +15,7 @@
   Title: {{input value=editedTitle}}
   <button {{action "editExisting" editedTitle}} class="btn btn-primary">Edit record</button>
 
+  <hr>
   <h2>Contributors</h2>
   <table class="table">
     <tr>
@@ -43,8 +44,8 @@
   <hr>
 
   <h2> Add contributor </h2>
-  <label> User ID </label> {{input value=contributorID}}
-  <label> Permissions </label>
+  <p><label> User ID </label> {{input value=contributorID}} </p>
+  <p><label> Permissions </label></p>
   <p>
     {{radio-button name="permission" value="read" checked=contributorPermissions}} Read
     {{radio-button name="permission" value="write" checked=contributorPermissions}} Read + Write

--- a/tests/dummy/app/templates/nodes/detail.hbs
+++ b/tests/dummy/app/templates/nodes/detail.hbs
@@ -22,15 +22,31 @@
       <table class="table">
           <tr>
             <th>ID</th>
+            <th> Permissions </th>
             <th>Author?</th>
           </tr>
           {{#each model.contributors as |contrib|}}
               <tr>
                 <td>{{contrib.id}}</td>
+                <td> {{contrib.permission}} </td>
                 <td>{{contrib.bibliographic}}</td>
               </tr>
           {{/each}}
       </table>
+
+    <h2> Add contributor </h2>
+    <label> User ID </label> {{input value=contributorID}}<br>
+
+    <label> Permissions </label><br>
+    {{radio-button name="permission" value="read" checked=contributorPermissions}} Read <br>
+    {{radio-button name="permission" value="write" checked=contributorPermissions}} Read + Write <br>
+    {{radio-button name="permission" value="admin" checked=contributorPermissions}} Administrator <br>
+
+    <label> Bibliographic Contributor </label> <br>
+    {{radio-button name="bibliographic" value=1 checked=bibliographic}} Bibliographic <br>
+    {{radio-button name="bibliographic" value=0 checked=bibliographic}} Non-Bibliographic <br>
+
+    <button {{action "addContributor" contributorID contributorPermissions bibliographic}} class="btn btn-primary">Add</button>
 
   <label>Affiliated Institutions</label>
   <p>

--- a/tests/dummy/app/templates/nodes/detail.hbs
+++ b/tests/dummy/app/templates/nodes/detail.hbs
@@ -15,48 +15,49 @@
   Title: {{input value=editedTitle}}
   <button {{action "editExisting" editedTitle}} class="btn btn-primary">Edit record</button>
 
-   <h2>Contributors</h2>
+  <h2>Contributors</h2>
+  <table class="table">
+    <tr>
+      <th>ID</th>
+      <th> Permissions </th>
+      <th>Bibliographic</th>
+      <th> </th>
+    </tr>
+    {{#each model.contributors as |contrib|}}
+      <tr>
+        <td>{{contrib.id}}</td>
+        <td>
+          <select onchange={{action "permissionChange" value="target.value" bubbles=true}}>
+            <option value="read {{contrib.id}}" selected={{permissionHelper contrib.permission "read"}}> Read </option>
+            <option value="write {{contrib.id}}" selected={{permissionHelper contrib.permission "write"}}>  Read + Write </option>
+            <option value="admin {{contrib.id}}" selected={{permissionHelper contrib.permission "admin"}}>  Administrator </option>
+          </select>
+        </td>
+        <input onchange={{action "bibliographicChange" value="target"}} checked={{bibliographicHelper contrib.bibliographic}} type="checkbox" name="bibliographic" value="{{contrib.id}}">
+        <td> <button {{action "deleteContributor" contrib}} class="btn btn-danger"> Remove </button> </td>
+      </tr>
+    {{/each}}
+  </table>
+  <button {{action "updateContributors" editedPermissions editedBibliographic}} class="btn btn-primary"> Save changes </button>
 
-      <table class="table">
-          <tr>
-            <th>ID</th>
-            <th> Permissions </th>
-            <th>Bibliographic</th>
-            <th> </th>
-            <th> </th>
-          </tr>
-          {{#each model.contributors as |contrib|}}
-              <tr>
-                <td>{{contrib.id}}</td>
-                <td> <select onchange={{action "permissionChange" value="target.value" bubbles=true}}>
-                      <option value="read {{contrib.id}}" selected={{permissionHelper contrib.permission "read"}}> Read </option>
-                      <option value="write {{contrib.id}}" selected={{permissionHelper contrib.permission "write"}}>  Read + Write </option>
-                      <option value="admin {{contrib.id}}" selected={{permissionHelper contrib.permission "admin"}}>  Administrator </option>
-                    </select>
-                </td>
-                <input onchange={{action "bibliographicChange" value="target"}} checked={{bibliographicHelper contrib.bibliographic}} type="checkbox" name="bibliographic" value="{{contrib.id}}">
-                <td> <button {{action "deleteContributor" contrib}} class="btn btn-danger"> Remove </button> </td>
-              </tr>
-          {{/each}}
-      </table>
-      <td> <button {{action "updateContributors" editedPermissions editedBibliographic}} class="btn btn-primary"> Save changes </button></td>
+  <hr>
 
-    <hr>
-
-    <h2> Add contributor </h2>
-    <label> User ID </label> {{input value=contributorID}}
-
-    <label> Permissions </label>
-    <p>{{radio-button name="permission" value="read" checked=contributorPermissions}} Read
+  <h2> Add contributor </h2>
+  <label> User ID </label> {{input value=contributorID}}
+  <label> Permissions </label>
+  <p>
+    {{radio-button name="permission" value="read" checked=contributorPermissions}} Read
     {{radio-button name="permission" value="write" checked=contributorPermissions}} Read + Write
-    {{radio-button name="permission" value="admin" checked=contributorPermissions}} Administrator </p>
+    {{radio-button name="permission" value="admin" checked=contributorPermissions}} Administrator
+  </p>
 
-    <label> Bibliographic </label>
-    <p> {{radio-button name="bibliographic" value=1 checked=bibliographic}} Bibliographic
-    {{radio-button name="bibliographic" value=0 checked=bibliographic}} Non-Bibliographic </p>
-
-    <button {{action "addContributor" contributorID contributorPermissions bibliographic}} class="btn btn-primary">Add</button>
-    <hr>
+  <label> Bibliographic </label>
+  <p>
+    {{radio-button name="bibliographic" value=1 checked=bibliographic}} Bibliographic
+    {{radio-button name="bibliographic" value=0 checked=bibliographic}} Non-Bibliographic
+  </p>
+  <button {{action "addContributor" contributorID contributorPermissions bibliographic}} class="btn btn-primary">Add</button>
+  <hr>
 
   <label>Affiliated Institutions</label>
   <p>

--- a/tests/dummy/app/templates/nodes/detail.hbs
+++ b/tests/dummy/app/templates/nodes/detail.hbs
@@ -25,33 +25,39 @@
             <th> Permissions </th>
             <th>Bibliographic</th>
             <th> </th>
+            <th> </th>
           </tr>
           {{#each model.contributors as |contrib|}}
               <tr>
                 <td>{{contrib.id}}</td>
-                <td> {{contrib.permission}} </td>
-                <td>{{contrib.bibliographic}}</td>
+                <td> <select onchange={{action "permissionChange" value="target.value" bubbles=true}}>
+                      <option value="read {{contrib.id}}" selected={{permissionHelper contrib.permission "read"}}> Read </option>
+                      <option value="write {{contrib.id}}" selected={{permissionHelper contrib.permission "write"}}>  Read + Write </option>
+                      <option value="admin {{contrib.id}}" selected={{permissionHelper contrib.permission "admin"}}>  Administrator </option>
+                    </select>
+                </td>
+                <input onchange={{action "bibliographicChange" value="target"}} checked={{bibliographicHelper contrib.bibliographic}} type="checkbox" name="bibliographic" value="{{contrib.id}}">
                 <td> <button {{action "deleteContributor" contrib}} class="btn btn-danger"> Remove </button> </td>
               </tr>
           {{/each}}
       </table>
+      <td> <button {{action "updateContributors" editedPermissions editedBibliographic}} class="btn btn-primary"> Save changes </button></td>
 
     <hr>
 
     <h2> Add contributor </h2>
-    <label> User ID </label> {{input value=contributorID}}<br>
+    <label> User ID </label> {{input value=contributorID}}
 
-    <label> Permissions </label><br>
-    {{radio-button name="permission" value="read" checked=contributorPermissions}} Read <br>
-    {{radio-button name="permission" value="write" checked=contributorPermissions}} Read + Write <br>
-    {{radio-button name="permission" value="admin" checked=contributorPermissions}} Administrator <br>
+    <label> Permissions </label>
+    <p>{{radio-button name="permission" value="read" checked=contributorPermissions}} Read
+    {{radio-button name="permission" value="write" checked=contributorPermissions}} Read + Write
+    {{radio-button name="permission" value="admin" checked=contributorPermissions}} Administrator </p>
 
-    <label> Bibliographic </label> <br>
-    {{radio-button name="bibliographic" value=1 checked=bibliographic}} Bibliographic <br>
-    {{radio-button name="bibliographic" value=0 checked=bibliographic}} Non-Bibliographic <br>
+    <label> Bibliographic </label>
+    <p> {{radio-button name="bibliographic" value=1 checked=bibliographic}} Bibliographic
+    {{radio-button name="bibliographic" value=0 checked=bibliographic}} Non-Bibliographic </p>
 
-    <button {{action "addContributor" contributorID contributorPermissions bibliographic}} class="btn btn-primary">Add</button> <br>
-
+    <button {{action "addContributor" contributorID contributorPermissions bibliographic}} class="btn btn-primary">Add</button>
     <hr>
 
   <label>Affiliated Institutions</label>

--- a/tests/dummy/app/templates/nodes/detail.hbs
+++ b/tests/dummy/app/templates/nodes/detail.hbs
@@ -23,16 +23,20 @@
           <tr>
             <th>ID</th>
             <th> Permissions </th>
-            <th>Author?</th>
+            <th>Bibliographic</th>
+            <th> </th>
           </tr>
           {{#each model.contributors as |contrib|}}
               <tr>
                 <td>{{contrib.id}}</td>
                 <td> {{contrib.permission}} </td>
                 <td>{{contrib.bibliographic}}</td>
+                <td> <button {{action "deleteContributor" contrib}} class="btn btn-danger"> Remove </button> </td>
               </tr>
           {{/each}}
       </table>
+
+    <hr>
 
     <h2> Add contributor </h2>
     <label> User ID </label> {{input value=contributorID}}<br>
@@ -42,11 +46,13 @@
     {{radio-button name="permission" value="write" checked=contributorPermissions}} Read + Write <br>
     {{radio-button name="permission" value="admin" checked=contributorPermissions}} Administrator <br>
 
-    <label> Bibliographic Contributor </label> <br>
+    <label> Bibliographic </label> <br>
     {{radio-button name="bibliographic" value=1 checked=bibliographic}} Bibliographic <br>
     {{radio-button name="bibliographic" value=0 checked=bibliographic}} Non-Bibliographic <br>
 
-    <button {{action "addContributor" contributorID contributorPermissions bibliographic}} class="btn btn-primary">Add</button>
+    <button {{action "addContributor" contributorID contributorPermissions bibliographic}} class="btn btn-primary">Add</button> <br>
+
+    <hr>
 
   <label>Affiliated Institutions</label>
   <p>
@@ -58,6 +64,8 @@
        	{{/each}}
     </table>
   </p>
+
+  <hr>
 
   <h2>Files</h2>
    {{#each model.files as |provider|}}

--- a/tests/unit/helpers/bibliographic-helper-test.js
+++ b/tests/unit/helpers/bibliographic-helper-test.js
@@ -1,0 +1,10 @@
+import { bibliographicHelper } from 'dummy/helpers/bibliographic-helper';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | bibliographic helper');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = bibliographicHelper([42]);
+  assert.ok(result);
+});


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-38

# Purpose
- [x] Add contributor
- [x] Update contributors 
- [x] Remove contributor

# Notes for Reviewers

Bulk update functionality https://openscience.atlassian.net/browse/EOSF-42 will improve this feature.  Right now, you can update multiple contributors in the dummy app, but it is making single, consecutive requests in the background to update each contributor.  There's no guarantee currently that these requests happen in the correct order.     This can cause problems, if for example, there are two contributors on the project, and I am the only admin. if I attempt to make you the admin, and change my permissions to read, this has to happen in the correct order.  You need to be an admin before I can remove myself as admin.

If bulk update functionality isn't eventually implemented, there could be additional checks to ensure the requests happen in the correct order.

### Routes Added/Updated

None.

