### PR TITLE
Set up YUIDoc to work with ember-osf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # compiled output
 /dist
+/docs
 /tmp
 
 # dependencies

--- a/addon/mixins/infinity-custom.js
+++ b/addon/mixins/infinity-custom.js
@@ -8,12 +8,12 @@ const assign = Ember.assign || Ember.merge;
  * For the most part, the API and semantics are identical to ember infinity, except that the means of configuring the store find method is more flexible
  *  (supporting relationship queries that do not operate via store methods)
 
- @class RouteMixin
+ @class InfinityCustomMixin
  @namespace EmberOSF
  @module ember-osf/mixins/infinity-custom
  @extends Ember.Mixin, InfinityRoute
  */
-const RouteMixin = Ember.Mixin.create(InfinityRoute, {
+export default Ember.Mixin.create(InfinityRoute, {
     /**
      * Repurpose an ember-infinity hook to override the method used for queries
      * @type {function}
@@ -81,5 +81,3 @@ const RouteMixin = Ember.Mixin.create(InfinityRoute, {
             this._afterInfinityModel(this));
     }
 });
-
-export default RouteMixin;

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
       "package.json",
       "bower_components",
       "dist",
+      "docs",
       "tmp",
       "vendor",
       "app/locales",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "scripts": {
     "build": "ember build",
+    "docs": "yuidoc",
+    "docs-deploy": "yuidoc && ghp-import -r origin -p -b gh-pages docs/",
     "start": "ember server",
     "test": "ember test",
     "check-style": "./node_modules/jscs/bin/jscs ."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ghp-import

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,0 +1,15 @@
+{
+    "name": "Ember OSF",
+    "description": "Ember components for interacting with the Open Science Framework",
+    "version": "0.0.1",
+    "url": "https://github.com/CenterForOpenScience/ember-osf",
+    "logo": "https://cos.io/static/img/icons/cos_wide.png",
+    "options": {
+        "linkNatives": "true",
+        "attributesEmit": "true",
+        "paths": [
+            "addon"
+        ],
+        "outdir": "docs/"
+    }
+}


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-81

# Purpose
Demonstrate ability to dynamically generate documentation for ember-osf modules.

![screen shot 2016-06-29 at 9 44 38 am](https://cloud.githubusercontent.com/assets/2957073/16454363/7e83e15e-3dde-11e6-835e-c4f4425ac40b.png)

# Notes for Reviewers
This is the same doc generator and convention as used by ember. Most of our docstrings already follow these conventions.

A separate PR would be required if we wanted to serve this via github pages. (with autodeployment code in this branch)

See sample deployment here: http://abought.github.io/ember-osf/

## How to use this
Install YUIDoc, then run it without arguments from the `ember-osf` root folder. Docs will be deposited in the `docs/` folder, as specified in yuidoc.json.

`npm -g install yuidocjs`
`yuidoc`

## TODO
Styling and improved text can move to a future ticket: get tooling out there and let the whole team make improvements.

- [x] Explore auto-deployment to Github pages

Here is ember's yuidoc.json file for comparison: https://github.com/emberjs/ember.js/blob/master/yuidoc.json

## Routes Added/Updated
None. Docs will appear in the new docs/ folder when command is run.

