### PR TITLE
Feature/PATCH Requests Should Serialize only Dirty Attributes [EOSF-61]

### DIFF
--- a/addon/models/node.js
+++ b/addon/models/node.js
@@ -56,8 +56,19 @@ export default OsfModel.extend({
     files: DS.hasMany('file-provider'),
     //forkedFrom: DS.belongsTo('node'),
     nodeLinks: DS.hasMany('node-links', {
-        inverse: null,
-        updateRequestType: 'POST'
+        updateRequest: {
+            requestType: () => 'POST',
+            isBulk: () => true,
+            serialized(serialized) {
+                return {
+                    data: serialized.map(function(record) {
+                        var data = record.data;
+                        return data;
+                    })
+                };
+            }
+        },
+        inverse: null
     }),
     registrations: DS.hasMany('registrations', {
         inverse: 'registeredFrom'

--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -72,6 +72,12 @@ export default DS.JSONAPISerializer.extend({
     serialize: function(snapshot, options) {
         var serialized = this._super(snapshot, options);
         serialized.data.type = Ember.String.underscore(serialized.data.type);
+        // Only send dirty attributes in request
+        for (var attribute in serialized.data.attributes) {
+            if (!(Ember.String.camelize(attribute) in snapshot.record.changedAttributes())) {
+                delete serialized.data.attributes[attribute];
+            }
+        }
         // Don't send relationships to the server; this can lead to 500 errors.
         delete serialized.data.relationships;
         return serialized;


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-61

# Purpose

The default for our PATCH requests right now is to serialize the entire object and send it. Instead, we should just serialize the few fields we want to change.  This is important for when multiple users are trying to update things simultaneously, where your changes could overwrite my changes.

Also brings node links functionality up to date with latest relationship changes.

# Notes for Reviewers

Method was just to call super, and let all attributes be serialized and then remove the fields not present in changedAttributes().

## Routes Added/Updated

None


