### PR TITLE
[hold][WIP] Comment form improvements

### DIFF
--- a/addon/adapters/comment.js
+++ b/addon/adapters/comment.js
@@ -1,4 +1,29 @@
 import OsfAdapter from './osf-adapter';
 
 export default OsfAdapter.extend({
+    buildURL(modelName, id, snapshot, requestType) { // jshint ignore:line
+        if (requestType === 'createRecord') {
+            // Create operations must get URL from the parent. Otherwise, all comments will be fetched via relationship fields.
+            let targetType = snapshot.adapterOptions.targetType;
+
+            // if (targetType === 'preprint') {
+            //     // Preprint comments are made through the nodes endpoint
+            //     targetType = 'node';
+            // }
+            let parent = this.store.peekRecord(targetType, snapshot.adapterOptions.targetID);
+
+            if (parent) {
+                return this._buildRelationshipURL(
+                    parent._internalModel.createSnapshot(),
+                    'comments'
+                );
+            } else {
+                throw new Error('Trying to add a comment to a record that hasn\'t been loaded into the store');
+            }
+        } else {
+            return this._super(...arguments);
+        }
+
+    }
+
 });

--- a/addon/adapters/comment.js
+++ b/addon/adapters/comment.js
@@ -6,16 +6,14 @@ export default OsfAdapter.extend({
             // Create operations must get URL from the parent. Otherwise, all comments will be fetched via relationship fields.
             let targetType = snapshot.adapterOptions.targetType;
 
-            // if (targetType === 'preprint') {
-            //     // Preprint comments are made through the nodes endpoint
-            //     targetType = 'node';
-            // }
             let parent = this.store.peekRecord(targetType, snapshot.adapterOptions.targetID);
 
             if (parent) {
+                // Get the relationship URL from the appropriately named field, based on the target type
+                const relTarget = (targetType === 'comment') ? 'replies' : 'comments';
                 return this._buildRelationshipURL(
                     parent._internalModel.createSnapshot(),
-                    'comments'
+                    relTarget
                 );
             } else {
                 throw new Error('Trying to add a comment to a record that hasn\'t been loaded into the store');

--- a/addon/adapters/osf-adapter.js
+++ b/addon/adapters/osf-adapter.js
@@ -80,7 +80,8 @@ export default DS.JSONAPIAdapter.extend(HasManyQuery.RESTAdapterMixin, GenericDa
         return createdSnapshots.map(s => s.record.save({
             adapterOptions: {
                 nested: true,
-                url: url
+                url: url,
+                forRelationship: true  // TODO(abought): Is this necessary? (what is meaning of "nested" param?)
             }
         }).then(res => {
             snapshot.record.resolveRelationship(relationship).addCanonicalRecord(s.record);

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -32,6 +32,7 @@ export default Ember.Component.extend({
     node: null, // TODO: Track whether the node is being viewed in "anonymous" mode and change how authors are displayed
 
     // Conditionals that control display of template sections
+    editMode: false,
     showChildren: false,
 
     isDeletedAbuse: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
@@ -42,6 +43,10 @@ export default Ember.Component.extend({
     }),
     isAbuseNotDeleted: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
         return !this.get('comment.deleted') && this.get('comment.isAbuse');
+    }),
+
+    isVisible: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
+        return !this.get('comment.deleted') && !this.get('comment.isAbuse');
     }),
 
     actions: {

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -122,19 +122,21 @@ export default Ember.Component.extend({
             let comment = this.get('comment');
             return this.attrs.addComment(text, this.get('comment'))
                 .then((res) => {
+                    this.send('toggleReplyMode');
                     // When a new comment is filed, we don't refetch data about the parent- and therefore it doesn't realize that it now has replies.
                     // Since this is a read-only field, we can't save the record like this...
                     // Hack: when a comment is saved, tell the comment it has children, but don't save
                     // FIXME: leaving the store in a dirty state is something we'll probably regret- revisit
                     comment.set('hasChildren', true);
-                    this.send('toggleReplyMode');
-                    this.send('toggleChildren');
+
+                    // Always show children when request succeeds
+                    this.set('showChildren', true);
                     return res;
                 });
         },
         editComment(text) {
-            // Edit the comment owned by this component. Don't return anything, as form should disappear when editing is done.
-            this.attrs.editComment(text, this.get('comment'))
+            // Edit the comment owned by this component.
+            return this.attrs.editComment(text, this.get('comment'))
                 .then((res) => this.send('toggleEditMode'));
         }
     }

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -126,7 +126,7 @@ export default Ember.Component.extend({
             // TODO: Max call stack size exceeded is never a good error...
             // Edit the comment owned by this component. Don't return anything, as form should disappear when editing is done.
             this.attrs.editComment(text, this.get('comment'))
-                .then((res) => this.set('toggleEditMode'));
+                .then((res) => this.send('toggleEditMode'));
         }
     }
 });

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -137,7 +137,7 @@ export default Ember.Component.extend({
         editComment(text) {
             // Edit the comment owned by this component.
             return this.attrs.editComment(text, this.get('comment'))
-                .then((res) => this.send('toggleEditMode'));
+                .then(() => this.send('toggleEditMode'));
         }
     }
 });

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -40,7 +40,7 @@ export default Ember.Component.extend({
     /**
      * The parent resource to which comments are attached.
      * @property resource
-     * @type Node|File|Wiki|Comment
+     * @type Comment|File|Node|Preprint|Wiki
      */
     resource: null, // TODO: Track whether the node is being viewed in "anonymous" mode and change how authors are displayed
 

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -14,6 +14,7 @@ import layout from './template';
  * ```handlebars
  * {{comment-detail
  *   comment=comment
+ *   resource=node
  *   editComment=attrs.editComment
  *   deleteComment=attrs.deleteComment
  *   restoreComment=attrs.restoreComment
@@ -29,14 +30,19 @@ import layout from './template';
 export default Ember.Component.extend({
     layout,
     comment: null,
-    node: null, // TODO: Track whether the node is being viewed in "anonymous" mode and change how authors are displayed
+    /**
+     * The parent resource to which comments are attached.
+     * @property resource
+     * @type Node|File|Wiki|Comment
+     */
+    resource: null, // TODO: Track whether the node is being viewed in "anonymous" mode and change how authors are displayed
 
     // Conditionals that control display of template sections
     replyMode: false,
     editMode: false,
     deleteMode: false,
     reportMode: false,
-    
+
     showChildren: false,
 
     // Conditionals that track actions in progress
@@ -55,8 +61,10 @@ export default Ember.Component.extend({
     isVisible: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
         return !this.get('comment.deleted') && !this.get('comment.isAbuse');
     }),
-    canReport: Ember.computed('node.currentUserCanComment', 'comment.canEdit', function() {
-        return this.get('node.currentUserCanComment') && !this.get('comment.canEdit');
+    
+    canComment: Ember.computed.alias('resource.currentUserCanComment'),
+    canReport: Ember.computed('canComment', 'comment.canEdit', function() {
+        return this.get('canComment') && !this.get('comment.canEdit');
     }),
 
     actions: {

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -32,8 +32,15 @@ export default Ember.Component.extend({
     node: null, // TODO: Track whether the node is being viewed in "anonymous" mode and change how authors are displayed
 
     // Conditionals that control display of template sections
+    replyMode: false,
     editMode: false,
+    deleteMode: false,
+    reportMode: false,
+    
     showChildren: false,
+
+    // Conditionals that track actions in progress
+
 
     isDeletedAbuse: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
         return this.get('comment.deleted') && this.get('comment.isAbuse');
@@ -48,12 +55,31 @@ export default Ember.Component.extend({
     isVisible: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
         return !this.get('comment.deleted') && !this.get('comment.isAbuse');
     }),
+    canReport: Ember.computed('node.currentUserCanComment', 'comment.canEdit', function() {
+        return this.get('node.currentUserCanComment') && !this.get('comment.canEdit');
+    }),
 
     actions: {
         toggleChildren() {
             // TODO: Implement toggling of children widgets
             this.toggleProperty('showChildren');
             // TODO: Fetch children as needed
+        },
+        toggleEditMode() {
+            // Allow editing of a pre-existing comment
+            this.toggleProperty('editMode');
+        },
+        toggleReplyMode() {
+            // Allow new replies to a parent comment
+            this.toggleProperty('replyMode');
+        },
+        toggleDeleteMode() {
+            // Show buttons relevant to comment deletion
+            this.toggleProperty('deleteMode');
+        },
+        reportMode() {
+            // Show buttons relevant to reporting a comment
+            this.toggleProperty('reportMode');
         }
     }
 });

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -114,8 +114,6 @@ export default Ember.Component.extend({
                     throw new Ember.Error('Failed to load comments');
                 });
             }
-
-
         },
         toggleDeleteMode() {
             // Show buttons relevant to comment deletion
@@ -125,7 +123,6 @@ export default Ember.Component.extend({
             // Show buttons relevant to reporting a comment
             this.toggleProperty('reportMode');
         },
-
         fetchChildren() {
             // Fetch child comments (replies)
             // TODO:
@@ -136,7 +133,6 @@ export default Ember.Component.extend({
             // TODO: For now we will just use comment.replies, which is limited in number of results available
 
         },
-
         replyComment(text) {
             // Reply to the comment owned by this component
             let comment = this.get('comment');

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -15,6 +15,7 @@ import layout from './template';
  * {{comment-detail
  *   comment=comment
  *   resource=node
+ *   addComment=attrs.addComment
  *   editComment=attrs.editComment
  *   deleteComment=attrs.deleteComment
  *   restoreComment=attrs.restoreComment
@@ -23,6 +24,7 @@ import layout from './template';
  * @class comment-detail
  * @param {DS.Model} comment The comment to display
  * @param {DS.Model} resource The parent resource that owns the comment
+ * @param {action} addComment
  * @param {action} editComment
  * @param {action} deleteComment
  * @param {action} restoreComment
@@ -110,6 +112,21 @@ export default Ember.Component.extend({
             // 2. Handle additional query params, embeds, viewonly behaviors, related counts etc
             // 3. Ensure that children are rendered.
             // 4. Ensure that when a reply is added, it's added to the list of known children.
+        },
+
+        replyComment(text) {
+            // Reply to the comment owned by this component
+            return this.attrs.addComment(text, this.get('comment'))
+                .then((res) => {
+                    this.send('toggleReplyMode');
+                    return res;
+                });
+        },
+        editComment(text) {
+            // TODO: Max call stack size exceeded is never a good error...
+            // Edit the comment owned by this component. Don't return anything, as form should disappear when editing is done.
+            this.attrs.editComment(text, this.get('comment'))
+                .then((res) => this.set('toggleEditMode'));
         }
     }
 });

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -22,6 +22,7 @@ import layout from './template';
  * ```
  * @class comment-detail
  * @param {DS.Model} comment The comment to display
+ * @param {DS.Model} resource The parent resource that owns the comment
  * @param {action} editComment
  * @param {action} deleteComment
  * @param {action} restoreComment
@@ -29,6 +30,10 @@ import layout from './template';
  */
 export default Ember.Component.extend({
     layout,
+    /**
+     * The comment to display
+     * @property comment
+     */
     comment: null,
     /**
      * The parent resource to which comments are attached.
@@ -36,6 +41,9 @@ export default Ember.Component.extend({
      * @type Node|File|Wiki|Comment
      */
     resource: null, // TODO: Track whether the node is being viewed in "anonymous" mode and change how authors are displayed
+
+    // Store information about direct replies to this comment
+    _replies: Ember.A(),
 
     // Conditionals that control display of template sections
     replyMode: false,
@@ -47,7 +55,7 @@ export default Ember.Component.extend({
 
     // Conditionals that track actions in progress
 
-
+    // TODO: Perhaps these fields should be defined on the comment?
     isDeletedAbuse: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
         return this.get('comment.deleted') && this.get('comment.isAbuse');
     }),
@@ -57,11 +65,12 @@ export default Ember.Component.extend({
     isAbuseNotDeleted: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
         return !this.get('comment.deleted') && this.get('comment.isAbuse');
     }),
-
-    isVisible: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
+    // TODO: Rename this variable after parity with source is achieved
+    // Whether to show comment text. Source template called "isVisible", which has special meaning in ember....!
+    isShowingContent: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
         return !this.get('comment.deleted') && !this.get('comment.isAbuse');
     }),
-    
+
     canComment: Ember.computed.alias('resource.currentUserCanComment'),
     canReport: Ember.computed('canComment', 'comment.canEdit', function() {
         return this.get('canComment') && !this.get('comment.canEdit');
@@ -70,8 +79,11 @@ export default Ember.Component.extend({
     actions: {
         toggleChildren() {
             // TODO: Implement toggling of children widgets
+            if (!this.get('showChildren')) {
+                this.send('fetchChildren');
+            }
+            // TODO: If fetch is in progress, should there be a loading indicator of some sort?
             this.toggleProperty('showChildren');
-            // TODO: Fetch children as needed
         },
         toggleEditMode() {
             // Allow editing of a pre-existing comment
@@ -85,9 +97,19 @@ export default Ember.Component.extend({
             // Show buttons relevant to comment deletion
             this.toggleProperty('deleteMode');
         },
-        reportMode() {
+        toggleReportMode() {
             // Show buttons relevant to reporting a comment
             this.toggleProperty('reportMode');
+        },
+
+        fetchChildren() {
+            // Fetch child comments (replies)
+
+            // TODO:
+            // 1. track what page of results to fetch
+            // 2. Handle additional query params, embeds, viewonly behaviors, related counts etc
+            // 3. Ensure that children are rendered.
+            // 4. Ensure that when a reply is added, it's added to the list of known children.
         }
     }
 });

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -95,7 +95,27 @@ export default Ember.Component.extend({
         },
         toggleReplyMode() {
             // Allow new replies to a parent comment
-            this.toggleProperty('replyMode');
+            // TODO: We need a mechanism to indicate that replies failed to load for that user. (explain why button didn't bring a reply box it request fails)
+            let replyMode = this.get('replyMode');
+            if (!this.get('comment.hasChildren')) {
+                this.toggleProperty('replyMode');
+            } else if (replyMode) {
+                this.set('replyMode', false);
+            } else {
+                // If the comment has children, do not show the reply box until child comments are loaded.
+                // This makes sense for the UI, but it also addresses issue where the adapter would fail to track dirty
+                //   state for new comments on a relationship that had not yet loaded
+                let children = this.get('comment.replies');
+                // TODO: Improve error reporting UI here; throw error for now
+                children.then(() => {
+                    this.set('showChildren', true);
+                    this.set('replyMode', true);
+                }).catch(() => {
+                    throw new Ember.Error('Failed to load comments');
+                });
+            }
+
+
         },
         toggleDeleteMode() {
             // Show buttons relevant to comment deletion

--- a/addon/components/comment-detail/component.js
+++ b/addon/components/comment-detail/component.js
@@ -28,5 +28,27 @@ import layout from './template';
  */
 export default Ember.Component.extend({
     layout,
-    comment: null
+    comment: null,
+    node: null, // TODO: Track whether the node is being viewed in "anonymous" mode and change how authors are displayed
+
+    // Conditionals that control display of template sections
+    showChildren: false,
+
+    isDeletedAbuse: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
+        return this.get('comment.deleted') && this.get('comment.isAbuse');
+    }),
+    isDeletedNotAbuse: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
+        return this.get('comment.deleted') && !this.get('comment.isAbuse');
+    }),
+    isAbuseNotDeleted: Ember.computed('comment.deleted', 'comment.isAbuse', function() {
+        return !this.get('comment.deleted') && this.get('comment.isAbuse');
+    }),
+
+    actions: {
+        toggleChildren() {
+            // TODO: Implement toggling of children widgets
+            this.toggleProperty('showChildren');
+            // TODO: Fetch children as needed
+        }
+    }
 });

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -1,7 +1,7 @@
 {{!-- TODO: This template does not currently implement Comment abuse reporting functionality, #EOSF-76 --}}
 
 <div class="comment-container" data-bind="attr:{id: id}">
-    < class="comment-body m-b-sm p-sm osf-box">
+    <div class="comment-body m-b-sm p-sm osf-box">
          <!-- div data-bind="visible: loading">
             <i class="fa fa-spinner fa-spin"></i>
          </div -->
@@ -56,7 +56,7 @@
                     {{!-- TODO: Implement this with EOSF-76 --}}
                     <a data-bind="click: submitUnreportAbuse">Not abuse</a>
                 {{/if}}
-            {{/if}}}
+            {{/if}}
 
             {{#if isVisible}}
 
@@ -85,34 +85,37 @@
 
                 <div class="comment-content">
 
-                    <div data-bind="ifnot: editing">
-                        <span class="component-overflow" data-bind="html: contentDisplay"></span>
-                        <span class="pull-right comment-actions" data-bind="if: hasChildren()">
-                            <i data-bind="css: toggleIcon, click: toggle"></i>
-                        </span>
-                    </div>
+
+                    {{#unless editMode}}
+                        {{!-- TODO: Will need to test this with comments that include HTML. (because apparently that was an option??) --}}
+                        {{!-- TODO: The OSF spec calls for comments to be stored as markdown, then linkified and rendered frontend into HTML --}}
+                        {{!-- This will be mandatory for new feature like @mentions and is not yet supported here --}}
+                        <span class="component-overflow">{{comment.content}}</span>
+                        {{#if comment.hasChildren}}
+                            <span class="comment-actions pull-right">
+                                <button {{action toggleChildren}}>
+                                    <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
+                                </button>
+                            </span>
+                        {{/if}}
+                    {{/unless}}
 
                     <!--
                         Hack: Use template binding with if rather than vanilla if
                         binding to get access to afterRender
                     -->
-                    <div data-bind="template {if: editing, afterRender: autosizeText}">
-                        <div class="form-group" style="padding-top: 10px">
-                            <textarea class="form-control" data-bind="value: content, valueUpdate: 'input', attr: {maxlength: $root.MAXLENGTH}"></textarea>
-                        </div>
-                        <div class="clearfix">
-                            <div class="form-inline pull-right">
-                                <a class="btn btn-default btn-sm" data-bind="click: cancelEdit">Cancel</a>
-                                <a class="btn btn-success btn-sm" data-bind="click: submitEdit, visible: editNotEmpty">Save</a>
-                                <span data-bind="text: editErrorMessage" class="text-danger"></span>
-                            </div>
-                        </div>
+                    {{!-- TODO: support autosizetext behavior when form loads --}}
+                    {{!-- TODO: Support configurable text for comment form (edit vs commenting) --}}
+                    {{!-- TODO: May need to add back class=clearfix markup around buttons --}}
+                    <div style="padding-top: 10px">
+                        {{!-- TODO: Replace addComment with editComment --}}
+                        {{comment-form addComment=attrs.addComment}}
                     </div>
                 </div>
 
                 <div>
-
-                    <span class="text-danger" data-bind="text: errorMessage"></span>
+                    {{!-- TODO: Revisit error display mechanism to differentiate between validation and saving errors (do we need two fields?) --}}
+                    <!--<span class="text-danger" data-bind="text: errorMessage"></span>-->
 
                     <span>&nbsp;</span>
 
@@ -174,28 +177,21 @@
 
         <!-- ko if: replying -->
 
-            <div>
-                <div class="form-group" style="padding-top: 10px">
-                    <textarea class="form-control" placeholder="Add a comment" data-bind="value: replyContent, valueUpdate: 'input', attr: {maxlength: $root.MAXLENGTH}"></textarea>
-                </div>
-                <div class="clearfix">
-                    <div class="pull-right">
-                        <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
-                        <a class="btn btn-success btn-sm" data-bind="click: submitReply, visible: replyNotEmpty, css: {disabled: submittingReply}, text: commentButtonText"></a>
-                        <span data-bind="text: replyErrorMessage" class="text-danger"></span>
-                    </div>
-                </div>
+            <div style="padding-top: 10px">
+                {{!-- TODO: Replace addComment with a custom addReply action --}}
+                {{comment-form addComment=attrs.addComment}}
             </div>
 
         <!-- /ko -->
 
+        {{!-- TODO: Implement the fetch more functionality below --}}
         <!-- ko if: showChildren() -->
             <!-- ko template: {name:  'commentTemplate', foreach: comments} -->
             <!-- /ko -->
             <!-- ko if: urlForNext() -->
-            <div class="row">
-                <button class="btn btn-link pull-right more-replies" type="button" data-bind="click: getMoreComments">More replies</button>
-            </div>
+                        <!--<div class="row">-->
+                            <!--<button class="btn btn-link pull-right more-replies" type="button" data-bind="click: getMoreComments">More replies</button>-->
+                        <!--</div>-->
             <!-- /ko -->
         <!-- /ko -->
 
@@ -214,26 +210,26 @@
 
 
 
-    {{#if comment.deleted}}
-        <div>
-            Comment deleted
-            {{# if comment.canEdit}}
-                <button {{action restoreComment comment}} class="btn btn-warning">Restore</button>
-            {{/if}}
-        </div>
-    {{else}}
-        <div>
-            <strong>
-                {{comment.dateCreated}}
-            </strong>:
-            {{# if comment.canEdit}}
-                {{input value=comment.content}}
-                <button {{action editComment comment}} class="btn btn-success">Edit</button>
-                <button {{action deleteComment comment}} class="btn btn-danger">Delete</button>
-            {{else}}
-                <span>{{comment.content}}</span>
-                <button {{action reportComment comment}} class="btn btn-warning">Report</button>
-            {{/if}}
-        </div>
-    {{/if}}
-</div>
+    <!--{{#if comment.deleted}}-->
+        <!--<div>-->
+            <!--Comment deleted-->
+            <!--{{# if comment.canEdit}}-->
+                <!--<button {{action restoreComment comment}} class="btn btn-warning">Restore</button>-->
+            <!--{{/if}}-->
+        <!--</div>-->
+    <!--{{else}}-->
+        <!--<div>-->
+            <!--<strong>-->
+                <!--{{comment.dateCreated}}-->
+            <!--</strong>:-->
+            <!--{{# if comment.canEdit}}-->
+                <!--{{input value=comment.content}}-->
+                <!--<button {{action editComment comment}} class="btn btn-success">Edit</button>-->
+                <!--<button {{action deleteComment comment}} class="btn btn-danger">Delete</button>-->
+            <!--{{else}}-->
+                <!--<span>{{comment.content}}</span>-->
+                <!--<button {{action reportComment comment}} class="btn btn-warning">Report</button>-->
+            <!--{{/if}}-->
+        <!--</div>-->
+    <!--{{/if}}-->
+<!--</div>-->

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -1,4 +1,212 @@
-<div>
+{{!-- TODO: This template does not currently implement Comment abuse reporting functionality, #EOSF-76 --}}
+
+<div class="comment-container" data-bind="attr:{id: id}">
+    < class="comment-body m-b-sm p-sm osf-box">
+         <!-- div data-bind="visible: loading">
+            <i class="fa fa-spinner fa-spin"></i>
+         </div -->
+
+        {{#unless comment.loading}}
+            {{#if isDeletedAbuse}}
+                <div>
+                    <span class="text-muted">
+                        <em>Comment confirmed as spam.</em>
+                    </span>
+                    {{#if comment.hasChildren}}
+                        <span class="comment-actions pull-right">
+                            <button {{action toggleChildren}}>
+                                <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
+                            </button>
+                        </span>
+                    {{/if}}
+                </div>
+            {{/if}}
+            {{#if isDeletedNotAbuse}}
+                <div>
+                    <span class="text-muted">
+                        <em>Comment deleted.</em>
+                    </span>
+                    {{#if comment.hasChildren}}
+                        <span class="comment-actions pull-right">
+                            <button {{action toggleChildren}}>
+                                <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
+                            </button>
+                        </span>
+                    {{/if}}
+                </div>
+                <div data-bind="if: canEdit">
+                    <a data-bind="click: submitUndelete">Restore</a>
+                </div>
+            {{/if}}
+
+            <div data-bind="if: isAbuseNotDeleted">
+                <div>
+                    <span class="text-muted">
+                        <em>Comment reported.</em>
+                    </span>
+                    <span data-bind="if: hasChildren()" class="comment-actions pull-right">
+                        <i data-bind="css: toggleIcon, click: toggle"></i>
+                    </span>
+                </div>
+                <div data-bind="if: hasReport">
+                    <a data-bind="click: submitUnreportAbuse">Not abuse</a>
+                </div>
+            </div>
+
+            <div data-bind="if: isVisible">
+
+                <div class="comment-info">
+                    <form class="form-inline">
+                        <span data-bind="if: author.gravatarUrl">
+                            <img data-bind="css: {'comment-gravatar': author.gravatarUrl}, attr: {src: author.gravatarUrl}"/>
+                        </span>
+                        <span data-bind="if: author.id">
+                            <a class="comment-author" data-bind="text: author.fullname, attr: {href: author.urls.profile}"></a>
+                        </span>
+                        <span data-bind="ifnot: author.id">
+                            <span class="comment-author" data-bind="text: author.fullname"></span>
+                        </span>
+                        <span class="comment-date pull-right">
+                            <span data-bind="template: {if: modified, afterRender: setupToolTips}">
+                                <a data-toggle="tooltip" data-bind="attr: {title: prettyDateModified()}">*</a>
+                            </span>
+                            <span data-bind="text: prettyDateCreated"></span>
+                            &nbsp;
+                        </span>
+                    </form>
+                </div>
+
+                <div class="comment-content">
+
+                    <div data-bind="ifnot: editing">
+                        <span class="component-overflow" data-bind="html: contentDisplay"></span>
+                        <span class="pull-right comment-actions" data-bind="if: hasChildren()">
+                            <i data-bind="css: toggleIcon, click: toggle"></i>
+                        </span>
+                    </div>
+
+                    <!--
+                        Hack: Use template binding with if rather than vanilla if
+                        binding to get access to afterRender
+                    -->
+                    <div data-bind="template {if: editing, afterRender: autosizeText}">
+                        <div class="form-group" style="padding-top: 10px">
+                            <textarea class="form-control" data-bind="value: content, valueUpdate: 'input', attr: {maxlength: $root.MAXLENGTH}"></textarea>
+                        </div>
+                        <div class="clearfix">
+                            <div class="form-inline pull-right">
+                                <a class="btn btn-default btn-sm" data-bind="click: cancelEdit">Cancel</a>
+                                <a class="btn btn-success btn-sm" data-bind="click: submitEdit, visible: editNotEmpty">Save</a>
+                                <span data-bind="text: editErrorMessage" class="text-danger"></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div>
+
+                    <span class="text-danger" data-bind="text: errorMessage"></span>
+
+                    <span>&nbsp;</span>
+
+                    <!-- Action bar -->
+                    <div style="display: inline">
+                        <div data-bind="ifnot: editing" class="comment-actions pull-right">
+                            <span data-bind="ifnot: isHam">
+                                <span data-bind="if: canEdit, click: edit">
+                                    <i class="fa fa-pencil"></i>
+                                </span>
+                                <span data-bind="if: $root.canComment, click: showReply">
+                                    <i class="fa fa-reply"></i>
+                                </span>
+                                <span data-bind="if: canReport, click: reportAbuse">
+                                    <i class="fa fa-warning"></i>
+                                </span>
+                                <span data-bind="if: canEdit, click: startDelete">
+                                    <i class="fa fa-trash-o"></i>
+                                </span>
+                            </span>
+                            <span data-bind="if: isHam">
+                                <span data-bind="if: $root.canComment, click: showReply">
+                                    <i class="fa fa-reply"></i>
+                                </span>
+                                <span>
+                                    <i class="text-success fa fa-check-circle-o"></i>
+                                </span>
+                            </span>
+                        </div>
+                    </div>
+
+                </div>
+
+                <div class="comment-report clearfix" data-bind="if: reporting">
+                    <form class="form-inline" data-bind="submit: submitAbuse">
+                        <select class="form-control" data-bind="options: abuseOptions, optionsText: abuseLabel, value: abuseCategory"></select>
+                        <input class="form-control" data-bind="value: abuseText" placeholder="Describe abuse" />
+                    </form>
+                    <div class="pull-right m-t-xs">
+                        <a class="btn btn-default btn-sm" data-bind="click: cancelAbuse"> Cancel</a>
+                        <a class="btn btn-danger btn-sm" data-bind="click: submitAbuse"> Report</a>
+                    </div>
+                </div>
+
+                <div class="comment-delete clearfix m-t-xs" data-bind="if: deleting">
+                    <div class="pull-right">
+                        <a class="btn btn-default btn-sm" data-bind="click: cancelDelete">Cancel</a>
+                        <a class="btn btn-danger btn-sm" data-bind="click: submitDelete">Delete</a>
+                    </div>
+                </div>
+
+            </div>
+        {{/unless}}
+
+
+    </div>
+
+    <ul class="comment-list">
+
+        <!-- ko if: replying -->
+
+            <div>
+                <div class="form-group" style="padding-top: 10px">
+                    <textarea class="form-control" placeholder="Add a comment" data-bind="value: replyContent, valueUpdate: 'input', attr: {maxlength: $root.MAXLENGTH}"></textarea>
+                </div>
+                <div class="clearfix">
+                    <div class="pull-right">
+                        <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
+                        <a class="btn btn-success btn-sm" data-bind="click: submitReply, visible: replyNotEmpty, css: {disabled: submittingReply}, text: commentButtonText"></a>
+                        <span data-bind="text: replyErrorMessage" class="text-danger"></span>
+                    </div>
+                </div>
+            </div>
+
+        <!-- /ko -->
+
+        <!-- ko if: showChildren() -->
+            <!-- ko template: {name:  'commentTemplate', foreach: comments} -->
+            <!-- /ko -->
+            <!-- ko if: urlForNext() -->
+            <div class="row">
+                <button class="btn btn-link pull-right more-replies" type="button" data-bind="click: getMoreComments">More replies</button>
+            </div>
+            <!-- /ko -->
+        <!-- /ko -->
+
+    </ul>
+
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
     {{#if comment.deleted}}
         <div>
             Comment deleted

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -1,6 +1,6 @@
 {{!-- TODO: This template does not currently implement Comment abuse reporting functionality, #EOSF-76 --}}
 
-<div class="comment-container" data-bind="attr:{id: id}">
+<div class="comment-container">
     <div class="comment-body m-b-sm p-sm osf-box">
          <!-- div data-bind="visible: loading">
             <i class="fa fa-spinner fa-spin"></i>
@@ -58,7 +58,7 @@
                 {{/if}}
             {{/if}}
 
-            {{#if isVisible}}
+            {{#if isShowingContent}}
 
                 <div class="comment-info">
                     {{!-- TODO: Why is there a form here? --}}

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -104,9 +104,7 @@
                     {{!-- TODO: Support configurable text for comment form (edit vs commenting) --}}
                     {{#if editMode}}
                         <div style="padding-top: 10px">
-                            {{!-- TODO: Support editing functionality for a form? Original comment text, different button labels--}}
-                            {{!-- TODO: Replace addComment with editComment --}}
-                            {{comment-form addComment=attrs.addComment
+                            {{comment-form submitComment=(action 'editComment')
                               showButtons=true
                               initialText=comment.content
                               cancelComment=(action 'toggleEditMode')}}
@@ -195,8 +193,7 @@
         {{#if replyMode}}
 
             <div style="padding-top: 10px">
-                {{!-- TODO: Replace addComment with a custom addReply action (referencing the comment as target) --}}
-                {{comment-form addComment=attrs.addComment showButton=true}}
+                {{comment-form submitComment=(action 'replyComment') showButton=true}}
             </div>
 
         {{/if}}

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -14,9 +14,9 @@
                     </span>
                     {{#if comment.hasChildren}}
                         <span class="comment-actions pull-right">
-                            <button {{action 'toggleChildren'}}>
+                            <span {{action 'toggleChildren'}}>
                                 <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
-                            </button>
+                            </span>
                         </span>
                     {{/if}}
                 </div>
@@ -28,9 +28,9 @@
                     </span>
                     {{#if comment.hasChildren}}
                         <span class="comment-actions pull-right">
-                            <button {{action 'toggleChildren'}}>
+                            <span {{action 'toggleChildren'}}>
                                 <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
-                            </button>
+                            </span>
                         </span>
                     {{/if}}
                 </div>
@@ -46,9 +46,9 @@
                     </span>
                     {{#if comment.hasChildren}}
                         <span class="comment-actions pull-right">
-                            <button {{action 'toggleChildren'}}>
+                            <span {{action 'toggleChildren'}}>
                                 <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
-                            </button>
+                            </span>
                         </span>
                     {{/if}}
                 </div>
@@ -93,9 +93,9 @@
                         <span class="component-overflow">{{comment.content}}</span>
                         {{#if comment.hasChildren}}
                             <span class="comment-actions pull-right">
-                                <button {{action 'toggleChildren'}}>
+                                <span {{action 'toggleChildren'}}>
                                     <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
-                                </button>
+                                </span>
                             </span>
                         {{/if}}
                     {{/unless}}
@@ -107,10 +107,13 @@
                     {{!-- TODO: support autosizetext behavior when form loads --}}
                     {{!-- TODO: Support configurable text for comment form (edit vs commenting) --}}
                     {{!-- TODO: May need to add back class=clearfix markup around buttons --}}
-                    <div style="padding-top: 10px">
-                        {{!-- TODO: Replace addComment with editComment --}}
-                        {{comment-form addComment=attrs.addComment}}
-                    </div>
+                    {{#if editMode}}
+                        <div style="padding-top: 10px">
+                            {{!-- TODO: Support editing functionality for a form? Original comment text, different button labels--}}
+                            {{!-- TODO: Replace addComment with editComment --}}
+                            {{comment-form addComment=attrs.addComment}}
+                        </div>
+                    {{/if}}
                 </div>
 
                 <div>
@@ -128,32 +131,31 @@
                                 {{#unless comment.isHam}}
                                     {{!-- If there are no outstanding/unresolved spam reports, show a full set of buttons, including for reporting --}}
                                     {{#if comment.canEdit}}
-                                        <button {{action 'toggleEditMode'}}><i class="fa fa-pencil"></i></button>
+                                        {{!-- TODO: Restyle. Avoid using spans for clickable elements for accessibility reasons --}}
+                                        <span {{action 'toggleEditMode'}}><i class="fa fa-pencil"></i></span>
                                     {{/if}}
 
-                                    {{#if node.currentUserCanComment}}
-                                        <button {{action 'toggleReplyMode'}}>
-                                            <i class="fa fa-reply"></i>
-                                        </button>
+                                    {{#if canComment}}
+                                        <span {{action 'toggleReplyMode'}}><i class="fa fa-reply"></i></span>
                                     {{/if}}
                                     {{#if canReport}}
-                                        <button {{action reportComment}}>
+                                        <span {{action reportComment}}>
                                             {{!-- TODO: Bare fontawesome icons are an accessibility issue. See http://fontawesome.io/accessibility/ --}}
                                             <i class="fa fa-warning"></i>
-                                        </button>
+                                        </span>
                                     {{/if}}
                                     {{#if comment.canEdit}}
-                                        <button {{action 'toggleDeleteMode'}}>
+                                        <span {{action 'toggleDeleteMode'}}>
                                             <i class="fa fa-trash-o"></i>
-                                        </button>
+                                        </span>
                                     {{/if}}
                                 {{else}}
                                         {{!-- TODO: DRY this code up and avoid redundant button definitions --}}
                                     {{!-- Why don't we show the delete button for comments confirmed not spam? --}}
-                                    {{#if node.currentUserCanComment}}
-                                        <button {{action 'toggleReplyMode'}}>
+                                    {{#if canComment}}
+                                        <span {{action 'toggleReplyMode'}}>
                                             <i class="fa fa-reply"></i>
-                                        </button>
+                                        </span>
                                     {{/if}}
                                     <span>
                                         <i class="text-success fa fa-check-circle-o"></i>
@@ -192,14 +194,14 @@
 
     <ul class="comment-list">
 
-        <!-- ko if: replying -->
+        {{#if replyMode}}
 
             <div style="padding-top: 10px">
                 {{!-- TODO: Replace addComment with a custom addReply action (referencing the comment as target) --}}
                 {{comment-form addComment=attrs.addComment}}
             </div>
 
-        <!-- /ko -->
+        {{/if}}
 
         {{!-- TODO: Implement the fetch more functionality below --}}
         <!-- ko if: showChildren() -->

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -87,9 +87,8 @@
 
 
                     {{#unless editMode}}
-                        {{!-- TODO: Will need to test this with comments that include HTML. (because apparently that was an option??) --}}
                         {{!-- TODO: The OSF spec calls for comments to be stored as markdown, then linkified and rendered frontend into HTML --}}
-                        {{!-- This will be mandatory for new feature like @mentions and is not yet supported here --}}
+                        {{!-- This will be mandatory for new feature like @mentions and is not yet supported here. May need to review HTML safety for these fields. --}}
                         <span class="component-overflow">{{comment.content}}</span>
                         {{#if comment.hasChildren}}
                             <span class="comment-actions pull-right">

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -1,5 +1,4 @@
 {{!-- TODO: This template does not currently implement Comment abuse reporting functionality, #EOSF-76 --}}
-
 <div class="comment-container">
     <div class="comment-body m-b-sm p-sm osf-box">
         {{#if comment.isPending}}
@@ -12,7 +11,6 @@
                         <em>Comment confirmed as spam.</em>
                     </span>
                     {{#if comment.hasChildren}}
-                        {{!-- TODO: When making a reply, the template does not getting the new hasChildren value correctly  until comment is reloaded --}}
                         <span class="comment-actions pull-right">
                             <span {{action 'toggleChildren'}}>
                                 <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
@@ -100,13 +98,15 @@
                     {{/unless}}
 
 
-                    {{!-- TODO: support autosizetext behavior when form loads --}}
+                    {{!-- TODO: Once in pane, examine whether autosizing is needed --}}
                     {{#if editMode}}
                         <div style="padding-top: 10px">
-                            {{comment-form submitComment=(action 'editComment')
+                            {{comment-form
+                              cancelComment=(action 'toggleEditMode')
+                              submitComment=(action 'editComment')
                               showButtons=true
-                              initialText=comment.content
-                              cancelComment=(action 'toggleEditMode')}}
+                              initialText=comment.content}}
+
                         </div>
                     {{/if}}
                 </div>
@@ -122,7 +122,6 @@
 
                         {{#unless editMode}}
                             <div class="comment-actions pull-right">
-                                {{!- TODO: Logic convoluted- unless/else --}}
                                 {{#unless comment.isHam}}
                                     {{!-- If there are no outstanding/unresolved spam reports, show a full set of buttons, including for reporting --}}
                                     {{#if comment.canEdit}}
@@ -145,8 +144,7 @@
                                         </span>
                                     {{/if}}
                                 {{else}}
-                                        {{!-- TODO: DRY this code up and avoid redundant button definitions --}}
-                                    {{!-- Why don't we show the delete button for comments confirmed not spam? --}}
+                                    {{!-- TODO: DRY this code up and avoid redundant button definitions --}}
                                     {{#if canComment}}
                                         <span {{action 'toggleReplyMode'}}>
                                             <i class="fa fa-reply"></i>
@@ -191,7 +189,10 @@
 
         {{#if replyMode}}
             <div style="padding-top: 10px">
-                {{comment-form submitComment=(action 'replyComment') showButtons=true}}
+                {{comment-form
+                  cancelComment=(action 'toggleReplyMode')
+                  submitComment=(action 'replyComment')
+                  showButtons=true}}
             </div>
         {{/if}}
 

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -5,8 +5,8 @@
          <!-- div data-bind="visible: loading">
             <i class="fa fa-spinner fa-spin"></i>
          </div -->
-
-        {{#unless comment.loading}}
+        {{!-- TODO: Check on, and implement, loading indicator for comments --}}
+        {{#unless comment.isPending}}
             {{#if isDeletedAbuse}}
                 <div>
                     <span class="text-muted">
@@ -34,43 +34,50 @@
                         </span>
                     {{/if}}
                 </div>
-                <div data-bind="if: canEdit">
-                    <a data-bind="click: submitUndelete">Restore</a>
-                </div>
+                {{#if comment.canEdit}}
+                    <a {{action restoreComment}}>Restore</a>
+                {{/if}}
             {{/if}}
 
-            <div data-bind="if: isAbuseNotDeleted">
+            {{#if isAbuseNotDeleted}}
                 <div>
                     <span class="text-muted">
                         <em>Comment reported.</em>
                     </span>
-                    <span data-bind="if: hasChildren()" class="comment-actions pull-right">
-                        <i data-bind="css: toggleIcon, click: toggle"></i>
-                    </span>
+                    {{#if comment.hasChildren}}
+                        <span class="comment-actions pull-right">
+                            <button {{action toggleChildren}}>
+                                <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
+                            </button>
+                        </span>
+                    {{/if}}
                 </div>
-                <div data-bind="if: hasReport">
+                {{#if comment.hasReport}}
+                    {{!-- TODO: Implement this with EOSF-76 --}}
                     <a data-bind="click: submitUnreportAbuse">Not abuse</a>
-                </div>
-            </div>
+                {{/if}}
+            {{/if}}}
 
-            <div data-bind="if: isVisible">
+            {{#if isVisible}}
 
                 <div class="comment-info">
+                    {{!-- TODO: Why is there a form here? --}}
                     <form class="form-inline">
-                        <span data-bind="if: author.gravatarUrl">
-                            <img data-bind="css: {'comment-gravatar': author.gravatarUrl}, attr: {src: author.gravatarUrl}"/>
-                        </span>
-                        <span data-bind="if: author.id">
-                            <a class="comment-author" data-bind="text: author.fullname, attr: {href: author.urls.profile}"></a>
-                        </span>
-                        <span data-bind="ifnot: author.id">
-                            <span class="comment-author" data-bind="text: author.fullname"></span>
-                        </span>
+                        {{#if comment.user.profileImage}}
+                            <img class="comment-gravatar" src="{{comment.user.profileImage}}"/>
+                        {{/if}}
+                        {{#if comment.user}}
+                            <a class="comment-author" href="{{comment.user.profileURL}}">{{comment.user.fullName}}</a>
+                        {{/if}}
+                        {{!-- TODO: Under what circumstances does this ever happen? In theory all user data should be accessible... deleted account maybe??? --}}
+                        <!--<span data-bind="ifnot: author.id">-->
+                            <!--<span class="comment-author" data-bind="text: author.fullname"></span>-->
+                        <!--</span>-->
                         <span class="comment-date pull-right">
-                            <span data-bind="template: {if: modified, afterRender: setupToolTips}">
-                                <a data-toggle="tooltip" data-bind="attr: {title: prettyDateModified()}">*</a>
-                            </span>
-                            <span data-bind="text: prettyDateCreated"></span>
+                            {{#if comment.modified}}
+                                <a title="Modified {{moment-from-now comment.dateModified}}">*</a>
+                            {{/if}}
+                            {{moment-from-now comment.dateCreated}}
                             &nbsp;
                         </span>
                     </form>
@@ -157,7 +164,7 @@
                     </div>
                 </div>
 
-            </div>
+            {{/if}}
         {{/unless}}
 
 

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -63,15 +63,15 @@
                     {{!-- TODO: Why is there a form here? --}}
                     <form class="form-inline">
                         {{#if comment.user.profileImage}}
-                            <img class="comment-gravatar" src="{{comment.user.profileImage}}"/>
+                            <img class="comment-gravatar" src="{{comment.user.profileImage}}">
                         {{/if}}
                         {{#if comment.user}}
                             <a class="comment-author" href="{{comment.user.profileURL}}">{{comment.user.fullName}}</a>
                         {{/if}}
                         {{!-- TODO: Support anonymous views throughout this template, eg anon view-only links. EOSF-112 --}}
-                        <!--<span data-bind="ifnot: author.id">-->
-                            <!--<span class="comment-author" data-bind="text: author.fullname"></span>-->
-                        <!--</span>-->
+                        {{!--<span data-bind="ifnot: author.id">--}}
+                        {{!--<span class="comment-author" data-bind="text: author.fullname"></span>--}}
+                        {{!--</span>--}}
                         <span class="comment-date pull-right">
                             {{#if comment.modified}}
                                 <a title="Modified {{moment-from-now comment.dateModified}}">*</a>
@@ -112,11 +112,11 @@
 
                 <div>
                     {{!-- TODO: Revisit error display mechanism to differentiate between validation and saving errors (do we need two fields?) --}}
-                    <!--<span class="text-danger" data-bind="text: errorMessage"></span>-->
+                    {{!--<span class="text-danger" data-bind="text: errorMessage"></span>--}}
 
                     <span>&nbsp;</span>
 
-                    <!-- Action bar -->
+                    {{!-- Action bar --}}
                     <div style="display: inline">
 
                         {{#unless editMode}}
@@ -162,16 +162,16 @@
                 </div>
                 {{#if reportMode}}
                     {{!-- TODO: Implement comment abuse reporting in separate ticket, EOSF-76 --}}
-                    <!--<div class="comment-report clearfix">-->
-                        <!--<form class="form-inline" data-bind="submit: submitAbuse">-->
-                            <!--<select class="form-control" data-bind="options: abuseOptions, optionsText: abuseLabel, value: abuseCategory"></select>-->
-                            <!--<input class="form-control" data-bind="value: abuseText" placeholder="Describe abuse" />-->
-                        <!--</form>-->
-                        <!--<div class="pull-right m-t-xs">-->
-                            <!--<a class="btn btn-default btn-sm" data-bind="click: cancelAbuse"> Cancel</a>-->
-                            <!--<a class="btn btn-danger btn-sm" data-bind="click: submitAbuse"> Report</a>-->
-                        <!--</div>-->
-                    <!--</div>-->
+                    {{!--<div class="comment-report clearfix">--}}
+                    {{!--<form class="form-inline" data-bind="submit: submitAbuse">--}}
+                    {{!--<select class="form-control" data-bind="options: abuseOptions, optionsText: abuseLabel, value: abuseCategory"></select>--}}
+                    {{!--<input class="form-control" data-bind="value: abuseText" placeholder="Describe abuse" />--}}
+                    {{!--</form>--}}
+                    {{!--<div class="pull-right m-t-xs">--}}
+                    {{!--<a class="btn btn-default btn-sm" data-bind="click: cancelAbuse"> Cancel</a>--}}
+                    {{!--<a class="btn btn-danger btn-sm" data-bind="click: submitAbuse"> Report</a>--}}
+                    {{!--</div>--}}
+                    {{!--</div>--}}
                 {{/if}}
                 {{#if deleteMode}}
                     <div class="comment-delete clearfix m-t-xs">
@@ -210,7 +210,7 @@
         {{/if}}
 
         {{!-- TODO: Implement the fetch more functionality below --}}
-        <!--<button class="btn btn-link pull-right more-replies" type="button" data-bind="click: getMoreComments">More replies</button>-->
+        {{!--<button class="btn btn-link pull-right more-replies" type="button" data-bind="click: getMoreComments">More replies</button>--}}
 
 
     </ul>

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -139,7 +139,7 @@
                                         <span {{action 'toggleReplyMode'}}><i class="fa fa-reply"></i></span>
                                     {{/if}}
                                     {{#if canReport}}
-                                        <span {{action reportComment}}>
+                                        <span {{action reportComment comment}}>
                                             {{!-- TODO: Bare fontawesome icons are an accessibility issue. See http://fontawesome.io/accessibility/ --}}
                                             <i class="fa fa-warning"></i>
                                         </span>
@@ -183,7 +183,7 @@
                     <div class="comment-delete clearfix m-t-xs">
                         <div class="pull-right">
                             <button class="btn btn-default btn-sm" {{action 'toggleDeleteMode'}}>Cancel</button>
-                            <button class="btn btn-danger btn-sm" {{action deleteComment}}>Delete</button>
+                            <button class="btn btn-danger btn-sm" {{action deleteComment comment}}>Delete</button>
                         </div>
                     </div>
                 {{/if}}

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -2,17 +2,16 @@
 
 <div class="comment-container">
     <div class="comment-body m-b-sm p-sm osf-box">
-         <!-- div data-bind="visible: loading">
-            <i class="fa fa-spinner fa-spin"></i>
-         </div -->
-        {{!-- TODO: Check on, and implement, loading indicator for comments --}}
-        {{#unless comment.isPending}}
+        {{#if comment.isPending}}
+            <i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Loading...
+        {{else}}
             {{#if isDeletedAbuse}}
                 <div>
                     <span class="text-muted">
                         <em>Comment confirmed as spam.</em>
                     </span>
                     {{#if comment.hasChildren}}
+                        {{!-- TODO: When making a reply, the template does not getting the new hasChildren value correctly  until comment is reloaded --}}
                         <span class="comment-actions pull-right">
                             <span {{action 'toggleChildren'}}>
                                 <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
@@ -53,7 +52,7 @@
                     {{/if}}
                 </div>
                 {{#if comment.hasReport}}
-                    {{!-- TODO: Implement this with EOSF-76 --}}
+                    {{!-- TODO: Implement reporting functionality, EOSF-76 . May be lower priority if we don't expose reporting features to external api consumers --}}
                     <a data-bind="click: submitUnreportAbuse">Not abuse</a>
                 {{/if}}
             {{/if}}
@@ -69,7 +68,7 @@
                         {{#if comment.user}}
                             <a class="comment-author" href="{{comment.user.profileURL}}">{{comment.user.fullName}}</a>
                         {{/if}}
-                        {{!-- TODO: Under what circumstances does this ever happen? In theory all user data should be accessible... deleted account maybe??? --}}
+                        {{!-- TODO: Support anonymous views throughout this template, eg anon view-only links. EOSF-112 --}}
                         <!--<span data-bind="ifnot: author.id">-->
                             <!--<span class="comment-author" data-bind="text: author.fullname"></span>-->
                         <!--</span>-->
@@ -101,7 +100,6 @@
 
 
                     {{!-- TODO: support autosizetext behavior when form loads --}}
-                    {{!-- TODO: Support configurable text for comment form (edit vs commenting) --}}
                     {{#if editMode}}
                         <div style="padding-top: 10px">
                             {{comment-form submitComment=(action 'editComment')
@@ -184,30 +182,36 @@
                     </div>
                 {{/if}}
             {{/if}}
-        {{/unless}}
+        {{/if}}
 
     </div>
 
     <ul class="comment-list">
 
         {{#if replyMode}}
-
             <div style="padding-top: 10px">
-                {{comment-form submitComment=(action 'replyComment') showButton=true}}
+                {{comment-form submitComment=(action 'replyComment') showButtons=true}}
             </div>
+        {{/if}}
 
+
+        {{#if showChildren}}
+            {{!-- TODO: Get this to work with more than first page of replies --}}
+            {{#each comment.replies as |reply|}}
+                {{comment-detail
+                  comment=reply
+                  resource=resource
+                  addComment=attrs.addComment
+                  editComment=attrs.editComment
+                  deleteComment=attrs.deleteComment
+                  restoreComment=attrs.restoreComment
+                  reportComment=attrs.reportComment}}
+            {{/each}}
         {{/if}}
 
         {{!-- TODO: Implement the fetch more functionality below --}}
-        <!-- ko if: showChildren() -->
-            <!-- ko template: {name:  'commentTemplate', foreach: comments} -->
-            <!-- /ko -->
-            <!-- ko if: urlForNext() -->
-                        <!--<div class="row">-->
-                            <!--<button class="btn btn-link pull-right more-replies" type="button" data-bind="click: getMoreComments">More replies</button>-->
-                        <!--</div>-->
-            <!-- /ko -->
-        <!-- /ko -->
+        <!--<button class="btn btn-link pull-right more-replies" type="button" data-bind="click: getMoreComments">More replies</button>-->
+
 
     </ul>
 

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -14,7 +14,7 @@
                     </span>
                     {{#if comment.hasChildren}}
                         <span class="comment-actions pull-right">
-                            <button {{action toggleChildren}}>
+                            <button {{action 'toggleChildren'}}>
                                 <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
                             </button>
                         </span>
@@ -28,7 +28,7 @@
                     </span>
                     {{#if comment.hasChildren}}
                         <span class="comment-actions pull-right">
-                            <button {{action toggleChildren}}>
+                            <button {{action 'toggleChildren'}}>
                                 <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
                             </button>
                         </span>
@@ -46,7 +46,7 @@
                     </span>
                     {{#if comment.hasChildren}}
                         <span class="comment-actions pull-right">
-                            <button {{action toggleChildren}}>
+                            <button {{action 'toggleChildren'}}>
                                 <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
                             </button>
                         </span>
@@ -93,7 +93,7 @@
                         <span class="component-overflow">{{comment.content}}</span>
                         {{#if comment.hasChildren}}
                             <span class="comment-actions pull-right">
-                                <button {{action toggleChildren}}>
+                                <button {{action 'toggleChildren'}}>
                                     <i class="fa {{if showChildren 'fa-minus' 'fa-plus'}}"></i>
                                 </button>
                             </span>
@@ -121,55 +121,72 @@
 
                     <!-- Action bar -->
                     <div style="display: inline">
-                        <div data-bind="ifnot: editing" class="comment-actions pull-right">
-                            <span data-bind="ifnot: isHam">
-                                <span data-bind="if: canEdit, click: edit">
-                                    <i class="fa fa-pencil"></i>
-                                </span>
-                                <span data-bind="if: $root.canComment, click: showReply">
-                                    <i class="fa fa-reply"></i>
-                                </span>
-                                <span data-bind="if: canReport, click: reportAbuse">
-                                    <i class="fa fa-warning"></i>
-                                </span>
-                                <span data-bind="if: canEdit, click: startDelete">
-                                    <i class="fa fa-trash-o"></i>
-                                </span>
-                            </span>
-                            <span data-bind="if: isHam">
-                                <span data-bind="if: $root.canComment, click: showReply">
-                                    <i class="fa fa-reply"></i>
-                                </span>
-                                <span>
-                                    <i class="text-success fa fa-check-circle-o"></i>
-                                </span>
-                            </span>
+
+                        {{#unless editMode}}
+                            <div class="comment-actions pull-right">
+                                {{!- TODO: Logic convoluted- unless/else --}}
+                                {{#unless comment.isHam}}
+                                    {{!-- If there are no outstanding/unresolved spam reports, show a full set of buttons, including for reporting --}}
+                                    {{#if comment.canEdit}}
+                                        <button {{action 'toggleEditMode'}}><i class="fa fa-pencil"></i></button>
+                                    {{/if}}
+
+                                    {{#if node.currentUserCanComment}}
+                                        <button {{action 'toggleReplyMode'}}>
+                                            <i class="fa fa-reply"></i>
+                                        </button>
+                                    {{/if}}
+                                    {{#if canReport}}
+                                        <button {{action reportComment}}>
+                                            {{!-- TODO: Bare fontawesome icons are an accessibility issue. See http://fontawesome.io/accessibility/ --}}
+                                            <i class="fa fa-warning"></i>
+                                        </button>
+                                    {{/if}}
+                                    {{#if comment.canEdit}}
+                                        <button {{action 'toggleDeleteMode'}}>
+                                            <i class="fa fa-trash-o"></i>
+                                        </button>
+                                    {{/if}}
+                                {{else}}
+                                        {{!-- TODO: DRY this code up and avoid redundant button definitions --}}
+                                    {{!-- Why don't we show the delete button for comments confirmed not spam? --}}
+                                    {{#if node.currentUserCanComment}}
+                                        <button {{action 'toggleReplyMode'}}>
+                                            <i class="fa fa-reply"></i>
+                                        </button>
+                                    {{/if}}
+                                    <span>
+                                        <i class="text-success fa fa-check-circle-o"></i>
+                                    </span>
+                                {{/unless}}
+                            </div>
+                        {{/unless}}
+                    </div>
+
+                </div>
+                {{#if reportMode}}
+                    {{!-- TODO: Implement comment abuse reporting in separate ticket, EOSF-76 --}}
+                    <!--<div class="comment-report clearfix">-->
+                        <!--<form class="form-inline" data-bind="submit: submitAbuse">-->
+                            <!--<select class="form-control" data-bind="options: abuseOptions, optionsText: abuseLabel, value: abuseCategory"></select>-->
+                            <!--<input class="form-control" data-bind="value: abuseText" placeholder="Describe abuse" />-->
+                        <!--</form>-->
+                        <!--<div class="pull-right m-t-xs">-->
+                            <!--<a class="btn btn-default btn-sm" data-bind="click: cancelAbuse"> Cancel</a>-->
+                            <!--<a class="btn btn-danger btn-sm" data-bind="click: submitAbuse"> Report</a>-->
+                        <!--</div>-->
+                    <!--</div>-->
+                {{/if}}
+                {{#if deleteMode}}
+                    <div class="comment-delete clearfix m-t-xs">
+                        <div class="pull-right">
+                            <button class="btn btn-default btn-sm" {{action 'toggleDeleteMode'}}>Cancel</button>
+                            <button class="btn btn-danger btn-sm" {{action deleteComment}}>Delete</button>
                         </div>
                     </div>
-
-                </div>
-
-                <div class="comment-report clearfix" data-bind="if: reporting">
-                    <form class="form-inline" data-bind="submit: submitAbuse">
-                        <select class="form-control" data-bind="options: abuseOptions, optionsText: abuseLabel, value: abuseCategory"></select>
-                        <input class="form-control" data-bind="value: abuseText" placeholder="Describe abuse" />
-                    </form>
-                    <div class="pull-right m-t-xs">
-                        <a class="btn btn-default btn-sm" data-bind="click: cancelAbuse"> Cancel</a>
-                        <a class="btn btn-danger btn-sm" data-bind="click: submitAbuse"> Report</a>
-                    </div>
-                </div>
-
-                <div class="comment-delete clearfix m-t-xs" data-bind="if: deleting">
-                    <div class="pull-right">
-                        <a class="btn btn-default btn-sm" data-bind="click: cancelDelete">Cancel</a>
-                        <a class="btn btn-danger btn-sm" data-bind="click: submitDelete">Delete</a>
-                    </div>
-                </div>
-
+                {{/if}}
             {{/if}}
         {{/unless}}
-
 
     </div>
 
@@ -178,7 +195,7 @@
         <!-- ko if: replying -->
 
             <div style="padding-top: 10px">
-                {{!-- TODO: Replace addComment with a custom addReply action --}}
+                {{!-- TODO: Replace addComment with a custom addReply action (referencing the comment as target) --}}
                 {{comment-form addComment=attrs.addComment}}
             </div>
 
@@ -198,38 +215,3 @@
     </ul>
 
 </div>
-
-
-
-
-
-
-
-
-
-
-
-
-    <!--{{#if comment.deleted}}-->
-        <!--<div>-->
-            <!--Comment deleted-->
-            <!--{{# if comment.canEdit}}-->
-                <!--<button {{action restoreComment comment}} class="btn btn-warning">Restore</button>-->
-            <!--{{/if}}-->
-        <!--</div>-->
-    <!--{{else}}-->
-        <!--<div>-->
-            <!--<strong>-->
-                <!--{{comment.dateCreated}}-->
-            <!--</strong>:-->
-            <!--{{# if comment.canEdit}}-->
-                <!--{{input value=comment.content}}-->
-                <!--<button {{action editComment comment}} class="btn btn-success">Edit</button>-->
-                <!--<button {{action deleteComment comment}} class="btn btn-danger">Delete</button>-->
-            <!--{{else}}-->
-                <!--<span>{{comment.content}}</span>-->
-                <!--<button {{action reportComment comment}} class="btn btn-warning">Report</button>-->
-            <!--{{/if}}-->
-        <!--</div>-->
-    <!--{{/if}}-->
-<!--</div>-->

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -35,7 +35,7 @@
                     {{/if}}
                 </div>
                 {{#if comment.canEdit}}
-                    <a {{action restoreComment}}>Restore</a>
+                    <a {{action restoreComment comment}}>Restore</a>
                 {{/if}}
             {{/if}}
 

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -3,6 +3,7 @@
 <div class="comment-container">
     <div class="comment-body m-b-sm p-sm osf-box">
         {{#if comment.isPending}}
+            {{!-- TODO: Get loading indicator working correctly via isLoaded--}}
             <i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Loading...
         {{else}}
             {{#if isDeletedAbuse}}

--- a/addon/components/comment-detail/template.hbs
+++ b/addon/components/comment-detail/template.hbs
@@ -99,18 +99,17 @@
                         {{/if}}
                     {{/unless}}
 
-                    <!--
-                        Hack: Use template binding with if rather than vanilla if
-                        binding to get access to afterRender
-                    -->
+
                     {{!-- TODO: support autosizetext behavior when form loads --}}
                     {{!-- TODO: Support configurable text for comment form (edit vs commenting) --}}
-                    {{!-- TODO: May need to add back class=clearfix markup around buttons --}}
                     {{#if editMode}}
                         <div style="padding-top: 10px">
                             {{!-- TODO: Support editing functionality for a form? Original comment text, different button labels--}}
                             {{!-- TODO: Replace addComment with editComment --}}
-                            {{comment-form addComment=attrs.addComment}}
+                            {{comment-form addComment=attrs.addComment
+                              showButtons=true
+                              initialText=comment.content
+                              cancelComment=(action 'toggleEditMode')}}
                         </div>
                     {{/if}}
                 </div>
@@ -197,7 +196,7 @@
 
             <div style="padding-top: 10px">
                 {{!-- TODO: Replace addComment with a custom addReply action (referencing the comment as target) --}}
-                {{comment-form addComment=attrs.addComment}}
+                {{comment-form addComment=attrs.addComment showButton=true}}
             </div>
 
         {{/if}}

--- a/addon/components/comment-form/component.js
+++ b/addon/components/comment-form/component.js
@@ -8,8 +8,6 @@ import layout from './template';
  * @submodule components
  */
 
-
-
 const Validations = buildValidations({
     _commentText: validator('length', {
         max: 500,

--- a/addon/components/comment-form/component.js
+++ b/addon/components/comment-form/component.js
@@ -64,13 +64,12 @@ export default Ember.Component.extend(Validations, {
                 return;
             }
             this.set('submitInProgress', true);
-            if (this.get('editMode')) {
-                this.sendAction('submitComment', text);
-            } else {
-                let res = this.attrs.submitComment(text);
-                // If adding a comment, clear the box for another comment
-                res.then(() => this.send('resetForm'));
-            }
+
+            let res = this.attrs.submitComment(text);
+            // If adding a comment, clear the box for another comment
+            res.then(() => this.send('resetForm'))
+                .catch(() => this.set('errorMessage', 'Could not submit comment'));
+
         },
         cancelComment() {
             // User can pass in their own cancelComment function, eg to exit reply mode

--- a/addon/components/comment-form/component.js
+++ b/addon/components/comment-form/component.js
@@ -24,12 +24,12 @@ const Validations = buildValidations({
  * Sample usage:
  * ```handlebars
  * {{comment-form
- *   addComment=attrs.addComment
+ *   submitComment=attrs.addComment
  *   showButtons=false}}
  * ```
  *
  * @class comment-form
- * @param {action} addComment The action to fire when adding a new comment to the discussion. Returns a promise.
+ * @param {action} submitComment The action to fire when adding a new comment to the discussion. Returns a promise.
  */
 export default Ember.Component.extend(Validations, {
     layout,
@@ -55,18 +55,22 @@ export default Ember.Component.extend(Validations, {
     actions: {
         /**
          * Call a passed-in closure action to handle submitting a comment. Reset the form if save succeeds.
-         * @method addComment
+         * @method submitComment
          * @param {String} text The text of the comment to create
          */
-        addComment(text) {
-            // TODO: Rename to submitComment (edit or save as appropriate)
+        submitComment(text) {
             if (!text) {
                 this.set('errorMessage', 'Please enter a comment');
                 return;
             }
-            this.set('submitInProgress', true);
-            let res = this.attrs.addComment(text);
-            res.then(() => this.send('resetForm'));
+            if (this.get('editMode')) {
+                this.sendAction('submitComment', text);
+            } else {
+                this.set('submitInProgress', true);
+                let res = this.attrs.submitComment(text);
+                // If adding a comment, clear the box for another comment
+                res.then(() => this.send('resetForm'));
+            }
         },
         cancelComment() {
             // User can pass in their own cancelComment function, eg to exit reply mode

--- a/addon/components/comment-form/component.js
+++ b/addon/components/comment-form/component.js
@@ -21,6 +21,15 @@ import layout from './template';
 export default Ember.Component.extend({
     layout,
     _commentText: null,
+    errorMessage: null,
+    submitInProgress: false,
+    /**
+     * Maximum comment length for validation
+     * @property maxLength
+     * @type Integer
+     */
+    // TODO: Implement validation
+    maxLength: 500,
 
     actions: {
         /**
@@ -29,8 +38,21 @@ export default Ember.Component.extend({
          * @param {String} text The text of the comment to create
          */
         addComment(text) {
+            if (!text) {
+                this.set('errorMessage', 'Please enter a comment');
+                return;
+            }
+            this.set('submitInProgress', true);
             let res = this.attrs.addComment(text);
-            res.then(() => this.set('_commentText', ''));
+            res.then(() => this.send('resetForm'));
+        },
+        cancelComment() {
+            this.send('resetForm');
+        },
+        resetForm() {
+            this.set('_commentText', '');
+            this.set('submitInProgress', false);
+            this.set('errorMessage', '');
         }
     }
 });

--- a/addon/components/comment-form/component.js
+++ b/addon/components/comment-form/component.js
@@ -63,10 +63,10 @@ export default Ember.Component.extend(Validations, {
                 this.set('errorMessage', 'Please enter a comment');
                 return;
             }
+            this.set('submitInProgress', true);
             if (this.get('editMode')) {
                 this.sendAction('submitComment', text);
             } else {
-                this.set('submitInProgress', true);
                 let res = this.attrs.submitComment(text);
                 // If adding a comment, clear the box for another comment
                 res.then(() => this.send('resetForm'));

--- a/addon/components/comment-form/component.js
+++ b/addon/components/comment-form/component.js
@@ -18,12 +18,14 @@ const Validations = buildValidations({
 });
 
 /**
- * Allow users to add comments to a page.
+ * Allow users to add comments to a page, or edit an existing comment if initialText is provided..
  *
  * This component is typically used as part of the `comment-pane` component; see that component for further information.
  * Sample usage:
  * ```handlebars
- * {{comment-form addComment=attrs.addComment}}
+ * {{comment-form
+ *   addComment=attrs.addComment
+ *   showButtons=false}}
  * ```
  *
  * @class comment-form
@@ -31,7 +33,22 @@ const Validations = buildValidations({
  */
 export default Ember.Component.extend(Validations, {
     layout,
-    _commentText: null,
+    /**
+     * The default text for the comment. If passed in, this component acts as an edit widget instead of creation.
+     * @property initialText
+     * @type String|null
+     */
+    initialText: null,
+
+    /**
+     * Control whether buttons should be displayed by default
+     * @property showButtons
+     * @type boolean
+     */
+
+    // Track internal state
+    _commentText: Ember.computed.oneWay('initialText'),
+    editMode: Ember.computed.bool('initialText'),
     errorMessage: null,
     submitInProgress: false,
 
@@ -52,7 +69,12 @@ export default Ember.Component.extend(Validations, {
             res.then(() => this.send('resetForm'));
         },
         cancelComment() {
-            this.send('resetForm');
+            // User can pass in their own cancelComment function, eg to exit reply mode
+            if (this.attrs.cancelComment) {
+                this.attrs.cancelComment();
+            } else {
+                this.send('resetForm');
+            }
         },
         resetForm() {
             this.set('_commentText', '');

--- a/addon/components/comment-form/component.js
+++ b/addon/components/comment-form/component.js
@@ -1,10 +1,21 @@
 import Ember from 'ember';
+import { validator, buildValidations } from 'ember-cp-validations';
+
 import layout from './template';
 
 /**
  * @module ember-osf
  * @submodule components
  */
+
+
+
+const Validations = buildValidations({
+    _commentText: validator('length', {
+        max: 500,
+        message: 'Comment should not be more than 500 characters'
+    })
+});
 
 /**
  * Allow users to add comments to a page.
@@ -18,18 +29,11 @@ import layout from './template';
  * @class comment-form
  * @param {action} addComment The action to fire when adding a new comment to the discussion. Returns a promise.
  */
-export default Ember.Component.extend({
+export default Ember.Component.extend(Validations, {
     layout,
     _commentText: null,
     errorMessage: null,
     submitInProgress: false,
-    /**
-     * Maximum comment length for validation
-     * @property maxLength
-     * @type Integer
-     */
-    // TODO: Implement validation
-    maxLength: 500,
 
     actions: {
         /**
@@ -38,6 +42,7 @@ export default Ember.Component.extend({
          * @param {String} text The text of the comment to create
          */
         addComment(text) {
+            // TODO: Rename to submitComment (edit or save as appropriate)
             if (!text) {
                 this.set('errorMessage', 'Please enter a comment');
                 return;

--- a/addon/components/comment-form/template.hbs
+++ b/addon/components/comment-form/template.hbs
@@ -4,7 +4,6 @@
 
     {{#if _commentText}}
         <div class="form-group">
-            {{!-- TODO: Support submittingReply check --}}
             <button {{action 'cancelComment'}} class="btn btn-default btn-sm">Cancel</button>
             <button {{action 'addComment' _commentText}} class="btn btn-success btn-sm">{{if submitInProgress 'Commenting' 'Comment'}}</button>
             {{#if errorMessage}}<span class="text-danger">{{errorMessage}}</span>{{/if}}

--- a/addon/components/comment-form/template.hbs
+++ b/addon/components/comment-form/template.hbs
@@ -3,11 +3,11 @@
         {{textarea class="form-control" placeholder="Add a comment" value=_commentText}}
     </div>
 
-    {{#if _commentText}}
+    {{#if (or _commentText showButtons)}}
         <div class="clearfix">
             <div class="pull-right">
                 <button {{action 'cancelComment'}} class="btn btn-default btn-sm">Cancel</button>
-                <button {{action 'addComment' _commentText}} class="btn btn-success btn-sm">{{if submitInProgress 'Commenting' 'Comment'}}</button>
+                <button {{action 'addComment' _commentText}} class="btn btn-success btn-sm">{{if editMode (if submitInProgress 'Saving' 'Save') (if submitInProgress 'Commenting' 'Comment')}}</button>
             </div>
 
             {{#if errorMessage}}<span class="text-danger">{{errorMessage}}</span>{{/if}}

--- a/addon/components/comment-form/template.hbs
+++ b/addon/components/comment-form/template.hbs
@@ -7,7 +7,8 @@
         <div class="clearfix">
             <div class="pull-right">
                 <button {{action 'cancelComment'}} class="btn btn-default btn-sm">Cancel</button>
-                <button {{action 'addComment' _commentText}} class="btn btn-success btn-sm">{{if editMode (if submitInProgress 'Saving' 'Save') (if submitInProgress 'Commenting' 'Comment')}}</button>
+                {{!-- TODO: Support configurable add/edit mode --}}
+                <button {{action 'submitComment' _commentText}} class="btn btn-success btn-sm">{{if editMode (if submitInProgress 'Saving' 'Save') (if submitInProgress 'Commenting' 'Comment')}}</button>
             </div>
 
             {{#if errorMessage}}<span class="text-danger">{{errorMessage}}</span>{{/if}}

--- a/addon/components/comment-form/template.hbs
+++ b/addon/components/comment-form/template.hbs
@@ -1,12 +1,23 @@
 <div>
-    {{!-- TODO: Add validators (MAXLENGTH) for parity with comment functionality --}}
-    {{textarea class="form-control" maxlength="500" placeholder="Add a comment" value=_commentText}}
+    <div class="form-group">
+        {{textarea class="form-control" placeholder="Add a comment" value=_commentText}}
+    </div>
 
     {{#if _commentText}}
-        <div class="form-group">
-            <button {{action 'cancelComment'}} class="btn btn-default btn-sm">Cancel</button>
-            <button {{action 'addComment' _commentText}} class="btn btn-success btn-sm">{{if submitInProgress 'Commenting' 'Comment'}}</button>
+        <div class="clearfix">
+            <div class="pull-right">
+                <button {{action 'cancelComment'}} class="btn btn-default btn-sm">Cancel</button>
+                <button {{action 'addComment' _commentText}} class="btn btn-success btn-sm">{{if submitInProgress 'Commenting' 'Comment'}}</button>
+            </div>
+
             {{#if errorMessage}}<span class="text-danger">{{errorMessage}}</span>{{/if}}
+            {{#if validations.isInvalid}}
+                <div class="text-danger">
+                    {{#each validations.errors as |error|}}
+                        {{error.message}}<br>
+                    {{/each}}
+                </div>
+            {{/if}}
         </div>
     {{/if}}
 </div>

--- a/addon/components/comment-form/template.hbs
+++ b/addon/components/comment-form/template.hbs
@@ -1,6 +1,13 @@
 <div>
+    {{!-- TODO: Add validators (MAXLENGTH) for parity with comment functionality --}}
     {{textarea class="form-control" maxlength="500" placeholder="Add a comment" value=_commentText}}
-    <button {{action 'addComment' _commentText}} class="btn btn-success" disabled={{if (not _commentText) true}}>
-        Add comment
-    </button>
+
+    {{#if _commentText}}
+        <div class="form-group">
+            {{!-- TODO: Support submittingReply check --}}
+            <button {{action 'cancelComment'}} class="btn btn-default btn-sm">Cancel</button>
+            <button {{action 'addComment' _commentText}} class="btn btn-success btn-sm">{{if submitInProgress 'Commenting' 'Comment'}}</button>
+            {{#if errorMessage}}<span class="text-danger">{{errorMessage}}</span>{{/if}}
+        </div>
+    {{/if}}
 </div>

--- a/addon/components/comment-pane/component.js
+++ b/addon/components/comment-pane/component.js
@@ -14,6 +14,7 @@ import layout from './template';
  * ```handlebars
  * {{comment-pane
  *   comments=comments
+ *   resource=model
  *   addComment=(action 'addComment')
  *   editComment=(action 'editComment')
  *   deleteComment=(action 'deleteComment')

--- a/addon/components/comment-pane/component.js
+++ b/addon/components/comment-pane/component.js
@@ -14,6 +14,7 @@ import layout from './template';
  * ```handlebars
  * {{comment-pane
  *   comments=comments
+ *   title=model.title
  *   resource=model
  *   addComment=(action 'addComment')
  *   editComment=(action 'editComment')
@@ -23,6 +24,8 @@ import layout from './template';
  * ```
  * @class comment-pane
  * @param {Comment[]} comments An array of comments to be displayed
+ * @param {String} title The title of the resource
+ * @param {DS.Model} resource The parent resource that owns the comment
  * @param {action} addComment
  * @param {action} editComment
  * @param {action} deleteComment

--- a/addon/components/comment-pane/style.scss
+++ b/addon/components/comment-pane/style.scss
@@ -1,0 +1,124 @@
+.comment-pane {
+    position: fixed;
+    z-index: 999; /* Note: Must be lower than Bootstrap modals, BlockUI */
+    width: 0;
+    top: 47px!important;
+    right: 0;
+    height: 100%;
+}
+
+@media (max-width: 767px) {
+    .comment-pane {
+        top: 99px!important;
+    }
+}
+
+.comment-info {
+  padding-bottom: 10px;
+}
+
+.comment-container {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+
+.comment-body {
+    padding: 5px;
+    background-color: white;
+}
+
+.comment-author {
+    color: #999999;
+}
+
+.comment-date {
+    color: #999999;
+}
+.edit-comment {
+    background-color: #F3F3F3;
+}
+
+.comment-body i {
+    padding-right: 5px;
+}
+
+.cp-handle-div {
+    /* Handle starts under Bootstrap header */
+    width: 100px;
+    height: 48px;
+    margin-left: -50px;
+    text-align: center;
+    border-bottom-left-radius: 15px;
+    padding-top: 10px;
+}
+
+.comment-handle-icon {
+    padding-top: 2px;
+    color: #428bca;
+    cursor: pointer;
+    position: relative;
+}
+
+.cp-bar {
+    width: 1px;  /* Note: Should be the same as .cp-sidebar:margin-left */
+    top: 88px;
+    height: 100%;
+    background-color: transparent;
+    position: absolute;
+    cursor: ew-resize;
+}
+
+.cp-sidebar {
+    height: 95%;
+    margin-left: 1px;  /* Note: Should be the same as .cp-bar:width */
+    background-color: whitesmoke;
+    padding: 10px;
+    overflow-y: auto;
+    box-shadow: -1px 0 3px lightgrey;
+}
+
+/*
+* Note: Separate class needed because padding does not get applied to overflow elements in firefox:
+* http://stackoverflow.com/questions/13471910/css-applying-padding-to-box-with-scroll-bottom-padding-doesnt-work
+*/
+.cp-sidebar-content {
+    padding-bottom: 70px!important;
+}
+
+.unselectable {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.unread-comments-count {
+    font-size: small;
+    background-color: #428bca;
+    color: #FFF;
+    position: absolute;
+    margin-left: 30px;
+    margin-top: 4px;
+    z-index:1000;
+}
+
+.comment-actions a:hover {
+    text-decoration: none !important;
+}
+
+.comment-actions i {
+    cursor: pointer;
+}
+
+.comment-content img{
+  vertical-align: middle;
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.comment-gravatar {
+    height: 20px;
+}

--- a/addon/components/comment-pane/style.scss
+++ b/addon/components/comment-pane/style.scss
@@ -1,3 +1,4 @@
+// TODO: This contains styles for comment pane, form, and detail. Break this into separate files in the future.
 .comment-pane {
     position: fixed;
     z-index: 999; /* Note: Must be lower than Bootstrap modals, BlockUI */

--- a/addon/components/comment-pane/template.hbs
+++ b/addon/components/comment-pane/template.hbs
@@ -5,6 +5,7 @@
 {{#each comments as |comment|}}
     {{comment-detail
     comment=comment
+    resource=resource
     editComment=attrs.editComment
     deleteComment=attrs.deleteComment
     restoreComment=attrs.restoreComment

--- a/addon/components/comment-pane/template.hbs
+++ b/addon/components/comment-pane/template.hbs
@@ -1,4 +1,7 @@
 <h3>Comments</h3>
+
+{{comment-form addComment=attrs.addComment}}
+
 {{#each comments as |comment|}}
     {{comment-detail
     comment=comment
@@ -10,4 +13,4 @@
     (none)
 {{/each}}
 
-{{comment-form addComment=attrs.addComment}}
+

--- a/addon/components/comment-pane/template.hbs
+++ b/addon/components/comment-pane/template.hbs
@@ -1,17 +1,14 @@
 <h3>Comments</h3>
 
-{{comment-form addComment=attrs.addComment}}
+{{comment-form submitComment=attrs.addComment}}
 
 {{#each comments as |comment|}}
     {{comment-detail
     comment=comment
     resource=resource
+    addComment=attrs.addComment
     editComment=attrs.editComment
     deleteComment=attrs.deleteComment
     restoreComment=attrs.restoreComment
     reportComment=attrs.reportComment}}
-{{else}}
-    (none)
 {{/each}}
-
-

--- a/addon/components/comment-pane/template.hbs
+++ b/addon/components/comment-pane/template.hbs
@@ -2,13 +2,19 @@
 
 {{comment-form submitComment=attrs.addComment}}
 
-{{#each comments as |comment|}}
-    {{comment-detail
-    comment=comment
-    resource=resource
-    addComment=attrs.addComment
-    editComment=attrs.editComment
-    deleteComment=attrs.deleteComment
-    restoreComment=attrs.restoreComment
-    reportComment=attrs.reportComment}}
-{{/each}}
+{{#if comments.isPending}}
+    {{!-- TODO: Get loading indicator working correctly --}}
+    <i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Loading...
+{{else}}
+    {{#each comments as |comment|}}
+        {{comment-detail
+        comment=comment
+        resource=resource
+        addComment=attrs.addComment
+        editComment=attrs.editComment
+        deleteComment=attrs.deleteComment
+        restoreComment=attrs.restoreComment
+        reportComment=attrs.reportComment}}
+    {{/each}}
+{{/if}}
+

--- a/addon/components/comment-pane/template.hbs
+++ b/addon/components/comment-pane/template.hbs
@@ -1,9 +1,9 @@
-<h3>Comments</h3>
+<h3>{{title}} | Discussion</h3>
 
 {{comment-form submitComment=attrs.addComment}}
 
 {{#if comments.isPending}}
-    {{!-- TODO: Get loading indicator working correctly --}}
+    {{!-- TODO: Get loading indicator working correctly. Should be watching comments.isLoaded (on a DS.ManyArray)- get oage load  --}}
     <i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Loading...
 {{else}}
     {{#each comments as |comment|}}

--- a/addon/mixins/commentable.js
+++ b/addon/mixins/commentable.js
@@ -38,13 +38,13 @@ export default Ember.Mixin.create({
          */
         addComment(text, parent) {
             // FIXME: Known issue: if you add a comment, then delete without refreshing, you get a 409 error. This is because the target fields are still there in the store and haven't been cleared of placeholder values.
-            // Solution will involve only serializing those if adapterOptions indicates we're saving a new (not updated) comment
+            // TODO: Test to see if adapterOptions changes resolve the above error.
 
-            // TODO: Rework signature so parent/ target argument is always required in all usages
+            // TODO: Rework method signature so parent/ target argument is always required in all usages
             let target = parent || this.get('model');
 
             let targetID = target.get('guid') || target.id;
-            let targetType = Ember.Inflector.inflector.pluralize(target.constructor.modelName);
+            let targetType = target.constructor.modelName;
 
             var comment = this.store.createRecord('comment', {
                 content: text,
@@ -69,6 +69,7 @@ export default Ember.Mixin.create({
          * @return {Promise}
          */
         editComment(text, comment) {
+            // TODO: Change argument order in all usages to support currying
             comment.set('content', text);
             return comment.save();
         },

--- a/addon/mixins/commentable.js
+++ b/addon/mixins/commentable.js
@@ -36,6 +36,7 @@ export default Ember.Mixin.create({
          * @return {Promise}
          */
         addComment(text, parent) {
+            // TODO: Known issue: if you add a comment, then delete without refreshing, you get a 409 error. This is because the target fields are still there in the store and haven't been cleared of placeholder values.
             let target = parent || this.get('model');
             var commentsRel = target.get('comments') || target.get('replies');
 

--- a/addon/mixins/commentable.js
+++ b/addon/mixins/commentable.js
@@ -33,7 +33,7 @@ export default Ember.Mixin.create({
          * Action that adds a new comment targeting the model by GUID.
          * @method addComment
          * @param {String} text The text of the new comment
-         * @return {Promise}
+         * @return {Promise} The newly created comment
          */
         addComment(text, parent) {
             // TODO: Known issue: if you add a comment, then delete without refreshing, you get a 409 error. This is because the target fields are still there in the store and haven't been cleared of placeholder values.
@@ -46,7 +46,7 @@ export default Ember.Mixin.create({
                 targetType: Ember.Inflector.inflector.pluralize(target.constructor.modelName)
             });
             commentsRel.pushObject(comment);
-            return target.save();
+            return target.save().then(()=> comment);
         },
         /**
          * Action that edits an existing comment.

--- a/addon/mixins/commentable.js
+++ b/addon/mixins/commentable.js
@@ -35,26 +35,27 @@ export default Ember.Mixin.create({
          * @param {String} text The text of the new comment
          * @return {Promise}
          */
-        addComment(text) {
-            // Assumes that the page's model hook is the target for the comment
-            let model = this.get('model');
-            var commentsRel = model.get('comments');
+        addComment(text, parent) {
+            let target = parent || this.get('model');
+            var commentsRel = target.get('comments') || target.get('replies');
 
             var comment = this.store.createRecord('comment', {
                 content: text,
-                targetID: model.get('guid') || model.id,
-                targetType: Ember.Inflector.inflector.pluralize(model.constructor.modelName)
+                targetID: target.get('guid') || target.id,
+                targetType: Ember.Inflector.inflector.pluralize(target.constructor.modelName)
             });
             commentsRel.pushObject(comment);
-            return model.save();
+            return target.save();
         },
         /**
          * Action that edits an existing comment.
          * @method editComment
+         * @param {String} text The text of the comment to save
          * @param {DS.Model} comment A comment model
          * @return {Promise}
          */
-        editComment(comment) {
+        editComment(text, comment) {
+            comment.set('content', text);
             return comment.save();
         },
         /**

--- a/addon/models/comment.js
+++ b/addon/models/comment.js
@@ -22,11 +22,6 @@ export default OsfModel.extend({
     content: DS.attr('string'),
     page: DS.attr('string'),
 
-    // Placeholder for comment creation: allow specifying attributes that are sent to the server, but not as attributes
-    // Both type and ID will be serialized into relationships field
-    targetID: DS.attr('string'),
-    targetType: DS.attr('string'),
-
     // TODO dynamic belongsTo
     user: DS.belongsTo('user'),
     node: DS.belongsTo('node'),

--- a/addon/models/node.js
+++ b/addon/models/node.js
@@ -26,6 +26,7 @@ export default OsfModel.extend(FileItemMixin, {
     description: DS.attr('string'),
     category: DS.attr('string'),
 
+    currentUserCanComment: DS.attr('boolean'),
     currentUserPermissions: DS.attr('string'),
 
     fork: DS.attr('boolean'),

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -29,5 +29,9 @@ export default OsfModel.extend({
 
     affiliatedInstitutions: DS.hasMany('institutions', {
         inverse: 'users'
-    })
+    }),
+
+    // Calculated fields
+    profileURL: Ember.computed.alias('links.html')
+    profileImage: Ember.computed.alias('links.profile_image')
 });

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 
 import OsfModel from './osf-model';
@@ -32,6 +33,6 @@ export default OsfModel.extend({
     }),
 
     // Calculated fields
-    profileURL: Ember.computed.alias('links.html')
+    profileURL: Ember.computed.alias('links.html'),
     profileImage: Ember.computed.alias('links.profile_image')
 });

--- a/addon/serializers/comment.js
+++ b/addon/serializers/comment.js
@@ -2,28 +2,26 @@ import Ember from 'ember';
 import OsfSerializer from './osf-serializer';
 
 export default OsfSerializer.extend({
-    serialize(snapshot, options) {  // jshint ignore:line
-        // Add relationships field to identify comment target
-        let serialized = this._super(...arguments);
+    serializeIntoHash(hash, typeClass, snapshot, options) {  // jshint ignore:line
+        if (options.forRelationship) {
+            // New comments must identify their target as part of a relationship field
+            // TODO: pop off record when done so these dummy fields don't persist? Do they matter?
+            // TODO: This breaks commenting atm
+            let targetID = snapshot.record.get('targetID');
+            let targetType = snapshot.record.get('targetType');
+            Ember.assert('Must provide target ID', targetID);
+            Ember.assert('Must provide target type', targetType);
 
-        // For POST requests specifically, two additional fields are needed
-        let targetID = snapshot.record.get('targetID');
-        let targetType = snapshot.record.get('targetType');
-        // TODO: Find a better way to detect request type, so this can enforce fields that are needed for creation (but not for editing)
-        //Ember.assert('Must provide target ID', targetID);
-        //Ember.assert('Must provide target type', targetType);
-
-        if (targetID && targetType) {
-            serialized.data.relationships = {
+            hash.data.relationships = {
                 target: {
                     data: {
                         id: targetID,
                         type: targetType
                     }
                 }
-            };
+            }
         }
-        return serialized;
+        return this._super(hash, typeClass, snapshot, options);
     },
     extractRelationships(modelClass, resourceHash) {
         // TODO: remove when https://openscience.atlassian.net/browse/OSF-6646 is done

--- a/addon/serializers/comment.js
+++ b/addon/serializers/comment.js
@@ -7,15 +7,21 @@ export default OsfSerializer.extend({
 
         let adapterOptions = snapshot.adapterOptions;
         if (adapterOptions.operation === 'create') {
+            let targetType = adapterOptions.targetType;
             // New comments must explicitly identify their target, passed here via fields on .save({adapterOptions: {...}})
             Ember.assert('Must provide target ID', adapterOptions.targetID);
-            Ember.assert('Must provide target type', adapterOptions.targetType);
+            Ember.assert('Must provide target type', targetType);
+
+            // Preprint comments are made through the node
+            if (targetType === 'preprint') {
+                targetType = 'node';
+            }
 
             res.data.relationships = {
                 target: {
                     data: {
                         id: adapterOptions.targetID,
-                        type: adapterOptions.targetType
+                        type: Ember.Inflector.inflector.pluralize(targetType)
                     }}};
         }
         return res;

--- a/addon/serializers/comment.js
+++ b/addon/serializers/comment.js
@@ -2,26 +2,24 @@ import Ember from 'ember';
 import OsfSerializer from './osf-serializer';
 
 export default OsfSerializer.extend({
-    serializeIntoHash(hash, typeClass, snapshot, options) {  // jshint ignore:line
-        if (options.forRelationship) {
+    serialize(snapshot, options) {  // jshint ignore:line
+        let res = this._super(...arguments);
+        if (Ember.get(snapshot, 'adapterOptions.forRelationship')) {  // TODO: Next iteration: would be nice for createRelated to pass fields directly, to avoid placeholder fields.
             // New comments must identify their target as part of a relationship field
-            // TODO: pop off record when done so these dummy fields don't persist? Do they matter?
-            // TODO: This breaks commenting atm
             let targetID = snapshot.record.get('targetID');
             let targetType = snapshot.record.get('targetType');
             Ember.assert('Must provide target ID', targetID);
             Ember.assert('Must provide target type', targetType);
-
-            hash.data.relationships = {
+            res.data.relationships = {
                 target: {
                     data: {
                         id: targetID,
                         type: targetType
                     }
                 }
-            }
+            };
         }
-        return this._super(hash, typeClass, snapshot, options);
+        return res;
     },
     extractRelationships(modelClass, resourceHash) {
         // TODO: remove when https://openscience.atlassian.net/browse/OSF-6646 is done

--- a/addon/serializers/comment.js
+++ b/addon/serializers/comment.js
@@ -26,10 +26,4 @@ export default OsfSerializer.extend({
         }
         return res;
     },
-    extractRelationships(modelClass, resourceHash) {
-        // TODO: remove when https://openscience.atlassian.net/browse/OSF-6646 is done
-        resourceHash = this._super(modelClass, resourceHash);
-        resourceHash.replies.links.related = Ember.copy(resourceHash.replies.links.self);
-        return resourceHash;
-    }
 });

--- a/addon/serializers/comment.js
+++ b/addon/serializers/comment.js
@@ -6,7 +6,7 @@ export default OsfSerializer.extend({
         let res = this._super(...arguments);
 
         let adapterOptions = snapshot.adapterOptions;
-        if (adapterOptions.operation === 'create') {
+        if (adapterOptions && adapterOptions.operation === 'create') {
             let targetType = adapterOptions.targetType;
             // New comments must explicitly identify their target, passed here via fields on .save({adapterOptions: {...}})
             Ember.assert('Must provide target ID', adapterOptions.targetID);

--- a/addon/serializers/comment.js
+++ b/addon/serializers/comment.js
@@ -4,20 +4,19 @@ import OsfSerializer from './osf-serializer';
 export default OsfSerializer.extend({
     serialize(snapshot, options) {  // jshint ignore:line
         let res = this._super(...arguments);
-        if (Ember.get(snapshot, 'adapterOptions.forRelationship')) {  // TODO: Next iteration: would be nice for createRelated to pass fields directly, to avoid placeholder fields.
-            // New comments must identify their target as part of a relationship field
-            let targetID = snapshot.record.get('targetID');
-            let targetType = snapshot.record.get('targetType');
-            Ember.assert('Must provide target ID', targetID);
-            Ember.assert('Must provide target type', targetType);
+
+        let adapterOptions = snapshot.adapterOptions;
+        if (adapterOptions.operation === 'create') {
+            // New comments must explicitly identify their target, passed here via fields on .save({adapterOptions: {...}})
+            Ember.assert('Must provide target ID', adapterOptions.targetID);
+            Ember.assert('Must provide target type', adapterOptions.targetType);
+
             res.data.relationships = {
                 target: {
                     data: {
-                        id: targetID,
-                        type: targetType
-                    }
-                }
-            };
+                        id: adapterOptions.targetID,
+                        type: adapterOptions.targetType
+                    }}};
         }
         return res;
     },

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,3 +1,4 @@
+@import 'components/comment-pane/style';
 @import 'components/file-browser/style';
 @import 'components/file-widget/style';
 @import 'components/osf-navbar/style';

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-cli-template-lint": "0.4.7",
     "ember-cli-uglify": "^1.2.0",
     "ember-collection": "1.0.0-alpha.5",
+    "ember-cp-validations": "3.0.0-beta.2",
     "ember-data": "^2.3.0",
     "ember-data-factory-guy": "^2.6.1",
     "ember-disable-prototype-extensions": "^1.0.0",

--- a/tests/dummy/app/controllers/nodes/detail/comments.js
+++ b/tests/dummy/app/controllers/nodes/detail/comments.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+import CommentableMixin from 'ember-osf/mixins/commentable';
+
+export default Ember.Controller.extend(CommentableMixin, {
+});

--- a/tests/dummy/app/controllers/nodes/detail/index.js
+++ b/tests/dummy/app/controllers/nodes/detail/index.js
@@ -1,9 +1,8 @@
 import Ember from 'ember';
-import CommentableMixin from 'ember-osf/mixins/commentable';
 import TaggableMixin from 'ember-osf/mixins/taggable-mixin';
 import NodeActionsMixin from 'ember-osf/mixins/node-actions';
 
-export default Ember.Controller.extend(CommentableMixin, TaggableMixin, NodeActionsMixin, {
+export default Ember.Controller.extend(TaggableMixin, NodeActionsMixin, {
     toast: Ember.inject.service(),
     propertiesVisible: false,
     isSaving: false,

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -33,6 +33,7 @@ Router.map(function() {
                     path: '/:draft_registration_id'
                 });
             });
+            this.route('comments');
         });
     });
     this.route('signup');

--- a/tests/dummy/app/routes/nodes/detail/comments.js
+++ b/tests/dummy/app/routes/nodes/detail/comments.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+    model() {
+        return this.modelFor('nodes.detail');
+    }
+});

--- a/tests/dummy/app/templates/nodes/detail/comments.hbs
+++ b/tests/dummy/app/templates/nodes/detail/comments.hbs
@@ -1,0 +1,10 @@
+<h3>Comments for {{model.title}}</h3>
+
+{{comment-pane
+comments=comments
+resource=model
+addComment=(action 'addComment')
+editComment=(action 'editComment')
+deleteComment=(action 'deleteComment')
+restoreComment=(action 'restoreComment')
+reportComment=(action 'reportComment')}}

--- a/tests/dummy/app/templates/nodes/detail/comments.hbs
+++ b/tests/dummy/app/templates/nodes/detail/comments.hbs
@@ -1,10 +1,9 @@
-<h3>Comments for {{model.title}}</h3>
-
 {{comment-pane
-comments=comments
-resource=model
-addComment=(action 'addComment')
-editComment=(action 'editComment')
-deleteComment=(action 'deleteComment')
-restoreComment=(action 'restoreComment')
-reportComment=(action 'reportComment')}}
+  comments=comments
+  title=model.title
+  resource=model
+  addComment=(action 'addComment')
+  editComment=(action 'editComment')
+  deleteComment=(action 'deleteComment')
+  restoreComment=(action 'restoreComment')
+  reportComment=(action 'reportComment')}}

--- a/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
+++ b/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
@@ -61,6 +61,7 @@
 <div class="row">
     {{comment-pane
     comments=comments
+    resource=model
     addComment=(action 'addComment')
     editComment=(action 'editComment')
     deleteComment=(action 'deleteComment')

--- a/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
+++ b/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
@@ -60,11 +60,12 @@
 
 <div class="row">
     {{comment-pane
-    comments=comments
-    resource=model
-    addComment=(action 'addComment')
-    editComment=(action 'editComment')
-    deleteComment=(action 'deleteComment')
-    restoreComment=(action 'restoreComment')
-    reportComment=(action 'reportComment')}}
+      comments=comments
+      title=model.name
+      resource=model
+      addComment=(action 'addComment')
+      editComment=(action 'editComment')
+      deleteComment=(action 'deleteComment')
+      restoreComment=(action 'restoreComment')
+      reportComment=(action 'reportComment')}}
 </div>

--- a/tests/dummy/app/templates/nodes/detail/index.hbs
+++ b/tests/dummy/app/templates/nodes/detail/index.hbs
@@ -135,15 +135,6 @@
     <label> Target node id </label> {{input value=targetNodeId}}
     <button {{action "addNodeLink" targetNodeId}} class="btn btn-primary">Add</button>
 
-    {{comment-pane
-    comments=comments
-    resource=model
-    addComment=(action 'addComment')
-    editComment=(action 'editComment')
-    deleteComment=(action 'deleteComment')
-    restoreComment=(action 'restoreComment')
-    reportComment=(action 'reportComment')}}
-
 </div>
 
 {{outlet}}

--- a/tests/dummy/app/templates/nodes/detail/index.hbs
+++ b/tests/dummy/app/templates/nodes/detail/index.hbs
@@ -137,6 +137,7 @@
 
     {{comment-pane
     comments=comments
+    resource=model
     addComment=(action 'addComment')
     editComment=(action 'editComment')
     deleteComment=(action 'deleteComment')


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-100
# Purpose

Bring comment form to parity with OSF widgets.

This is intended to look and work like existing OSF widgets, to minimize the disruption of moving between pages during an incremental migration.
## Status

On hold, as we shifted priorities to implementing different pages. Keeping PR open to track work and blockers.
### Short-term deliverables:
- Styling
- Button and error functionality
- Validation
- Threading support
### Future improvements needed for parity
- Support viewing anonymous projects (don't represent author information in the comment display field)
- Render markdown in comment fields
- Support `@mention` functionality
- Comment reporting
## Long-term improvements
- Improve markup accessibility (eg icons need [titles](http://fontawesome.io/accessibility/))
## TODO

Core UI and features
- Threads
  - [x] Support UI
  - [x] Support threads for replies
- [ ] Loading state indicators 
- Generalize comment-form
  - [x] offer add and edit modes
  - [x] Support validation
- @mentions and markdown rendering

Additional features 
- Pagination behavior parity
  - [ ] fetch-more only when user has read through results on page, eg ember-infinity)
  - [ ] Do not limit comments page (or replies) to 10 comments only
- [ ] Display unread reply counts (in navbar "open comments pane" button). See [OSF-4656](https://openscience.atlassian.net/browse/OSF-4656) for docs on required API query param.
- [ ] Add error handling for many scenarios. Pages are built on assumption everything succeeds.

Adapter requirements
- Make requests using the following query params
  - [ ] embed=user
  - [ ] `filter[target]=<cid>` (built into rel url already, make sure it's respected)
  - [ ] `page[size]=30`
## Known issues
- [x] Creating a comment, then deleting it, leads to 409 errors. This is because the client-only dummy fields (targetID and targetType) are still there in the local store, and therefore are still getting serialized.
- [ ] The comment form should not clear if `submitComment` fails. (don't provisionally render the comment!)
- Replies
  - [ ] Sometimes replying sends a server request. This is tied to an adapter issue where multiple sequential operations do not always trigger an operation immediately. (eg the first attempt to reply may fail, but the second attempt to reply may cause both replies to be sent)
  - [ ] Gravatar doesn't show for newly created replies, sans reload.
# Notes for Reviewers

To be written
## Routes Added/Updated

See sample comment widgets on node detail page, eg
http://localhost:4200/nodes/m9pv6
