### PR TITLE
Fix error where cookie auth beforeModel hook failed

### DIFF
--- a/addon/authenticators/osf-cookie.js
+++ b/addon/authenticators/osf-cookie.js
@@ -1,3 +1,5 @@
+import Ember from 'ember';
+
 import Base from 'ember-simple-auth/authenticators/base';
 import config from 'ember-get-config';
 
@@ -49,6 +51,11 @@ export default Base.extend({
      * @return {Promise}
      */
     authenticate(code) {
-        return this._test(code);
+        let jqDeferred = this._test(code);
+        return new Ember.RSVP.Promise((resolve, reject) => {
+            // TODO: Improve param capture
+            jqDeferred.done((value) => resolve(value));
+            jqDeferred.fail((reason) => reject(reason));
+        });
     }
 });

--- a/addon/components/oauth-popup/template.hbs
+++ b/addon/components/oauth-popup/template.hbs
@@ -1,5 +1,5 @@
-{{#if (not hasBlock) }}
-    <button {{action 'login'}} class="btn btn-warning"> Login </button>
-{{else}}
+{{#if hasBlock }}
     {{yield this}}
+{{else}}
+    <button {{action 'login'}} class="btn btn-warning"> Login </button>
 {{/if}}

--- a/addon/components/osf-navbar/template.hbs
+++ b/addon/components/osf-navbar/template.hbs
@@ -81,15 +81,22 @@
                                 </div>
                             </li>
                         {{else}}
-                            {{#oauth-popup authUrl=authUrl loginSuccess=(action 'loginSuccess') loginFail=(action 'loginFail') as |popup|}}
-                                <li class="dropdown sign-in">
-                                    <div class="col-sm-12">
-                                        <button class="btn btn-success btn-top-signup m-r-xs" onclick={{action 'login' target=popup}} >
-                                            Login
-                                        </button>
-                                    </div>
-                                </li>
-                            {{/oauth-popup}}
+                            {{!-- Very ugly hack until we can refactor navbar to support pluggable auth types: Navbar users can override the login button (for consuming apps based on cookie or other auth) --}}
+                            {{!-- The cookie/token login mixins should eventually control the default login functionality and then we can pass in when using component in application template --}}
+                            {{#if hasBlock}}
+                                {{yield this}}
+                            {{else}}
+                                {{#oauth-popup authUrl=authUrl loginSuccess=(action 'loginSuccess') loginFail=(action 'loginFail') as |popup|}}
+                                    <li class="dropdown sign-in">
+                                        <div class="col-sm-12">
+                                            <button class="btn btn-success btn-top-signup m-r-xs" onclick={{action 'login' target=popup}} >
+                                                Login
+                                            </button>
+                                        </div>
+                                    </li>
+                                {{/oauth-popup}}
+                            {{/if}}
+
                             {{!--
                             <li class="dropdown sign-in" data-bind="with: $root.signIn">
                                 <div class="col-sm-12">

--- a/addon/mixins/osf-cookie-login-route.js
+++ b/addon/mixins/osf-cookie-login-route.js
@@ -20,6 +20,8 @@ export default Ember.Mixin.create(UnauthenticatedRouteMixin, {
     beforeModel() {
         // Determine whether the user is logged in by making a test request. This is quite a crude way of
         // determining whether the user has a cookie and should be improved in the future.
-        return this.get('session').authenticate('authenticator:osf-cookie');
+
+        // Block transition until auth attempt resolves. If auth fails, let the page load normally.
+        return this.get('session').authenticate('authenticator:osf-cookie').catch(err => console.log('Authentication failed: ', err));
     }
 });


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/PREP-87

# Purpose
Fix issue where (using cookie auth) the index page failed to load because the user was logged out.

When user was not logged in, beforeModel hook returned a rejected promise and failed. Catch that error and do nothing, so hook can pass through. (this just gets credentials if possible; it doesn't impose a hard requirement that the user be logged in)

BeforeModel hook (and ember simple auth) expect an ember promise, but receives a jquery object with slightly different semantics. Massage the promise type so things work correctly.

# Notes for Reviewers

## Routes Added/Updated
Anything using cookie auth: application route, eg in osf-ember and preprints app.