### PR TITLE
[WIP] Additional accessibility and translations for components

### DIFF
--- a/addon/components/file-chooser/template.hbs
+++ b/addon/components/file-chooser/template.hbs
@@ -6,13 +6,13 @@
             change=(action 'onFileInputChange')}}
     </p>
     <p>
-        You can also drag and drop a file from your computer.
+        {{t 'eosf.fileChooser.textHelp'}}
     </p>
     {{#if errorMessage}}
-        <div>Error: {{errorMessage}}</div>
+        <div>{{t 'eosf.fileChooser.textError'}}: {{errorMessage}}</div>
     {{/if}}
     {{#if files}}
-        <h4>Chosen files</h4>
+        <h4>{{t 'eosf.fileChooser.'}}</h4>
         <ul>
             {{#each files as |file|}}
                 <li>{{file.name}}</li>

--- a/addon/components/file-version/template.hbs
+++ b/addon/components/file-version/template.hbs
@@ -1,6 +1,5 @@
-<li class="file-version">
-    <div><label>ID: </label>{{version.id}}</div>
-    <div><label>Size: </label>{{version.size}}</div>
-    <div><label>Content type: </label>{{version.contentType}}</div>
-</li>
-{{yield}}
+<div class="file-version">
+    <div><strong>ID:</strong> {{version.id}}</div>
+    <div><strong>Size:</strong> {{version.size}}</div>
+    <div><strong>Content type:</strong> {{version.contentType}}</div>
+</div>

--- a/addon/components/pagination-control/template.hbs
+++ b/addon/components/pagination-control/template.hbs
@@ -1,6 +1,6 @@
 <div>
-    <button class="btn btn-primary" {{action 'previous'}} disabled={{disablePageReverse}}>Previous</button>
-    <button class="btn btn-primary" {{action 'next'}} disabled={{disablePageForward}}>Next</button>
+    <button class="btn btn-primary" {{action 'previous'}} disabled={{disablePageReverse}}>{{t 'eosf.paginationControl.buttonPrevious'}}</button>
+    <button class="btn btn-primary" {{action 'next'}} disabled={{disablePageForward}}>{{t 'eosf.paginationControl.buttonNext'}}</button>
 </div>
 
 <div>

--- a/addon/locales/en-us/translations.js
+++ b/addon/locales/en-us/translations.js
@@ -9,12 +9,26 @@ export default {
     //
     // "key.with.interpolation": "Text with {{anInterpolation}}"
     eosf: {
+        fileActions:{
+            labelInputMoveFolder: 'Folder ID',
+            labelInputMoveName: 'New name (optional)',
+            labelInputMoveNode: 'Node ID (optional)'
+        }, 
+        fileChooser: {
+            headingPicker: 'Chosen Files',
+            textHelp: 'You can also drag and drop a file from your computer.',
+            textError: 'Error'
+        },
         loginForm: {
             headingTitle: 'Login',
             labelInputEmail: 'Email',
             labelInputPassword: 'Password',
             labelInputRemember: 'Remember me',
             buttonSubmit: 'Sign in'
+        },
+        paginationControl: {
+            buttonNext: 'Next',
+            buttonPrevious: 'Previous'
         },
         signup: {
             headingTitle: 'Create a free account',

--- a/addon/locales/en-us/translations.js
+++ b/addon/locales/en-us/translations.js
@@ -10,10 +10,13 @@ export default {
     // "key.with.interpolation": "Text with {{anInterpolation}}"
     eosf: {
         fileActions:{
+            buttonMoveFile: 'Move', 
             labelInputMoveFolder: 'Folder ID',
             labelInputMoveName: 'New name (optional)',
-            labelInputMoveNode: 'Node ID (optional)'
-        }, 
+            labelInputMoveNode: 'Node ID (optional)',
+            labelInputOptionsCopy: 'Copy',
+            labelInputOptionsReplace: 'Replace'
+        },
         fileChooser: {
             headingPicker: 'Chosen Files',
             textHelp: 'You can also drag and drop a file from your computer.',

--- a/tests/dummy/app/components/file-actions/template.hbs
+++ b/tests/dummy/app/components/file-actions/template.hbs
@@ -2,7 +2,7 @@
     {{#unless file.isProvider}}
         <tr>
             <td>
-                Rename: 
+                Rename:
             </td>
             <td>
                 {{input value=newName}}
@@ -28,23 +28,23 @@
                 Move to:
             </td>
             <td>
-                <div>Folder ID: {{input value=moveTarget}}</div>
-                <div>Node ID (optional): {{input value=moveNode}}</div>
-                <div>New name (optional): {{input value=moveName}}</div>
+                <div><label for={{elem-id this 'file-actions-input-move-folder'}}>{{t 'eosf.fileActions.labelInputMoveFolder'}}: {{input required=true id=(elem-id this 'file-actions-input-move-folder') value=moveTarget }}</label></div>
+                <div><label for={{elem-id this 'file-actions-input-move-node'}}>{{t 'eosf.fileActions.labelInputMoveNode'}}: {{input id=(elem-id this 'file-actions-input-move-node') value=moveNode}}</label></div>
+                <div><label for={{elem-id this 'file-actions-input-move-name'}}>{{t 'eosf.fileActions.labelInputMoveName'}}: {{input id=(elem-id this 'file-actions-input-move-name') value=moveName}}</label></div>
                 <div>
-                    <label>
-                        Replace {{input type="checkbox" checked=moveReplace}}
+                    <label for={{elem-id this 'file-actions-input-option-replace'}}>
+                        {{t 'eosf.fileActions.labelInputOptionsReplace'}} {{input id=(elem-id this 'file-actions-input-option-replace') type="checkbox" checked=moveReplace}}
                     </label>
                 </div>
                 <div>
-                    <label>
-                        Copy {{input type="checkbox" checked=moveCopy}}
+                    <label for={{elem-id this 'file-actions-input-option-copy'}}>
+                        {{t 'eosf.fileActions.labelInputOptionsCopy'}} {{input id=(elem-id this 'file-actions-input-option-copy') type="checkbox" checked=moveCopy}}
                     </label>
                 </div>
             </td>
             <td>
                 <button {{action "moveFile" moveTarget}} class="btn btn-primary">
-                    Move
+                    {{t 'eosf.fileActions.buttonMoveFile'}}
                 </button>
             </td>
         </tr>


### PR DESCRIPTION
## Ticket
None provided; followon to https://openscience.atlassian.net/browse/EOSF-25

# Purpose
Continue adding `i18n` and accessibility features to our library of ember components to bring up to date with standards listed in #44. Includes work on form field accessibility.

# Notes for Reviewers
Components given a light review pass so far; this PR opened to track work in progress so it can be picked up/ extended as time permits. (and once the files widgets aren't being actively worked on- want to avoid a collision)

## Routes Added/Updated
Users list page (pagination controller)
File detail page (file chooser, actions, and versions components)

