### PR TITLE
Fix toastr build error in consuming apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-load-initializers": "0.5.1",
     "ember-power-select": "1.0.0-alpha.5",
     "ember-resolver": "2.0.3",
+    "ember-toastr": "1.4.1",
     "jscs": "3.0.4",
     "loader": "2.1.0",
     "loader.js": "4.0.3",
@@ -76,7 +77,6 @@
     "ember-radio-buttons": "^4.0.1",
     "ember-simple-auth": "1.1.0-beta.5",
     "ember-truth-helpers": "1.2.0",
-    "ember-toastr": "1.4.1",
     "js-yaml": "^3.6.0"
   },
   "ember-addon": {


### PR DESCRIPTION
## Ticket
None.

# Purpose
A new consuming app failed to build. Moving `toastr` from `dependencies` to `devDependencies` fixed this issue.

# Notes for Reviewers
Ours is not to question why....

Well, actually, that's the opposite of true. We're not sure why this works. Exercise your own judgment if this turns out to be problematic.

## Routes Added/Updated
None. Toast is used on the nodes detail page (edit node settings toggle panel), if you want an example to confirm it still works for the dummy app.