### PR TITLE
[hold] Convert `tags-widget` to ember

### DIFF
--- a/addon/components/tags-widget/component.js
+++ b/addon/components/tags-widget/component.js
@@ -9,62 +9,83 @@ import layout from './template';
 /**
  * Allow the user to view and manage tags.
  * See TaggableMixin for controller actions that can be used with this component.
- *
- * For more information on configuration options, see documentation for [jquery-tags-input](https://github.com/xoxco/jQuery-Tags-Input).
+ * Pattern is a regular expression to validate input against.
  *
  * ```handlebars
  * {{tags-widget
- *   addATag=(action 'addATag')
- *   removeATag=(action 'removeATag')
- *   tags=model.tags}}
+ *   addTag=(action 'addTag')
+ *   removeTag=(action 'removeTag')
+ *   tags=model.tags
+ *   pattern='^[\\w-]+$'}}
  * ```
  * @class tags-widget
  * @extends Ember.Component
  */
 export default Ember.Component.extend({
     layout,
-
-    /**
-     * Whether the user is allowed to edit tags.
-     * @property canEdit
-     * @type {Boolean}
-     */
-    canEdit: true,  // TODO: Implement editing decision logic in the future
+    classNameBindings: ['invalid:has-error'],
+    pattern: /^.{1,128}$/,
     tags: [],
-
-    tagName: 'input',
-    type: 'text',
-    attributeBindings: ['name', 'type', 'value', 'id'],
-
-    _initialize: Ember.on('didInsertElement', function () {
-        Ember.run.scheduleOnce('afterRender', this, function() {
-            this.$().tagsInput({
-                width: '100%',
-                interactive: this.get('canEdit'),
-                maxChars: 128,
-                onAddTag: (tag) => {
-                    this.send('addATag', tag);
-                },
-                onRemoveTag: (tag) => {
-                    this.send('removeATag', tag);
+    value: '',
+    didReceiveAttrs() {
+        this._super(...arguments);
+        // Initialize attributes
+        const tags = this.get('tags');
+        const pattern = this.get('pattern');
+        if (!Ember.isArray(tags)) {
+            this.set('tags', tags ? [tags] : []);
+        }
+        if (typeof pattern === 'string') {
+            this.set('pattern', new RegExp(pattern));
+        }
+    },
+    keyDown(evt) {
+        const value = this.get('value');
+        switch (evt.keyCode) {
+            case 13: // Enter
+                // Add tag to list after validating
+                const text = Ember.$.trim(value).replace(/\s{2,}/g, ' ');
+                if (text && this.get('pattern').test(text) && !this.get('tags').find(tag => tag === text)) {
+                    this.send('addTag', text);
                 }
-            });
-            // Populate the widget with the default tags passed in
-            let tags = this.get('tags');
-            this.$().importTags(tags.join(', '));
-        });
-    }),
-
+                break;
+            case 8: // Backspace
+                // Pop last tag back into input
+                if (!value && this.get('tags').length) {
+                    const tag = this.get('tags').popObject();
+                    this.set('value', `${tag} `);
+                    this.sendAction('removeTag', tag);
+                }
+                break;
+        }
+    },
+    keyUp() {
+        // Manual form validation
+        const text = Ember.$.trim(this.get('value')).replace(/\s{2,}/g, ' ');
+        this.set('invalid', text && !this.get('pattern').test(text));
+    },
+    click() {
+        this.set('focused', true);
+        this.$('input').focus();
+    },
+    // Bubbles from input
+    focusOut() {
+        this.set('focused', false);
+    },
+    // Bubbles from input, handles alternate methods of focusing on input
+    focusIn() {
+        this.set('focused', true);
+    },
     actions: {
-        addATag(tag) {
-            this.attrs.addATag(tag);
+        addTag(tag) {
+            this.get('tags').pushObject(tag);
+            this.set('value', '');
+            this.sendAction('addTag', tag);
         },
-        removeATag(tag) {
-            // Don't try to delete a blank tag (would result in a server error)
-            if (!tag) {
-                return false;
-            }
-            this.sendAction('removeATag', tag);
+        removeAt(index) {
+            const tag = this.get('tags').objectAt(index);
+            this.get('tags').removeAt(index);
+            this.sendAction('removeTag', tag);
         }
     }
 });

--- a/addon/components/tags-widget/component.js
+++ b/addon/components/tags-widget/component.js
@@ -25,16 +25,17 @@ export default Ember.Component.extend({
     layout,
     classNameBindings: ['invalid:has-error'],
     pattern: /^.{1,128}$/,
-    tags: [],
+    tags: Ember.A(),
     value: '',
     didReceiveAttrs() {
         this._super(...arguments);
         // Initialize attributes
-        const tags = this.get('tags');
+        let tags = this.get('tags');
         const pattern = this.get('pattern');
         if (!Ember.isArray(tags)) {
-            this.set('tags', tags ? [tags] : []);
+            tags = tags ? [tags] : [];
         }
+        this.set('tags', Ember.A(tags));
         if (typeof pattern === 'string') {
             this.set('pattern', new RegExp(pattern));
         }

--- a/addon/components/tags-widget/style.scss
+++ b/addon/components/tags-widget/style.scss
@@ -1,119 +1,70 @@
-// TODO: Styles lifted from OSF style.css. It is possible that some of these styles are deprecated and no longer necessary.
+// TODO: Some styling duplicated from bootstrap
 // TODO: Namespace these for the component
+$input-border-focus: #66afe9;
 
-.tag:hover
-{
-    background-color: #337ab7;
-    color: #E0EBF3;
-}
-.tag:hover > .tag-text, .tag:hover > a
-{
-    color: #E0EBF3;
-}
-.tag:hover > .remove-tag
-{
-    visibility: visible;
-/* to make the center of the x not transparent */
-    background: -moz-radial-gradient(center, ellipse cover,  rgba(255,255,255,1) 35%, rgba(255,255,255,1) 44%, rgba(255,255,255,1) 53%, rgba(255,255,255,0) 64%, rgba(255,255,255,0) 72%); /* FF3.6+ */
-    background: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop(35%,rgba(255,255,255,1)), color-stop(44%,rgba(255,255,255,1)), color-stop(53%,rgba(255,255,255,1)), color-stop(64%,rgba(255,255,255,0)), color-stop(72%,rgba(255,255,255,0))); /* Chrome,Safari4+ */
-    background: -webkit-radial-gradient(center, ellipse cover,  rgba(255,255,255,1) 35%,rgba(255,255,255,1) 44%,rgba(255,255,255,1) 53%,rgba(255,255,255,0) 64%,rgba(255,255,255,0) 72%); /* Chrome10+,Safari5.1+ */
-    background: -o-radial-gradient(center, ellipse cover,  rgba(255,255,255,1) 35%,rgba(255,255,255,1) 44%,rgba(255,255,255,1) 53%,rgba(255,255,255,0) 64%,rgba(255,255,255,0) 72%); /* Opera 12+ */
-    background: -ms-radial-gradient(center, ellipse cover,  rgba(255,255,255,1) 35%,rgba(255,255,255,1) 44%,rgba(255,255,255,1) 53%,rgba(255,255,255,0) 64%,rgba(255,255,255,0) 72%); /* IE10+ */
-    background: radial-gradient(ellipse at center,  rgba(255,255,255,1) 35%,rgba(255,255,255,1) 44%,rgba(255,255,255,1) 53%,rgba(255,255,255,0) 64%,rgba(255,255,255,0) 72%); /* W3C */
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#00ffffff',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
-}
-.tag-big
-{
-    font-size: 13pt;
-}
 
-.tag-med
-{
-    font-size: 11pt;
-}
-.tag-container
-{
-    position: relative;
-}
-
-.remove-tag
-{
-    visibility: hidden;
-    position: absolute;
-    top: -5px;
-    right: -5px;
-    color: #AAAAAA;
-}
-
-.remove-tag.big
-{
-    top: -8px;
-    right: -8px;
-}
-
-.remove-tag.med
-{
-    top: -6px;
-    right: -6px;
-}
-
-.tagsinput {
-    border:1px solid #CCC;
-    float: left;
-    padding: 5px;
-    background: #FFF;
-    padding:5px;
-    width:300px;
-    height:100px;
-    overflow-y: auto;
-}
-#node-tags_tag:focus {
-    outline: 2px solid #DEF;
-}
-
-.tagsinput div {
-    float: left;
-}
-
-.tagsinput span.tag {
-    float: left;
-    padding: 5px;
-}
-
-.tagsinput input {
-    width:80px;
-    margin:0px;
-    font-family: helvetica;
-    font-size: 13px;
-    border:1px solid transparent;
-    padding:5px;
-    margin-right:5px;
-    margin-bottom:5px;
-}
-
-.tag a {
-    font-weight: bold;
-    color: #000;
-    text-decoration:none;
-    font-size: 11px;
-    vertical-align: top;
-}
-
-.tag {
-    text-decoration:none;
-    display: inline-block;
-    background: #DEF;
-    margin-right: 5px;
-    margin-bottom:5px;
-    font-size:13px;
-    padding:5px;
-    border:1px solid transparent;
-    border-radius: 2px;
-    cursor: pointer;
-}
-
-/* Override insane add tag font
--------------------------------------------------- */
-.tagsinput input {
-    font-family : 'Open Sans', Helvetica, sans-serif;
+.tags-widget.form-control {
+    height: auto;
+    padding: 0.5rem 0.5rem 0;
+    cursor: text;
+    // Duplicated from bootstrap
+    &.focus {
+        border-color: $input-border-focus;
+        outline: 0;
+        box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px transparentize($input-border-focus, .6);
+    }
+    & > .tag {
+        display: inline-block;
+        padding: 0 1rem;
+        margin: 0 0.5rem 0.5rem 0;
+        color: black;
+        background-color: #DEF;
+        border-radius: 2px;
+        cursor: default;
+        transition: {
+            property: background-color, color;
+            duration: 0.1s;
+            timing-function: linear;
+        }
+        & > b {
+            display: inline-block;
+            cursor: pointer;
+            margin-left: 1rem;
+            &:active {
+                color: lighten(red, 30%);
+            }
+        }
+        &:hover {
+            color: white;
+            background-color: #337ab7;
+        }
+    }
+    & > label {
+        position: relative;
+        display: inline-block;
+        max-width: 100%;
+        margin-bottom: 0.5rem;
+        font-weight: normal;
+        visibility: hidden;
+        overflow: hidden;
+        white-space: pre;
+        &:before {
+            content: "";
+            visibility: visible;
+            padding-right: 0.5rem;
+        }
+        & > input {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            padding: 0;
+            border: none;
+            visibility: visible;
+            &:focus {
+                outline: none;
+            }
+        }
+    }
 }

--- a/addon/components/tags-widget/template.hbs
+++ b/addon/components/tags-widget/template.hbs
@@ -1,0 +1,7 @@
+<div class="tags-widget form-control {{if focused 'focus'}}">
+    {{#each tags as |tag index|}}
+        <span class="tag">{{tag}}<b {{action "removeAt" index}} title="Remove tag">x</b></span>
+    {{/each}}
+    {{! Expanding input }}
+    <label>{{value}}{{input value=value type=type name=name placeholder=placeholder}}</label>
+</div>

--- a/addon/mixins/taggable-mixin.js
+++ b/addon/mixins/taggable-mixin.js
@@ -17,10 +17,10 @@ export default Ember.Mixin.create({
          * list of tags, appends new tag to copy, and then sets tags on the resource
          * as the modified copy.
          *
-         * @method addATag
+         * @method addTag
          * @param {String} tag New tag to be added to list.
          */
-        addATag(tag) {
+        addTag(tag) {
             var resource = this.get('model');
             var currentTags = resource.get('tags').slice(0);
             Ember.A(currentTags);
@@ -31,10 +31,10 @@ export default Ember.Mixin.create({
         /**
          * Removes a tag from the current array of tags on the resource.
          *
-         * @method removeATag
+         * @method removeTag
          * @param {String} tag Tag to be removed from list.
          */
-        removeATag(tag) {
+        removeTag(tag) {
             var resource = this.get('model');
             var currentTags = resource.get('tags').slice(0);
             currentTags.splice(currentTags.indexOf(tag), 1);

--- a/bower.json
+++ b/bower.json
@@ -12,9 +12,7 @@
     "jquery-mockjax": "2.1.1",
     "dropzone": "~4.3.0",
     "toastr": "^2.1.2",
-    "font-awesome": "~4.5.0",
-    "typeahead.js": "^0.11.1",
-    "jquery.tagsinput": "^1.3.6"
+    "font-awesome": "~4.5.0"
   },
   "devDependencies": {
     "bootstrap": "~3.3.5",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -31,8 +31,6 @@ module.exports = function(defaults) {
     app.import(path.join(app.bowerDirectory, 'dropzone/dist/dropzone.css'));
     app.import(path.join(app.bowerDirectory, 'dropzone/dist/dropzone.js'));
 
-    app.import(path.join(app.bowerDirectory, 'jquery.tagsinput/src/jquery.tagsinput.js'));
-
     app.import(path.join(app.bowerDirectory, 'osf-style/css/base.css'));
     app.import('vendor/assets/ember-osf.css');
     return app.toTree();

--- a/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
+++ b/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
@@ -50,7 +50,7 @@
         }}
         <div>
             <p><label> Tags </label></p>
-            {{tags-widget addATag=(action 'addATag') removeATag=(action 'removeATag') tags=model.tags}}
+            {{tags-widget addTag=(action 'addTag') removeTag=(action 'removeTag') tags=model.tags}}
         </div>
     </div>
     <div class='col-md-9'>

--- a/tests/dummy/app/templates/nodes/detail/index.hbs
+++ b/tests/dummy/app/templates/nodes/detail/index.hbs
@@ -13,7 +13,7 @@
     <p><label>Date Modified:</label> {{moment-format model.dateModified}}</p>
     <p><label>Public </label> {{model.public}} </p>
     <p><label> Tags </label></p>
-    {{tags-widget addATag=(action 'addATag') removeATag=(action 'removeATag') tags=model.tags}}
+    {{tags-widget addTag=(action 'addTag') removeTag=(action 'removeTag') tags=model.tags}}
     <hr>
     <p>
         <a href="{{model.links.html}}" target="_blank" class="btn btn-primary">

--- a/tests/integration/components/tags-widget/component-test.js
+++ b/tests/integration/components/tags-widget/component-test.js
@@ -11,5 +11,6 @@ test('it renders a tag', function(assert) {
     this.set('tags', ['hello']);
 
     this.render(hbs`{{tags-widget tags=tags}}`);
-    assert.ok(this.$('input[type="text"]').tagExist('hello'));
+    // Check text node against tag text
+    assert.ok(this.$('span.tag').contents().filter((ignore, el) => el.nodeType === 3)[0].nodeValue === 'hello');
 });

--- a/tests/unit/controllers/file-test.js
+++ b/tests/unit/controllers/file-test.js
@@ -23,7 +23,7 @@ test('add a file tag', function(assert) {
     ctrl.set('model', model);
     ctrl.set('model.save', function() {return;});
     Ember.run(function() {
-        ctrl.send('addATag', 'new tag');
+        ctrl.send('addTag', 'new tag');
     });
     assert.deepEqual(ctrl.model.get('tags'), ['one', 'new tag']);
 });
@@ -33,6 +33,6 @@ test('remove a file tag', function(assert) {
     let model = FactoryGuy.make('file', {tags: ['one', 'two']});
     ctrl.set('model', model);
     ctrl.set('model.save', function() {return;});
-    Ember.run(function() {ctrl.send('removeATag', 'one');});
+    Ember.run(function() {ctrl.send('removeTag', 'one');});
     assert.deepEqual(ctrl.model.get('tags'), ['two']);
 });

--- a/tests/unit/controllers/node-test.js
+++ b/tests/unit/controllers/node-test.js
@@ -23,7 +23,7 @@ test('add a node tag', function(assert) {
     ctrl.set('model', model);
     ctrl.set('model.save', function() {return;});
     Ember.run(function() {
-        ctrl.send('addATag', 'new tag');
+        ctrl.send('addTag', 'new tag');
     });
     assert.deepEqual(ctrl.model.get('tags'), ['one', 'new tag']);
 });
@@ -34,7 +34,7 @@ test('remove a node tag', function(assert) {
     ctrl.set('model', model);
     ctrl.set('model.save', function() {return;});
     Ember.run(function() {
-        ctrl.send('removeATag', 'one');
+        ctrl.send('removeTag', 'one');
     });
     assert.deepEqual(ctrl.model.get('tags'), ['two']);
 });


### PR DESCRIPTION
## Ticket

N/A
# Purpose

`tags-widget` was previously implemented through a jquery plugin, which did not take advantage of Ember's built-in data binding and was far less extensible. This new implementation also has a few features:
- Populates input with deleted tag text for quick editing
- Supports validation via `pattern` regex
- (True) Auto-expanding `input`

This also removes two dependencies, `jquery.tagsInput` and `typeahead.js`, the latter of which was unused.

<img width="466" alt="screen shot 2016-07-21 at 10 44 19 am" src="https://cloud.githubusercontent.com/assets/5885378/17027010/28787ca8-4f30-11e6-9a87-d2fc378cb7d4.png">
# Notes for Reviewers
- `/^.{1,128}$/` seems to be the default validation from osf.io
- Styling repeats some from bootstrap because it is not explicitly imported
- Does not support typeahead, but I do not think it was implemented in the previous version
- Didn't implement `canEdit` functionality, if needed I can do that
## Routes Added/Updated

None
