### PR TITLE
Add REDIRECT_URI param to blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This file is structured like:
   CLIENT_ID: null
   PERSONAL_ACCESS_TOKEN: null
   OAUTH_SCOPES: osf.full_read osf.full_write
+  REDIRECT_URI: http://localhost:4200/login
 ```
 
 You will need to fill out options for each backend you want to use (see 'Running' below).
@@ -53,6 +54,8 @@ uri is correct.  If it needs a trailing slash, be sure to include a trailing sla
 Edit the new file (installed in the config directory) and set:
 - `CLIENT_ID` to the client id of your developer application
 - `PERSONAL_ACCESS_TOKEN` to the newly generated token (if applicable, optional for staging development)
+- REDIRECT_URI: Must exactly match the redirect URI used to register the OAuth developer application. 
+Default value is appropriate for local development using `ember server`, with a login page at `/login` 
 
 #### Using the Test API
 

--- a/blueprints/ember-osf/files/config/_local.yml
+++ b/blueprints/ember-osf/files/config/_local.yml
@@ -1,22 +1,26 @@
 
 ######## ember-osf settings ########
 # local:
-#   CLIENT_ID: null
-#   PERSONAL_ACCESS_TOKEN: null
-#   OAUTH_SCOPES: osf.full_read osf.full_write
+#    CLIENT_ID: null
+#    PERSONAL_ACCESS_TOKEN: null
+#    OAUTH_SCOPES: osf.full_read osf.full_write
+#    REDIRECT_URI: http://localhost:4200/login/
 
 # stage:
 #    CLIENT_ID: null
 #    PERSONAL_ACCESS_TOKEN: null
 #    OAUTH_SCOPES: osf.full_read osf.full_write
+#    REDIRECT_URI: http://localhost:4200/login/
 
 # stage2:
-#   CLIENT_ID: null
-#   PERSONAL_ACCESS_TOKEN: null
-#   OAUTH_SCOPES: osf.full_read osf.full_write
+#    CLIENT_ID: null
+#    PERSONAL_ACCESS_TOKEN: null
+#    OAUTH_SCOPES: osf.full_read osf.full_write
+#    REDIRECT_URI: http://localhost:4200/login/
 
 test:
-  CLIENT_ID: null
-  PERSONAL_ACCESS_TOKEN: null
-  OAUTH_SCOPES: osf.full_read osf.full_write
+    CLIENT_ID: null
+    PERSONAL_ACCESS_TOKEN: null
+    OAUTH_SCOPES: osf.full_read osf.full_write
+    REDIRECT_URI: http://localhost:4200/login/
 ######### end ember-osf ##########


### PR DESCRIPTION
## Ticket
None.

# Purpose
Add REDIRECT_URI param to blueprint to reflect recent refactorings. ([ref](https://github.com/CenterForOpenScience/ember-osf/pull/83#discussion_r68399798))

Also add documentation as appropriate.

# Notes for Reviewers
Need to confirm that the specified default values are correct for local development scenarios.

## Routes Added/Updated
If blueprint changes are propagated to a user's `config/local.yml` file, this should fix a bug where the `/login` functionality fails due to `redirect_uri=undefined` in the CAS URL.
