### PR TITLE
NodeActions that create something should return the new object

### DIFF
--- a/addon/mixins/commentable.js
+++ b/addon/mixins/commentable.js
@@ -33,7 +33,7 @@ export default Ember.Mixin.create({
          * Action that adds a new comment targeting the model by GUID.
          * @method addComment
          * @param {String} text The text of the new comment
-         * @return {Promise}
+         * @return {Promise} The newly created comment
          */
         addComment(text) {
             // Assumes that the page's model hook is the target for the comment
@@ -46,7 +46,7 @@ export default Ember.Mixin.create({
                 targetType: Ember.Inflector.inflector.pluralize(model.constructor.modelName)
             });
             commentsRel.pushObject(comment);
-            return model.save();
+            return model.save().then(() => comment);
         },
         /**
          * Action that edits an existing comment.

--- a/addon/mixins/node-actions.js
+++ b/addon/mixins/node-actions.js
@@ -126,7 +126,7 @@ export default Ember.Mixin.create({
                 bibliographic: isBibliographic
             });
             node.get('contributors').pushObject(contributor);
-            return node.save();
+            return node.save(() => contributor);
         },
         /**
          * Remove a contributor from a node
@@ -181,7 +181,7 @@ export default Ember.Mixin.create({
                 description: description || null
             });
             node.get('children').pushObject(child);
-            return node.save();
+            return node.save(() => child);
         },
         /**
          * Add a node link (pointer) to another node
@@ -197,7 +197,7 @@ export default Ember.Mixin.create({
                 target: targetNodeId
             });
             node.get('nodeLinks').pushObject(nodeLink);
-            return node.save();
+            return node.save(() => nodeLink);
         },
         /**
          * Remove a node link (pointer) to another node

--- a/addon/mixins/node-actions.js
+++ b/addon/mixins/node-actions.js
@@ -115,8 +115,7 @@ export default Ember.Mixin.create({
          * @param {String} userId ID of user that will be a contributor on the node
          * @param {String} permission User permission level. One of "read", "write", or "admin". Default: "write".
          * @param {Boolean} isBibliographic Whether user will be included in citations for the node. "default: true"
-         * @return {Promise} Returns a promise that resolves to the updated node
-         * with the new contributor relationship.
+         * @return {Promise} Returns a promise that resolves to the newly created contributor object.
          */
         addContributor(userId, permission, isBibliographic) {
             var node = this.get('_node');
@@ -126,7 +125,7 @@ export default Ember.Mixin.create({
                 bibliographic: isBibliographic
             });
             node.get('contributors').pushObject(contributor);
-            return node.save(() => contributor);
+            return node.save().then(() => contributor);
         },
         /**
          * Remove a contributor from a node
@@ -171,7 +170,7 @@ export default Ember.Mixin.create({
          * @param {String} title Title for the child
          * @param {String} description Description for the child
          * @param {String} category Category for the child
-         * @return {Promise} Returns a promise that resolves to the updated node with the new child relationship.
+         * @return {Promise} Returns a promise that resolves to the newly created child node.
          */
         addChild(title, description, category) {
             var node = this.get('_node');
@@ -181,15 +180,14 @@ export default Ember.Mixin.create({
                 description: description || null
             });
             node.get('children').pushObject(child);
-            return node.save(() => child);
+            return node.save().then(() => child);
         },
         /**
          * Add a node link (pointer) to another node
          *
          * @method addNodeLink
          * @param {String} targetNodeId ID of the node for which you wish to create a pointer
-         * @return {Promise} Returns a promise that resolves to the updated node with the
-         * newly added nodeLink relationship
+         * @return {Promise} Returns a promise that resolves to model for the newly created NodeLink
          */
         addNodeLink(targetNodeId) {
             var node = this.get('_node');
@@ -197,7 +195,7 @@ export default Ember.Mixin.create({
                 target: targetNodeId
             });
             node.get('nodeLinks').pushObject(nodeLink);
-            return node.save(() => nodeLink);
+            return node.save().then(() => nodeLink);
         },
         /**
          * Remove a node link (pointer) to another node


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-139

# Purpose
Although we save relationships through the parent model, actions that create something should return the newly created object, not just the thing used to handle the save.


# Notes for Reviewers
Checked the following applications for usages of these actions; this seems compatible, but let me know if breakages are discovered.

- `ember-osf` dummy
- osf.io `feature/osf-ember` branch (and PRs)
- `ember-share`
- `ember-preprints`
- `osf-meetings`

## Routes Added/Updated
Anything that depends on the node actions mixin to:
- create a child node (`addChild`)
- create a node link (`addNodeLink`)
- add node contributors (`addContributor`)
- add comments (`addComment`)


Also changes the `Commentable` mixin similarly. Cross-reference with standing PR:
https://github.com/CenterForOpenScience/ember-osf/pull/103

[#EOSF-139]