### PR TITLE
Flatten dropzone-widget events

### DIFF
--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -25,8 +25,8 @@ export default Ember.Component.extend({
     session: Ember.inject.service(),
     classNames: ['dropzone'],
     didInsertElement() {
-        let preUpload = this.get('preUpload'),
-            dropzoneOptions = this.get('options');
+        let preUpload = this.get('preUpload');
+        let dropzoneOptions = this.get('options');
 
         if (!this.get('buildUrl') && !preUpload && (!dropzoneOptions || !dropzoneOptions.url)) {
             console.error('Need to define url somewhere');

--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -8,6 +8,7 @@ import layout from './template';
 
 /**
  * Support file uploads via dropzone.
+ * Accepts dropzone event listeners as parameters (e.g. success, error, addedfile)
  *
  * Sample usage:
  * ```handlebars

--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -14,7 +14,7 @@ import layout from './template';
  * {{dropzone-widget
  *   preUpload=attrs.preUpload
  *   buildUrl=buildUrl
- *   listeners=dropzoneListeners
+ *   success=attrs.success
  *   options=dropzoneOptions}}
  * ```
  *
@@ -24,24 +24,26 @@ export default Ember.Component.extend({
     layout,
     session: Ember.inject.service(),
     classNames: ['dropzone'],
-    didRender() {
-        var preUpload = this.get('preUpload');
-        var dropzoneOptions = this.get('options');
-        var listeners = this.get('listeners');
+    didInsertElement() {
+        let preUpload = this.get('preUpload'),
+            dropzoneOptions = this.get('options');
+
         if (!this.get('buildUrl') && !preUpload && (!dropzoneOptions || !dropzoneOptions.url)) {
             console.error('Need to define url somewhere');
         }
-        var drop = new Dropzone('#' + this.elementId, {  // jshint ignore:line
+        let drop = new Dropzone(`#${this.elementId}`, {  // jshint ignore:line
             url: file => typeof this.get('buildUrl') === 'function' ? this.get('buildUrl')(file) : this.get('buildUrl'),
             autoProcessQueue: false,
         });
 
+        // Set osf session header
         let headers = {};
         this.get('session').authorize('authorizer:osf-token', (headerName, content) => {
             headers[headerName] = content;
         });
-
         drop.options.headers = headers;
+
+        // Attach preUpload to addedfile event
         drop.on('addedfile', file => {
             if (preUpload) {
                 preUpload(this, drop, file).then(() => drop.processFile(file));
@@ -49,9 +51,15 @@ export default Ember.Component.extend({
                 drop.processFile(file);
             }
         });
-        drop.options = Ember.merge(drop.options, dropzoneOptions);
-        if (listeners && typeof listeners === 'object') {
-            Object.keys(listeners).map(each => drop.on(each, listeners[each]));
+
+        // Set dropzone options
+        drop.options = Ember.assign(drop.options, dropzoneOptions);
+
+        // Attach dropzone event listeners
+        for (let event of drop.events) {
+            if (typeof this.get(event) === 'function') {
+                drop.on(event, (...args) => this.get(event)(this, drop, ...args));
+            }
         }
     }
 });

--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -27,9 +27,9 @@ export default Ember.Component.extend({
     classNames: ['dropzone'],
     didInsertElement() {
         let preUpload = this.get('preUpload');
-        let dropzoneOptions = this.get('options');
+        let dropzoneOptions = this.get('options') || {};
 
-        if (!this.get('buildUrl') && !preUpload && (!dropzoneOptions || !dropzoneOptions.url)) {
+        if (!this.get('buildUrl') && !preUpload && !dropzoneOptions.url) {
             console.error('Need to define url somewhere');
         }
         let drop = new Dropzone(`#${this.elementId}`, {  // jshint ignore:line
@@ -42,7 +42,7 @@ export default Ember.Component.extend({
         this.get('session').authorize('authorizer:osf-token', (headerName, content) => {
             headers[headerName] = content;
         });
-        drop.options.headers = headers;
+        dropzoneOptions.headers = headers;
 
         // Attach preUpload to addedfile event
         drop.on('addedfile', file => {
@@ -54,13 +54,13 @@ export default Ember.Component.extend({
         });
 
         // Set dropzone options
-        drop.options = Ember.assign(drop.options, dropzoneOptions);
+        drop.options = Ember.merge(drop.options, dropzoneOptions);
 
         // Attach dropzone event listeners
-        for (let event of drop.events) {
+        drop.events.forEach(event => {
             if (typeof this.get(event) === 'function') {
                 drop.on(event, (...args) => this.get(event)(this, drop, ...args));
             }
-        }
+        });
     }
 });


### PR DESCRIPTION
## Ticket
None.

# Purpose
Improve `dropzone-widget` ease of use by exposing event bindings to the component itself, rather than using a listeners object. This allows directly passing actions in to the component (e.g. `success`, `addedfile`).

Also, prevent dropzone from rebinding `this` to itself in event listeners. This allows listeners (typically Ember components or controllers) to retain their context.

# Notes for Reviewers
- Perhaps passing the component and the dropzone object to each listener is unnecessary
- Dropzone allows binding multiple listeners to an event, so `addedfile` will not be overwritten

## Routes Added/Updated
None, this is a component.