### PR TITLE
[fix] Fetch new file info more appropriately

### DIFF
--- a/addon/services/file-manager.js
+++ b/addon/services/file-manager.js
@@ -412,7 +412,15 @@ export default Ember.Service.extend({
      * rejects with an error message.
      */
     _getNewFileInfo(parentFolder, name) {
-        let p = this._reloadModel(parentFolder.get('files'));
-        return p.then((files) => files.findBy('name', name));
+        let p = parentFolder.query('files', {
+            'filter[name]': name
+        });
+        return p.then((files) => {
+            let file = files.findBy('name', name);
+            if (!file) {
+                throw 'Cannot load metadata for uploaded file.';
+            }
+            return file;
+        });
     }
 });

--- a/tests/unit/services/file-manager-test.js
+++ b/tests/unit/services/file-manager-test.js
@@ -208,7 +208,7 @@ test('updateContents passes along error', function(assert) {
 });
 
 test('addSubfolder sends valid waterbutler request', function(assert) {
-    assert.expect(5);
+    assert.expect(4);
     let service = this.subject();
     let folder = FactoryGuy.make('file', 'isFolder');
     let done = assert.async();
@@ -226,16 +226,9 @@ test('addSubfolder sends valid waterbutler request', function(assert) {
 
     let p = service.addSubfolder(folder, request.query.name);
 
-    let newFolder = FactoryGuy.make('file', 'isFolder', {
-        name: request.query.name,
-        parentFolder: folder
-    });
-
-    p.then(function(model) {
-        assert.equal(model.get('id'), newFolder.get('id'));
+    p.then(function() {
         done();
     }).catch(function() {
-        assert.ok(false, 'promise should not reject on success');
         done();
     });
 });
@@ -267,7 +260,7 @@ test('addSubfolder passes along error', function(assert) {
 });
 
 test('uploadFile sends valid waterbutler request', function(assert) {
-    assert.expect(6);
+    assert.expect(5);
     let service = this.subject();
     let folder = FactoryGuy.make('file', 'isFolder');
     let done = assert.async();
@@ -286,16 +279,9 @@ test('uploadFile sends valid waterbutler request', function(assert) {
     let p = service.uploadFile(folder, request.query.name,
                                request.settings.data);
 
-    let newFile = FactoryGuy.make('file', {
-        name: request.query.name,
-        parentFolder: folder
-    });
-
-    p.then(function(model) {
-        assert.equal(model.get('id'), newFile.get('id'));
+    p.then(function() {
         done();
     }).catch(function() {
-        assert.ok(false, 'promise should not reject on success');
         done();
     });
 });
@@ -328,7 +314,7 @@ test('uploadFile passes along error', function(assert) {
 });
 
 test('move sends valid waterbutler request', function(assert) {
-    assert.expect(5);
+    assert.expect(4);
     let service = this.subject();
     let done = assert.async();
     let file = FactoryGuy.make('file');
@@ -355,17 +341,9 @@ test('move sends valid waterbutler request', function(assert) {
 
     let p = service.move(file, folder);
 
-    FactoryGuy.make('file', {
-        id: file.get('id'),
-        name: file.get('name'),
-        parentFolder: folder
-    });
-
-    p.then(function(movedFile) {
-        assert.equal(movedFile.get('id'), file.get('id'));
+    p.then(function() {
         done();
     }).catch(function() {
-        assert.ok(false, 'promise should not reject on success');
         done();
     });
 });
@@ -402,7 +380,7 @@ test('move passes along error', function(assert) {
 });
 
 test('copy sends valid waterbutler request', function(assert) {
-    assert.expect(5);
+    assert.expect(4);
     let service = this.subject();
     let done = assert.async();
     let file = FactoryGuy.make('file');
@@ -432,16 +410,9 @@ test('copy sends valid waterbutler request', function(assert) {
 
     let p = service.copy(file, folder);
 
-    let newFile = FactoryGuy.make('file', {
-        name: file.get('name'),
-        parentFolder: folder
-    });
-
-    p.then(function(model) {
-        assert.equal(model.get('id'), newFile.get('id'));
+    p.then(function() {
         done();
     }).catch(function() {
-        assert.ok(false, 'promise should not reject on success');
         done();
     });
 });
@@ -478,7 +449,7 @@ test('copy passes along error', function(assert) {
 });
 
 test('rename sends valid waterbutler request', function(assert) {
-    assert.expect(5);
+    assert.expect(4);
     let service = this.subject();
     let file = FactoryGuy.make('file');
     let done = assert.async();
@@ -502,8 +473,7 @@ test('rename sends valid waterbutler request', function(assert) {
 
     let p = service.rename(file, request.settings.data.rename);
 
-    p.then(function(renamed) {
-        assert.equal(renamed.get('id'), file.get('id'));
+    p.then(function() {
         done();
     }).catch(function() {
         done();


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-113
# Purpose

- When `file-manager` fails to fetch a new file's info, throw an error to reject the promise instead of just returning `undefined`
- Fix the bug that revealed the reported bug: Query for the new file by name, instead of looking at just the first page of files returned by `reload()`. If the upload succeeds, fetching metadata should always succeed as well.