### PR TITLE
[WIP][r&d] Demonstrate ability to present ember URLs as GUID URLs

### DIFF
--- a/addon/mixins/guid-route-mask.js
+++ b/addon/mixins/guid-route-mask.js
@@ -1,0 +1,78 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+    _isGuidItem(model) {
+        // TODO: Hard-coded assumptions about guid item by model type- make this nice if we see it works
+        let guidModels = ['file', 'node', 'profile'];
+        return guidModels.indexOf(model.constructor.modelName) !== -1;
+    },
+
+    /**
+     * Get the guid associated with a model. Some models, like files, store guid on a parameter other than _id
+     * @param model
+     * @returns {*}
+     * @private
+     */
+    _guidForModel(model) {
+        return model.get('guid') || model.get('id');
+    },
+
+    /**
+     * Route name (with segments)
+     * @param routeName
+     * @returns {*}
+     */
+    findGuidParent(routeName) {
+        let model = this.modelFor(routeName);
+        if (this._isGuidItem(model)) {
+            return routeName;
+        }
+
+        // If this route isn't a guid route, maybe the parent is! If a parent exists, recurse; otherwise return null
+        let segments = routeName.split('.');
+        if (segments.length > 1) {
+            let parentPath = segments.slice(0, -1).join('.');
+            return this.findGuidParent(parentPath);
+        }
+        return null;
+    },
+
+    /**
+     * Given a routeName, get the route for that, and replace it with the model GUID
+     */
+    maskedGuidUrl(routeName) {
+
+        // 1. Get model for the guid section
+        // 2. Generate route for parent (so we know what to replace with GUID)
+        // 3.
+        // TODO: This may be very fragile if we need to consider the params for the parent route(s) to that segment as arguments to `generate`
+        let guidBaseModel = this.modelFor(routeName);
+        let newBaseURL = '/' + this._guidForModel(guidBaseModel);
+
+        let guidBaseRoute = this.router.generate(...arguments);
+        let currentRoute = this.router.generate(this.routeName);
+
+        let newRoute = currentRoute.replace(new RegExp('^' + guidBaseRoute), newBaseURL);
+        console.log('The expected path for this route is: ', currentRoute);
+        console.log('The base route for the GUID-containing segment is: ', guidBaseRoute);
+        console.log('The new route will be: ', newRoute);
+        console.log('The new base URL will be: ', newBaseURL);
+        return newRoute;
+    },
+
+    /**
+     * Detect the nearest GUID parent, and rewrite the URL accordingly
+     */
+    setupController() {
+        let guidParentRoute = this.findGuidParent(this.routeName);
+
+        console.log('This route is, or is a child of, a guid route. URL will be written starting from the following base: ', guidParentRoute);
+        // Rewrite the URL (if supported by the currently active location implementation)
+        if (guidParentRoute && this.router.location.replaceURL) {
+            let newUrl = this.maskedGuidUrl(guidParentRoute);
+            this.router.location.replaceURL(newUrl);
+        }
+        return this._super(...arguments);
+    }
+
+});

--- a/addon/mixins/guid-route-mask.js
+++ b/addon/mixins/guid-route-mask.js
@@ -1,5 +1,15 @@
 import Ember from 'ember';
 
