### PR TITLE
Bump i18n dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ember-cli-node-assets": "^0.1.3",
     "ember-data-has-many-query": "0.1.4",
     "ember-get-config": "0.0.2",
-    "ember-i18n": "4.2.1",
+    "ember-i18n": "4.2.2",
     "ember-moment": "6.1.0",
     "ember-radio-buttons": "^4.0.1",
     "ember-simple-auth": "1.1.0-beta.5",


### PR DESCRIPTION
## Ticket
None

# Purpose
This fixes an issue that broke addon-consuming apps that used ember 2.7. (ember internals were reorganized. See ember-i18n/issues/385

# Notes for Reviewers
No side effects. We may get some template lint warnings with new ember versions, telling us that we haven't translated text. We'll ignore those for now.

## Routes Added/Updated
None. Dummy app still appears to work.



