### PR TITLE
Feature/Tags Widget [EOSF-59]

### DIFF
--- a/addon/components/tags-widget/component.js
+++ b/addon/components/tags-widget/component.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+import layout from './template';
+
+export default Ember.Component.extend({
+    layout,
+    tags: [],
+    actions: {
+        addATag(tag) {
+            this.attrs.addATag(tag);
+        },
+        removeATag(tag) {
+            this.attrs.removeATag(tag);
+        }
+    }
+});

--- a/addon/components/tags-widget/component.js
+++ b/addon/components/tags-widget/component.js
@@ -6,10 +6,10 @@ export default Ember.Component.extend({
     tags: [],
     actions: {
         addATag(tag) {
-            this.attrs.addATag(tag);
+            this.sendAction('addATag', tag);
         },
         removeATag(tag) {
-            this.attrs.removeATag(tag);
+            this.sendAction('removeATag', tag);
         }
     }
 });

--- a/addon/components/tags-widget/template.hbs
+++ b/addon/components/tags-widget/template.hbs
@@ -1,12 +1,14 @@
-<label> Tags </label>
-
 {{#each tags as |tag|}}
-    <p> {{tag}}
+    <span>
+        {{tag}}
         <button type="button" {{action "removeATag" tag}} class="btn btn-default btn-sm">
             <i class="glyphicon glyphicon-remove"></i>
         </button>
-    </p>
+    </span>
 {{/each}}
-
-{{input value=newTag}}
-<button {{action "addATag" newTag}} class="btn btn-primary">Add</button>
+<br>
+<br>
+<p>
+    {{input value=newTag}}
+    <button {{action "addATag" newTag}} class="btn btn-primary">Add</button>
+</p>

--- a/addon/components/tags-widget/template.hbs
+++ b/addon/components/tags-widget/template.hbs
@@ -8,6 +8,5 @@
     </p>
 {{/each}}
 
-<h4>Add tag</h4>
-    {{input value=newTag}}
-    <button {{action "addATag" newTag}} class="btn btn-primary">Add</button>
+{{input value=newTag}}
+<button {{action "addATag" newTag}} class="btn btn-primary">Add</button>

--- a/addon/components/tags-widget/template.hbs
+++ b/addon/components/tags-widget/template.hbs
@@ -1,0 +1,13 @@
+<label> Tags </label>
+
+{{#each tags as |tag|}}
+    <p> {{tag}}
+        <button type="button" {{action "removeATag" tag}} class="btn btn-default btn-sm">
+            <i class="glyphicon glyphicon-remove"></i>
+        </button>
+    </p>
+{{/each}}
+
+<h4>Add tag</h4>
+    {{input value=newTag}}
+    <button {{action "addATag" newTag}} class="btn btn-primary">Add</button>

--- a/addon/mixins/taggable-mixin.js
+++ b/addon/mixins/taggable-mixin.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+    actions: {
+        addATag(tag) {
+            var resource = this.get('model');
+            var currentTags = resource.get('tags').slice(0);
+            Ember.A(currentTags);
+            currentTags.pushObject(tag);
+            resource.set('tags', currentTags);
+            resource.save();
+        },
+        removeATag(tag) {
+            var resource = this.get('model');
+            var currentTags = resource.get('tags').slice(0);
+            currentTags.splice(currentTags.indexOf(tag), 1);
+            resource.set('tags', currentTags);
+            resource.save();
+        }
+    }
+});

--- a/addon/models/file.js
+++ b/addon/models/file.js
@@ -14,6 +14,7 @@ export default OsfModel.extend({
     dateModified: DS.attr('date'),
     dateCreated: DS.attr('date'),
     extra: DS.attr(),
+    tags: DS.attr(),
 
     parentFolder: DS.belongsTo('file', { inverse: 'files' }),
     isFolder: Ember.computed.equal('kind', 'folder'),

--- a/app/components/tags-widget/component.js
+++ b/app/components/tags-widget/component.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/components/tags-widget/component';

--- a/tests/dummy/app/controllers/nodes/detail/files/provider/file.js
+++ b/tests/dummy/app/controllers/nodes/detail/files/provider/file.js
@@ -5,6 +5,21 @@ export default Ember.Controller.extend({
         reloadFiles() {
             this.transitionToRoute('nodes.detail.files.provider',
                 this.get('node'), this.model.get('provider'));
+        },
+        addATag(tag) {
+            var file = this.get('model');
+            var currentTags = file.get('tags').slice(0);
+            Ember.A(currentTags);
+            currentTags.pushObject(tag);
+            file.set('tags', currentTags);
+            file.save();
+        },
+        removeATag(tag) {
+            var node = this.get('model');
+            var currentTags = node.get('tags').slice(0);
+            currentTags.splice(currentTags.indexOf(tag), 1);
+            node.set('tags', currentTags);
+            node.save();
         }
     }
 });

--- a/tests/dummy/app/controllers/nodes/detail/files/provider/file.js
+++ b/tests/dummy/app/controllers/nodes/detail/files/provider/file.js
@@ -1,25 +1,11 @@
 import Ember from 'ember';
+import TaggableMixin from 'ember-osf/mixins/taggable-mixin';
 
-export default Ember.Controller.extend({
+export default Ember.Controller.extend(TaggableMixin, {
     actions: {
         reloadFiles() {
             this.transitionToRoute('nodes.detail.files.provider',
                 this.get('node'), this.model.get('provider'));
-        },
-        addATag(tag) {
-            var file = this.get('model');
-            var currentTags = file.get('tags').slice(0);
-            Ember.A(currentTags);
-            currentTags.pushObject(tag);
-            file.set('tags', currentTags);
-            file.save();
-        },
-        removeATag(tag) {
-            var node = this.get('model');
-            var currentTags = node.get('tags').slice(0);
-            currentTags.splice(currentTags.indexOf(tag), 1);
-            node.set('tags', currentTags);
-            node.save();
         }
     }
 });

--- a/tests/dummy/app/controllers/nodes/detail/index.js
+++ b/tests/dummy/app/controllers/nodes/detail/index.js
@@ -19,6 +19,21 @@ export default Ember.Controller.extend({
             var bibliographic = target.checked;
             var contributorId = target.value;
             this.editedBibliographic[contributorId] = bibliographic;
+        },
+        addATag(tag) {
+            var node = this.get('model');
+            var currentTags = node.get('tags').slice(0);
+            Ember.A(currentTags);
+            currentTags.pushObject(tag);
+            node.set('tags', currentTags);
+            node.save();
+        },
+        removeATag(tag) {
+            var node = this.get('model');
+            var currentTags = node.get('tags').slice(0);
+            currentTags.splice(currentTags.indexOf(tag), 1);
+            node.set('tags', currentTags);
+            node.save();
         }
     }
 });

--- a/tests/dummy/app/controllers/nodes/detail/index.js
+++ b/tests/dummy/app/controllers/nodes/detail/index.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import TaggableMixin from 'ember-osf/mixins/taggable-mixin';
 
-export default Ember.Controller.extend({
+export default Ember.Controller.extend(TaggableMixin, {
     editedPermissions: {},
     editedBibliographic: {},
     actions: {
@@ -19,21 +20,6 @@ export default Ember.Controller.extend({
             var bibliographic = target.checked;
             var contributorId = target.value;
             this.editedBibliographic[contributorId] = bibliographic;
-        },
-        addATag(tag) {
-            var node = this.get('model');
-            var currentTags = node.get('tags').slice(0);
-            Ember.A(currentTags);
-            currentTags.pushObject(tag);
-            node.set('tags', currentTags);
-            node.save();
-        },
-        removeATag(tag) {
-            var node = this.get('model');
-            var currentTags = node.get('tags').slice(0);
-            currentTags.splice(currentTags.indexOf(tag), 1);
-            node.set('tags', currentTags);
-            node.save();
         }
     }
 });

--- a/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
+++ b/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
@@ -14,6 +14,9 @@
     <p><label>Date created: </label>{{model.dateCreated}}</p>
     <p><label>Checkout: </label>{{model.checkout}}</p>
 
+    {{#tags-widget addATag=(action 'addATag') removeATag=(action 'removeATag') tags=model.tags}}
+    {{/tags-widget}}
+
     <hr>
 
     <h3>Actions</h3>

--- a/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
+++ b/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
@@ -13,7 +13,7 @@
     <p><label>Date modified: </label>{{model.dateModified}}</p>
     <p><label>Date created: </label>{{model.dateCreated}}</p>
     <p><label>Checkout: </label>{{model.checkout}}</p>
-
+    <p><label> Tags </label></p>
     {{#tags-widget addATag=(action 'addATag') removeATag=(action 'removeATag') tags=model.tags}}
     {{/tags-widget}}
 

--- a/tests/dummy/app/templates/nodes/detail/index.hbs
+++ b/tests/dummy/app/templates/nodes/detail/index.hbs
@@ -7,7 +7,7 @@
     <p><label>Date Created:</label> {{moment-format model.dateCreated}}</p>
     <p><label>Date Modified:</label> {{moment-format model.dateModified}}</p>
     <p><label>Public </label> {{model.public}} </p>
-
+    <p><label> Tags </label></p>
     {{#tags-widget addATag=(action 'addATag') removeATag=(action 'removeATag') tags=model.tags}}
     {{/tags-widget}}
 

--- a/tests/dummy/app/templates/nodes/detail/index.hbs
+++ b/tests/dummy/app/templates/nodes/detail/index.hbs
@@ -11,6 +11,8 @@
     {{#tags-widget addATag=(action 'addATag') removeATag=(action 'removeATag') tags=model.tags}}
     {{/tags-widget}}
 
+    <hr>
+
     <p>
         <a href="{{model.links.html}}" target="_blank" class="btn btn-primary">
             View on OSF

--- a/tests/dummy/app/templates/nodes/detail/index.hbs
+++ b/tests/dummy/app/templates/nodes/detail/index.hbs
@@ -8,6 +8,9 @@
     <p><label>Date Modified:</label> {{moment-format model.dateModified}}</p>
     <p><label>Public </label> {{model.public}} </p>
 
+    {{#tags-widget addATag=(action 'addATag') removeATag=(action 'removeATag') tags=model.tags}}
+    {{/tags-widget}}
+
     <p>
         <a href="{{model.links.html}}" target="_blank" class="btn btn-primary">
             View on OSF

--- a/tests/integration/components/tags-widget/component-test.js
+++ b/tests/integration/components/tags-widget/component-test.js
@@ -5,20 +5,12 @@ moduleForComponent('tags-widget', 'Integration | Component | tags widget', {
   integration: true
 });
 
-test('it renders', function(assert) {
+test('it renders a tag', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('tags', ["hello"]);
 
-  this.render(hbs`{{tags-widget}}`);
+  this.render(hbs`{{tags-widget tags=tags}}`);
 
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#tags-widget}}
-      template block text
-    {{/tags-widget}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$('span').text().trim(), 'hello');
 });

--- a/tests/integration/components/tags-widget/component-test.js
+++ b/tests/integration/components/tags-widget/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('tags-widget', 'Integration | Component | tags widget', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{tags-widget}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#tags-widget}}
+      template block text
+    {{/tags-widget}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/unit/mixins/taggable-mixin-test.js
+++ b/tests/unit/mixins/taggable-mixin-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import TaggableMixinMixin from 'ember-osf/mixins/taggable-mixin';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | taggable mixin');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let TaggableMixinObject = Ember.Object.extend(TaggableMixinMixin);
+  let subject = TaggableMixinObject.create();
+  assert.ok(subject);
+});


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-59

# Purpose

Adds tags component and demonstrates use for both node tags and file tags in the dummy app.

# Notes for Reviewers

addATag and removeATag methods on the controllers are a little weird.  I was having a hard time getting `snapshot.record.changedAttributes` to update.  For adding a tag, the only way I could get it to change was if I made a copy of the current tags (that did not reference the original), pushed the new tag onto the list, and then set the tags to this list.  If I pushed the new tag onto the current tags and then tried to set, changedAttributes would be an empty object.

Also, adding/removing tags from files are currently creating an extra log (checked_in), which is an OSF problem, to be fixed here https://github.com/CenterForOpenScience/osf.io/pull/5820.  The bigger problem is that for our API PATCH requests we are serializing everything.  Our API requests should just send the pieces we want to change ticket here https://openscience.atlassian.net/browse/EOSF-61

## Routes Added/Updated


