### PR TITLE
Feature/Preserve New Relationship Links in Embeds [EOSF-64]

### DIFF
--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -4,8 +4,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-import config from 'ember-get-config';
-
 export default DS.JSONAPISerializer.extend({
     attrs: {
         links: {
@@ -14,25 +12,6 @@ export default DS.JSONAPISerializer.extend({
         embeds: {
             serialize: false
         }
-    },
-
-    _restoreLinksBeforeEmbed(resourceId, embeddedType) {
-        // If items are embedded, the embedded resource detail replaces the links. The APIv2 might need to be modified
-        // to return the original links in addition to the embedded information.
-        let links = {};
-        if (embeddedType === 'linked_nodes') {
-            links = {
-                self: {
-                    href: config.OSF.apiUrl + '/v2/collections/' + resourceId + '/relationships/linked_nodes/',
-                    meta: {}
-                },
-                related: {
-                    href: config.OSF.apiUrl + '/v2/collections/' + resourceId + '/linked_nodes/',
-                    meta: {}
-                }
-            };
-        }
-        return links;
     },
 
     _extractEmbeds(resourceHash) {
@@ -53,11 +32,9 @@ export default DS.JSONAPISerializer.extend({
                 included.push(data);
             }
             resourceHash.embeds[embedded].type = embedded;
-            var links = this._restoreLinksBeforeEmbed(resourceHash.id, embedded);
-            if (links !== {}) {
-                resourceHash.embeds[embedded].links = links;
-            }
-            //Only needs to contain id and type but this way we don't have to special case arrays
+            // Merges links returned from embedded object with relationship links, so all returned links are available.
+            var embeddedLinks = resourceHash.embeds[embedded].links || {};
+            resourceHash.embeds[embedded].links = Object.assign(embeddedLinks, resourceHash.relationships[embedded].links);
             resourceHash.relationships[embedded] = resourceHash.embeds[embedded];
             resourceHash.relationships[embedded].is_embedded = true;
         }


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-64

❗ blocked by https://github.com/CenterForOpenScience/osf.io/pull/5823

# Purpose

Previously in the APIv2, embedded resources would be directly embedded rather than returning a relationship link.  Which works fine until you need the link!

 So for collections in the dummy app, we needed to embed linked_nodes so we could see the projects in the collection.  But when we went to add a project to the collection, we didn't have the link to do so.

# Changes

Uses the new links returned by https://github.com/CenterForOpenScience/osf.io/pull/5823 to send the request instead of generating our own.  Merges any links returned with the embedded resource with the links under relationships so all links are preserved.

# Notes for Reviewers

## Routes Added/Updated