+/**
+ * This is an experimental technology demonstration. It detects when a route is a child of a GUID route, and rewrites
+ * the URL in the address bar to be a GUID URL, while preserving state internally for transitions/ movement between routes.
+ *
+ * There are some known bugs when, eg, moving between two routes at the same level
+ *
+ * It makes livereload annoying to use, though.
+ *
+ * There will probably be other bugs.
+ */
 export default Ember.Mixin.create({
     _isGuidItem(model) {
         // TODO: Hard-coded assumptions about guid item by model type- make this nice if we see it works
@@ -62,6 +72,9 @@ export default Ember.Mixin.create({
 
     /**
      * Detect the nearest GUID parent, and rewrite the URL accordingly
+     *
+     * This doesn't *have* to happen here, but it does have to happen sometime after finalizeTransition if we want
+     * to avoid overwriting our new url
      */
     setupController() {
         let guidParentRoute = this.findGuidParent(this.routeName);

--- a/addon/models/file.js
+++ b/addon/models/file.js
@@ -17,6 +17,7 @@ import OsfModel from './osf-model';
 export default OsfModel.extend({
     name: DS.attr('string'),
     kind: DS.attr('string'),
+    guid: DS.attr('string'),
     path: DS.attr('string'),
     size: DS.attr('number'),
     provider: DS.attr('string'),

--- a/tests/dummy/app/routes/nodes/detail/files/index.js
+++ b/tests/dummy/app/routes/nodes/detail/files/index.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin, {
+import GuidRouteMaskMixin from 'ember-osf/mixins/guid-route-mask';
+
+export default Ember.Route.extend(AuthenticatedRouteMixin, GuidRouteMaskMixin, {
     setupController(controller, model) {
         this._super(controller, model);
         let node = this.modelFor('nodes.detail');
         controller.set('node', node);
-    },
+    }
 });

--- a/tests/dummy/app/routes/nodes/detail/files/provider/file.js
+++ b/tests/dummy/app/routes/nodes/detail/files/provider/file.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin, {
+import GuidRouteMaskMixin from 'ember-osf/mixins/guid-route-mask';
+
+export default Ember.Route.extend(AuthenticatedRouteMixin, GuidRouteMaskMixin , {
     fileManager: Ember.inject.service(),
 
     model(params) {

--- a/tests/unit/mixins/guid-route-mask-test.js
+++ b/tests/unit/mixins/guid-route-mask-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import GuidRouteMaskMixin from 'ember-osf/mixins/guid-route-mask';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | guid route mask');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let GuidRouteMaskObject = Ember.Object.extend(GuidRouteMaskMixin);
+  let subject = GuidRouteMaskObject.create();
+  assert.ok(subject);
+});


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-80

# Purpose
The OSF currently uses short IDs for URLs.

This PR, or some extension, would allow long-form ember routes like `http://osf.io/project/<guid>/files/<long_id>` to be rewritten as `http://osf.io/<file_guid>`.

It currently identifies three types of guid resource: files, projects, and wikis. It maps ember internal routes to a different address as displayed in the address bar.

Depending on page load time, the "long" URL may be visible in the address bar until the model hook resolves.

# Notes for Reviewers
## Implementation notes
### Alternative solutions
If we choose to use GUID urls in the ember app, there are two basic ways to go about it:
1. Let the OSF do the work of resolving. Serve the ember app into a given long-form URL, then mask that URL after the page has loaded
2. Let the ember app point at a GUID route, then resolve that GUID internally.

The latter option is complicated by the fact that ember decides what template to render based on the URL. It doesn't inherently know which template to render until it has the resource... and if we dynamically choose what to render internally, we still need to mask the URL. 

Some resources are nested, like how file detail pages are surrounded by the "project header" banner. Currently the files API endpoint does not tell us what project a file belongs to.

### Why a mixin?
Internally, `Ember.Location` implementations provide methods for taking the route state and displaying it to the user. They handle display for, but do not actually generate, URLs for a given route.

Ember actually generates routes using the `router.js` *generate* method. (which the undocumented `Ember.router#generate` delegates to under the hood)

This is relevant because Ember.Location does not by itself have access to a route's model, and therefore would have some trouble determining whether the route (or its parents) is a GUID route. (there is no `routeFor`, etc)

Although there are distinct disadvantages to this approach, this was implemented as a route mixin so as to:
1. Provide access to information about parent routes (modelFor, etc) so that we could travel up the route list
2. Have a hook (somewhere) that we can call to ensure the route is updated

## Quirks and known issues
This allows moving between routes, and at least so far I've been able to access things that depend on internal state (like rendering pages that depend on a parent model, when the route is shorter). 

- Livereload appears to reload based on URL... which this approach rewrites. It's quite annoying.
- The URL doesn't always stay rewritten as we move between two routes at the same level (eg two file detail pages)

## Routes Added/Updated
The mixin has been added to two routes to demonstrate that it works with nesting:
- A node detail route: http://localhost:4200/nodes/m9pv6
- A file detail route (under a node):
http://localhost:4200/nodes/m9pv6/files/osfstorage/573336608ca57e01d28f3202

The address bar should show the shortened URL.
![screen shot 2016-06-28 at 4 23 18 pm](https://cloud.githubusercontent.com/assets/2957073/16431044/a9e21f24-3d4c-11e6-8614-279d994f5abb.png)

