### PR TITLE
Add doc links to model source code

### DIFF
--- a/addon/mixins/paginated-route.js
+++ b/addon/mixins/paginated-route.js
@@ -11,33 +11,44 @@ export default Ember.Mixin.create({
         }
     },
 
-    // Configure how pagination query params in the frontend map to the query params expected by the API backend
-    //  (helps support different APIs). Most users will not need to change this.
-    apiArgs: {
-        page: 'page',
-        page_size: 'page[size]'
-    },
+    /**
+     * Allow configuration of the backend URL parameter used for page #
+     * @property pageParam
+     * @type String
+     * @default "page"
+     */
+    pageParam: 'page',
 
     /**
-     * @method queryForPage  Fetch a route-specifed page of results from an external API
+     * Allow configuration of the backend URL parameter for number of results per page
+     * @property perPageParam
+     * @type String
+     * @default "page[size]"
+     */
+    perPageParam: 'page[size]',
+
+    /**
+     * @method queryForPage  Fetch a route-specified page of results from an external API
      * @param modelName The name of the model to query in the store
-     * @param routeParams Parameters gictionary available to the model hook; must be passed in manually
+     * @param routeParams Parameters dictionary available to the model hook; must be passed in manually
      * @param userParams Additional user-specified query parameters
      * @returns {Promise}
      */
     queryForPage(modelName, routeParams, userParams) {
+        userParams = userParams || {};
         let params = Object.assign({}, userParams || {}, routeParams);
 
-        // Rename parameters to match what the API expects, and remove the old param name if necessary
-        let apiArgs = this.get('apiArgs');
-        for (let frontEndParamName of Object.keys(apiArgs)) {
-            let backEndParamName = apiArgs[frontEndParamName];
-            if (params[frontEndParamName]) {
-                params[backEndParamName] = params[frontEndParamName];
-            }
-            if (frontEndParamName !== backEndParamName) {
-                delete params[frontEndParamName];
-            }
+        // Rename the ember-route URL params to what the backend API expects, and remove the old param if necessary
+        const page = params.page;
+        delete params.page;
+
+        const pageSize = params.page_size;
+        delete params.page_size;
+        if (page) {
+            params[this.get('pageParam')] = page;
+        }
+        if (pageSize) {
+            params[this.get('perPageParam')] = pageSize;
         }
         return this.store.query(modelName, params);
     }

--- a/addon/models/collection.js
+++ b/addon/models/collection.js
@@ -3,6 +3,11 @@ import DS from 'ember-data';
 import OsfModel from './osf-model';
 import { serializeHasMany } from '../utils/serialize-relationship';
 
+/**
+ * Model for OSF APIv2 collections
+ * For field and usage information, see:
+ *  https://api.osf.io/v2/docs/#!/v2/Collection_List_GET
+ */
 export default OsfModel.extend({
     title: DS.attr('string'),
     dateCreated: DS.attr('date'),

--- a/addon/models/comment-report.js
+++ b/addon/models/comment-report.js
@@ -2,6 +2,11 @@ import DS from 'ember-data';
 
 import OsfModel from './osf-model';
 
+/**
+ * Model for OSF APIv2 comment reports. Primarily accessed via relationship fields.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/Comment_Reports_List_GET
+ */
 export default OsfModel.extend({
     category: DS.attr('string'),
     text: DS.belongsTo('comment')

--- a/addon/models/comment.js
+++ b/addon/models/comment.js
@@ -2,6 +2,14 @@ import DS from 'ember-data';
 
 import OsfModel from './osf-model';
 
+/**
+ * Model for OSF APIv2 comments. This model may be used with one of several API endpoints. It may be queried directly,
+ *  or accessed via relationship fields.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/Comment_Detail_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Comments_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Registration_Comments_List_GET
+ */
 export default OsfModel.extend({
     // TODO validation: maxLength
     content: DS.attr('string'),

--- a/addon/models/contributor.js
+++ b/addon/models/contributor.js
@@ -2,6 +2,11 @@ import DS from 'ember-data';
 
 import OsfModel from './osf-model';
 
+/**
+ * Model for OSF APIv2 contributors. Primarily accessed via relationship fields.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Contributors_List_GET
+ */
 export default OsfModel.extend({
     bibliographic: DS.attr('boolean'),
     permission: DS.attr('string'),

--- a/addon/models/file-provider.js
+++ b/addon/models/file-provider.js
@@ -3,6 +3,14 @@ import DS from 'ember-data';
 
 import OsfModel from './osf-model';
 
+/**
+ * Model for OSF APIv2 file providers. Primarily used in relationship fields.
+ * This model is used for basic file provider metadata. To interact with file contents directly, see the `file-manager` service.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Providers_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Provider_Detail_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Registration_Providers_List_GET
+*/
 export default OsfModel.extend({
     name: DS.attr('string'),
     kind: DS.attr('string'),

--- a/addon/models/file-version.js
+++ b/addon/models/file-version.js
@@ -2,6 +2,13 @@ import DS from 'ember-data';
 
 import OsfModel from './osf-model';
 
+/**
+ * Model for OSF APIv2 file versions. Primarily used in relationship fields.
+ * This model is used for basic file version metadata. To interact with file contents directly, see the `file-manager` service.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/File_Versions_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/File_Version_Detail_GET
+*/
 export default OsfModel.extend({
     size: DS.attr('number'),
     contentType: DS.attr('string')

--- a/addon/models/file.js
+++ b/addon/models/file.js
@@ -3,6 +3,17 @@ import DS from 'ember-data';
 
 import OsfModel from './osf-model';
 
+/**
+ * Model for OSF APIv2 files. This model may be used with one of several API endpoints. It may be queried directly,
+ *  or (more commonly) accessed via relationship fields.
+ * This model is used for basic file metadata. To interact with file contents directly, see the `file-manager` service.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/File_Detail_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Files_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Node_File_Detail_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Registration_Files_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Registration_File_Detail_GET
+ */
 export default OsfModel.extend({
     name: DS.attr('string'),
     kind: DS.attr('string'),

--- a/addon/models/institution.js
+++ b/addon/models/institution.js
@@ -2,6 +2,16 @@ import DS from 'ember-data';
 
 import OsfModel from './osf-model';
 
+/**
+ * Model for OSF APIv2 institutions. This model may be used with one of several API endpoints. It may be queried directly,
+ *  or accessed via relationship fields.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/Institution_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Institution_Detail_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Institutions_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Registration_Institutions_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/User_Institutions_GET
+ */
 export default OsfModel.extend({
     name: DS.attr('string'),
     description: DS.attr('string'),

--- a/addon/models/log.js
+++ b/addon/models/log.js
@@ -2,6 +2,14 @@ import DS from 'ember-data';
 
 import OsfModel from './osf-model';
 
+/**
+ * Model for OSF APIv2 log entries. This model may be used with one of several API endpoints. It may be queried directly,
+ *  or accessed via relationship fields.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Log_Detail_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Log_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Registration_Log_List_GET
+ */
 export default OsfModel.extend({
     date: DS.attr('date'),
     action: DS.attr('string'),

--- a/addon/models/node-link.js
+++ b/addon/models/node-link.js
@@ -2,6 +2,15 @@ import DS from 'ember-data';
 
 import OsfModel from './osf-model';
 
+/**
+ * Model for OSF APIv2 node links. This model may refer to one of several API endpoints. It may be queried directly,
+ *  or accessed via relationship fields.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Links_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Links_Detail_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Registration_Node_Links_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Registration_Node_Links_Detail_GET
+ */
 export default OsfModel.extend({
     targetNode: DS.belongsTo('node')
 

--- a/addon/models/node.js
+++ b/addon/models/node.js
@@ -4,6 +4,17 @@ import OsfModel from './osf-model';
 
 import { serializeHasMany } from '../utils/serialize-relationship';
 
+/**
+ * Model for OSF APIv2 nodes. This model may be used with one of several API endpoints. It may be queried directly,
+ *  or accessed via relationship fields.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/Node_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Detail_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Children_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Linked_Nodes_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Node_Forks_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/User_Nodes_GET
+ */
 export default OsfModel.extend({
     title: DS.attr('string'),
     description: DS.attr('string'),

--- a/addon/models/registration.js
+++ b/addon/models/registration.js
@@ -2,6 +2,15 @@ import DS from 'ember-data';
 
 import Node from './node';
 
+/**
+ * Model for OSF APIv2 registrations. This model may be used with one of several API endpoints. It may be queried directly,
+ *  or accessed via relationship fields.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/Registration_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Registration_Detail_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Registration_Children_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/User_Registrations_GET
+ */
 export default Node.extend({
     dateRegistered: DS.attr('date'),
     pendingRegistrationApproval: DS.attr('boolean'),

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -2,6 +2,14 @@ import DS from 'ember-data';
 
 import OsfModel from './osf-model';
 
+/**
+ * Model for OSF APIv2 users. This model may be used with one of several API endpoints. It may be queried directly,
+ *  or accessed via relationship fields.
+ * For field and usage information, see:
+ *    https://api.osf.io/v2/docs/#!/v2/User_List_GET
+ *    https://api.osf.io/v2/docs/#!/v2/User_Detail_GET
+ *    https://api.osf.io/v2/docs/#!/v2/Institution_User_List_GET
+ */
 export default OsfModel.extend({
     fullName: DS.attr('string'),
     givenName: DS.attr('string'),


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-71

# Purpose
Help implementers discover how to use models.

In source code, provide a link to APIv2 browseable docs, as the source of record for field definitions and usage. Because relationship fields are complicated, I've tried to map this to as many relevant routes as I can find based on APIv2 serializers.

Additionally, improve documentation and URL param configuration for the pagination mixin to match recently merged changes.

# Notes for Reviewers
BrianG has indicated that the API team is investigating how to make these links clickable. Currently, clicking these links takes you to swagger docs but does not expand the relevant section.

They have recommended [swagger docs](https://api.osf.io/v2/docs/) as entry point going forward.

## Routes Added/Updated
None.