### PR TITLE
[WIP] Feature/Return Contributor Save instead of Node Save [EOSF-141]

### DIFF
--- a/addon/mixins/node-actions.js
+++ b/addon/mixins/node-actions.js
@@ -113,8 +113,8 @@ export default Ember.Mixin.create({
          *
          * @method addContributor
          * @param {String} userId ID of user that will be a contributor on the node
-         * @param {String} permission User permission level. One of "read", "write", or "admin". Default: "write".
-         * @param {Boolean} isBibliographic Whether user will be included in citations for the node. "default: true"
+         * @param {String} permission User permission level. One of 'read', 'write', or 'admin'. Default: 'write'.
+         * @param {Boolean} isBibliographic Whether user will be included in citations for the node. 'default: true'
          * @return {Promise} Returns a promise that resolves to created contributor
          */
         addContributor(userId, permission, isBibliographic) {
@@ -125,7 +125,7 @@ export default Ember.Mixin.create({
                 bibliographic: isBibliographic
             });
             node.get('contributors').pushObject(contributor);
-            return node.save().then(() => contributor);
+            return node.save().then(() => contributor.save());
         },
         /**
          * Add unregistered contributor to a node.  Creates a user and then adds that user as a contributor.
@@ -149,7 +149,7 @@ export default Ember.Mixin.create({
                     bibliographic: isBibliographic
                 });
                 node.get('contributors').pushObject(contributor);
-                return node.save().then(() => contributor);
+                return node.save().then(() => contributor.save());
             });
         },
         /**
@@ -187,6 +187,25 @@ export default Ember.Mixin.create({
                 contributorMap[contributorId].set('bibliographic', bibliographicChanges[contributorId]);
             }
             return node.save();
+        },
+        /**
+         * Update a single contributor on a node.
+         *
+         * @method updateContributor
+         * @param {Contributor[]} contributor Contributor record to be modified
+         * @param {Object} newPermission New contributor permission
+         * @param {Object} newBibliographic New contributor bibliographic status
+         * @return {Promise} Returns a promise that resolves to the updated contributor.
+         */
+        updateContributor(contributor, newPermission, newBibliographic) {
+            var node = this.get('_node');
+            if (newPermission !== '') {
+                contributor.set('permission', newPermission);
+            }
+            if (newBibliographic !== '') {
+                contributor.set('bibliographic', newBibliographic);
+            }
+            return contributor.save();
         },
         /**
          * Add a child (component) to a node.

--- a/addon/mixins/node-actions.js
+++ b/addon/mixins/node-actions.js
@@ -198,7 +198,6 @@ export default Ember.Mixin.create({
          * @return {Promise} Returns a promise that resolves to the updated contributor.
          */
         updateContributor(contributor, newPermission, newBibliographic) {
-            var node = this.get('_node');
             if (newPermission !== '') {
                 contributor.set('permission', newPermission);
             }


### PR DESCRIPTION
## Ticket

❗ Not ready exploratory only
https://openscience.atlassian.net/browse/EOSF-141

# Purpose

Calling .save() on a node is masking errors when changing relationships.  Noticed in preprints author management PR https://github.com/CenterForOpenScience/ember-preprints/pull/19

*Example: Updating contributors.*
We have an updateContributors method on the NodeActionsMixin that bulk updates contributors.  We update a contributor by setting the contributor record with the new permission/bibliographic information contributor.set('permission', 'read') and then call node.save().  If I stop my API server (so the request will fail), the promise returned from node.save() is fulfilled.  There's no indication that the request didn't go through except in the console.

However, if I call contributor.save() with my API server stopped, the promise rejects as I would expect it to.  

# Notes for Reviewers

❗ Just early steps...if we actually move to returning contributor.save() instead of node.save() when modifying contributors, I imagine we will need some modifications to dirty relationships.

## Routes Added/Updated


