### PR TITLE
Allow same application to support cookie and token auth

### DIFF
--- a/addon/authenticators/osf-token.js
+++ b/addon/authenticators/osf-token.js
@@ -40,6 +40,11 @@ export default BaseAuthenticator.extend({
     },
     authenticate(accessToken) {
         // Adds the entire API user endpoint record to the session store as given
-        return this._test(accessToken);
+        let jqDeferred = this._test(accessToken);
+        return new Ember.RSVP.Promise((resolve, reject) => {
+            // TODO: Improve param capture
+            jqDeferred.done((value) => resolve(value));
+            jqDeferred.fail((reason) => reject(reason));
+        });
     }
 });

--- a/addon/components/osf-navbar/component.js
+++ b/addon/components/osf-navbar/component.js
@@ -2,8 +2,6 @@ import Ember from 'ember';
 import layout from './template';
 import config from 'ember-get-config';
 
-import { getAuthUrl } from 'ember-osf/utils/auth';
-
 /**
  * @module ember-osf
  * @submodule components
@@ -11,6 +9,10 @@ import { getAuthUrl } from 'ember-osf/utils/auth';
 
 /**
  * Display the OSF navbar
+ *
+ * Sample usage:
+ * {{osf-navbar loginAction=loginAction}}
+ *
  * @class osf-navbar
  */
 export default Ember.Component.extend({
@@ -27,7 +29,6 @@ export default Ember.Component.extend({
     }),
     fullName: null,
     host: config.OSF.url,
-    authUrl: getAuthUrl(),
     user: null,
     showSearch: false,
     _loadCurrentUser() {
@@ -35,11 +36,12 @@ export default Ember.Component.extend({
     },
     init() {
         this._super(...arguments);
+        // TODO: React to changes in service/ event?
         if (this.get('session.isAuthenticated')) {
             this._loadCurrentUser();
         }
     },
-    // TODO: Make these parameters configurable from... somewhere. (currently set by OSF settings module)
+    // TODO: These parameters are defined in osf settings.py; make sure ember config matches.
     allowLogin: true,
     enableInstitutions: true,
     actions: {
@@ -47,14 +49,8 @@ export default Ember.Component.extend({
             this.toggleProperty('showSearch');
         },
         logout() {
+            // TODO: May not work well if logging out from page that requires login- check?
             this.get('session').invalidate().then(() => window.location.reload(true));
         },
-        loginSuccess() {
-            this._loadCurrentUser();
-            this.sendAction('loginSuccess');
-        },
-        loginFail() {
-            this.sendAction('loginFail');
-        }
     }
 });

--- a/addon/components/osf-navbar/template.hbs
+++ b/addon/components/osf-navbar/template.hbs
@@ -9,6 +9,7 @@
                     <span class="icon-bar"></span>
                 </button>
                 {{# unless onSearchPage}}
+                    {{!-- TODO: Replace usage of knockout--}}
                     <span class="visible-xs" data-bind="click : toggleSearch, css: searchCSS">
                         <a class="osf-xs-search pull-right" {{action "toggleSearch"}} style="padding-top: 12px" >
                             <span rel="tooltip" data-placement="bottom" title="Search OSF" class="fa fa-search fa-lg fa-inverse" ></span>
@@ -34,7 +35,7 @@
                     </li>
                     {{# unless session.isAuthenticated}}
                         <li class="dropdown">
-                            <a href="${domain}support/" >Support</a>
+                            <a href="/support/" >Support</a>
                         </li>
                     {{/unless}}
 
@@ -50,7 +51,7 @@
                         <li class="dropdown">
                             <a href="#" class="dropdown-toggle nav-user-dropdown" data-toggle="dropdown" role="button" aria-expanded="false">
                                 <span class="osf-gravatar">
-                                    <img src={{gravatarUrl}} alt="User gravatar">
+                                    <img src="{{gravatarUrl}}" alt="User gravatar">
                                 </span> {{user.fullName}}
                                 <span class="caret"></span>
                             </a>
@@ -72,7 +73,7 @@
                             </ul>
                         </li>
                     {{else if allowLogin}}
-                        {{#if institution}}  {{!-- TODO: Find a source for this info (eg may only be on node pages? Make work with nested router --}}
+                        {{#if institution}}  {{!-- TODO: How does the page know whether this is an institution view? Implement in the future --}}
                             <li class="dropdown sign-in" data-bind="with: $root.signIn">
                                 <div class="btn-group">
                                     <a href="${domain}login/?campaign=institution&redirect_url=${redirect_url}" class="btn btn-info btn-top-login">
@@ -81,43 +82,12 @@
                                 </div>
                             </li>
                         {{else}}
-                            {{!-- Very ugly hack until we can refactor navbar to support pluggable auth types: Navbar users can override the login button (for consuming apps based on cookie or other auth) --}}
-                            {{!-- The cookie/token login mixins should eventually control the default login functionality and then we can pass in when using component in application template --}}
-                            {{#if hasBlock}}
-                                {{yield this}}
-                            {{else}}
-                                {{#oauth-popup authUrl=authUrl loginSuccess=(action 'loginSuccess') loginFail=(action 'loginFail') as |popup|}}
-                                    <li class="dropdown sign-in">
-                                        <div class="col-sm-12">
-                                            <button class="btn btn-success btn-top-signup m-r-xs" onclick={{action 'login' target=popup}} >
-                                                Login
-                                            </button>
-                                        </div>
-                                    </li>
-                                {{/oauth-popup}}
-                            {{/if}}
-
-                            {{!--
-                            <li class="dropdown sign-in" data-bind="with: $root.signIn">
+                            <li class="dropdown sign-in">
                                 <div class="col-sm-12">
-                                    <a href="${web_url_for('auth_login')}?sign_up=True" class="btn btn-success btn-top-signup m-r-xs">Sign up</a>
-                                    <button type="button" class="btn btn-info btn-top-login p-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-                                        Sign in <span class="caret hidden-xs"></span>
-                                    </button>
-                                    <ul class="dropdown-menu" id="menuLogin" role="menu">
-                                        <form class="form" id="signInForm" data-bind="submit: submit" action="${login_url}" method="POST">
-                                            <div class="form-group"><input id="email" class="form-control" type="email" data-bind="value: username" name="username" placeholder="Email" aria-label="Username"></div>
-                                            <div class="form-group"><input name="password" id="password" class="form-control" type="password" placeholder="Password" data-bind="value: password" aria-label="Password"></div>
-                                            <div class="form-group"><button type="submit" id="btnLogin" class="btn btn-block btn-primary">Login</button></div>
-                                            {{#if enableInstitutions}}
-                                                <div class="text-center m-b-sm"> <a href="/login/?campaign=institution">Login through your institution  <i class="fa fa-arrow-right"></i></a></div>
-                                            {{/if}}
-                                            <div class="text-center m-b-sm"> <a href="/forgotpassword">Forgot password?</a></div>
-                                        </form>
-                                    </ul>
+                                    <a href="/register/" class="btn btn-success btn-top-signup m-r-xs">Sign Up</a>
+                                    <a {{action loginAction}} class="btn btn-info btn-top-signup m-r-xs">Sign in</a>
                                 </div>
                             </li>
-                            --}}
                         {{/if}}
                     {{/if}}
                 </ul>
@@ -125,7 +95,6 @@
         </div>
     </nav>
     {{#if showSearch}}
-        {{#search-dropdown action='toggleSearch'}}
-        {{/search-dropdown}}
+        {{search-dropdown action='toggleSearch'}}
     {{/if}}
 </div>

--- a/addon/mixins/cas-authenticated-route.js
+++ b/addon/mixins/cas-authenticated-route.js
@@ -7,7 +7,7 @@ import { getAuthUrl } from 'ember-osf/utils/auth';
  */
 
 /**
- * Replacement for Ember-simple-auth route mixin. Instead of redirecting to an internal route,
+ * Replacement for Ember-simple-auth AuthenticatedRouteMixin. Instead of redirecting to an internal route,
  *   this mixin redirects to CAS login URL, and brings the user back to the last requested page afterwards
  *
  * For OAuth this is done via the state parameter, and for cookies this is done via the service parameter. (TODO: Need a mixin that detects this!)

--- a/addon/mixins/cas-authenticated-route.js
+++ b/addon/mixins/cas-authenticated-route.js
@@ -1,0 +1,43 @@
+import Ember from 'ember';
+import { getAuthUrl } from 'ember-osf/utils/auth';
+
+/**
+ * @module ember-osf
+ * @submodule mixins
+ */
+
+/**
+ * Replacement for Ember-simple-auth route mixin. Instead of redirecting to an internal route,
+ *   this mixin redirects to CAS login URL, and brings the user back to the last requested page afterwards
+ *
+ * For OAuth this is done via the state parameter, and for cookies this is done via the service parameter. (TODO: Need a mixin that detects this!)
+ *
+ * @class CasAuthenticatedRouteMixin
+ */
+export default Ember.Mixin.create({
+    /**
+      The session service.
+      @property session
+      @readOnly
+      @type SessionService
+      @public
+    */
+    session: Ember.inject.service('session'),
+
+    /**
+      Checks whether the session is authenticated, and if it is not, redirects to the login URL. (Sending back to this page after a successful transition)
+
+      __If `beforeModel` is overridden in a route that uses this mixin, the route's
+     implementation must call `this._super(...arguments)`__ so that the mixin's
+     `beforeModel` method is actually executed.
+      @method beforeModel
+      @public
+    */
+    beforeModel() {
+        if (!this.get('session.isAuthenticated')) {
+            window.location = getAuthUrl(window.location);
+        } else {
+            return this._super(...arguments);
+        }
+    }
+});

--- a/addon/mixins/osf-agnostic-auth-controller.js
+++ b/addon/mixins/osf-agnostic-auth-controller.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+/**
+ * @module ember-osf
+ * @submodule mixins
+ */
+
+/**
+ * Controller mixin for authentication-agnostic login: defines the application at runtime to use the authentication method
+ *   specified in environment config. Intended to be used in tandem with OsfAuthController mixin.
+ * Some authentication methods (eg cookies) are not available to third-party applications.
+ * This has limited use, since most applications will only need to support one method. It may be useful for ember apps
+ *   that run inside the OSF, eg to use the standalone dev server, or to offer support for branded apps
+ *   on third-party domains.
+ *
+ * @class OsfAgnosticAuthController
+ * @extends Ember.Mixin
+ * @uses ember-osf/OsfCookieLoginController
+ * @uses ember-osf/OsfTokenLoginController
+ */
+export default Ember.Mixin.create({
+});

--- a/addon/mixins/osf-agnostic-auth-controller.js
+++ b/addon/mixins/osf-agnostic-auth-controller.js
@@ -1,10 +1,23 @@
 import Ember from 'ember';
+import config from 'ember-get-config';
+
+import OsfTokenLoginController from '../mixins/osf-token-login-controller';
+import OsfCookieLoginController from '../mixins/osf-cookie-login-controller';
 
 /**
  * @module ember-osf
  * @submodule mixins
  */
+var AuthMixin;
 
+let authType = config.authorizationType;
+if (authType === 'token') {
+    AuthMixin = OsfTokenLoginController;
+} else if (authType === 'cookie') {
+    AuthMixin = OsfCookieLoginController;
+} else {
+    throw new Ember.Error(`Unrecognized authorization type: ${authType}`);
+}
 /**
  * Controller mixin for authentication-agnostic login: defines the application at runtime to use the authentication method
  *   specified in environment config. Intended to be used in tandem with OsfAuthController mixin.
@@ -18,5 +31,4 @@ import Ember from 'ember';
  * @uses ember-osf/OsfCookieLoginController
  * @uses ember-osf/OsfTokenLoginController
  */
-export default Ember.Mixin.create({
-});
+export default AuthMixin;

--- a/addon/mixins/osf-agnostic-auth-route.js
+++ b/addon/mixins/osf-agnostic-auth-route.js
@@ -1,10 +1,24 @@
 import Ember from 'ember';
+import config from 'ember-get-config';
+
+import OsfTokenLoginRoute from '../mixins/osf-token-login-route';
+import OsfCookieLoginRoute from '../mixins/osf-cookie-login-route';
 
 /**
  * @module ember-osf
  * @submodule mixins
  */
 
+var AuthMixin;
+
+let authType = config.authorizationType;
+if (authType === 'token') {
+    AuthMixin = OsfTokenLoginRoute;
+} else if (authType === 'cookie') {
+    AuthMixin = OsfCookieLoginRoute;
+} else {
+    throw new Ember.Error(`Unrecognized authorization type: ${authType}`);
+}
 /**
  * Route mixin for authentication-agnostic login: defines the application at runtime to use the authentication method
  *   specified in environment config. Intended to be used in tandem with OsfAgnosticAuthRoute mixin.
@@ -18,5 +32,4 @@ import Ember from 'ember';
  * @uses ember-osf/OsfCookieLoginRoute
  * @uses ember-osf/OsfTokenLoginRoute
  */
-export default Ember.Mixin.create({
-});
+export default AuthMixin;

--- a/addon/mixins/osf-agnostic-auth-route.js
+++ b/addon/mixins/osf-agnostic-auth-route.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+/**
+ * @module ember-osf
+ * @submodule mixins
+ */
+
+/**
+ * Route mixin for authentication-agnostic login: defines the application at runtime to use the authentication method
+ *   specified in environment config. Intended to be used in tandem with OsfAgnosticAuthRoute mixin.
+ * Some authentication methods (eg cookies) are not available to third-party applications.
+ * This has limited use, since most applications will only need to support one method. It may be useful for ember apps
+ *   that run inside the OSF, eg to use the standalone dev server, or to offer support for branded apps
+ *   on third-party domains.
+ *
+ * @class OsfAgnosticAuthRoute
+ * @extends Ember.Mixin
+ * @uses ember-osf/OsfCookieLoginRoute
+ * @uses ember-osf/OsfTokenLoginRoute
+ */
+export default Ember.Mixin.create({
+});

--- a/addon/mixins/osf-cookie-login-controller.js
+++ b/addon/mixins/osf-cookie-login-controller.js
@@ -20,11 +20,11 @@ export default Ember.Mixin.create({
     queryParams: ['ticket'],
     ticket: null,
 
-    /**
-     * The authorization
-     * @property authUrl
-     * @type String
-     * @public
-     */
-    authUrl: getAuthUrl()
+    actions: {
+        login() {
+            window.location = getAuthUrl(window.location);
+        },
+        loginSuccess() {},
+        loginFail() {}
+    }
 });

--- a/addon/mixins/osf-cookie-login-route.js
+++ b/addon/mixins/osf-cookie-login-route.js
@@ -1,7 +1,5 @@
 import Ember from 'ember';
 
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
-
 /**
  * @module ember
  * @submodule mixins
@@ -15,11 +13,14 @@ import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-
  * @extends Ember.Mixin
  * @uses ember-simple-auth/UnauthenticatedRouteMixin
  */
-export default Ember.Mixin.create(UnauthenticatedRouteMixin, {
+export default Ember.Mixin.create({
     session: Ember.inject.service(),
     beforeModel() {
         // Determine whether the user is logged in by making a test request. This is quite a crude way of
         // determining whether the user has a cookie and should be improved in the future.
+
+        // TODO: Should this check for resolution of a promise?
+        this._super(...arguments);
 
         // Block transition until auth attempt resolves. If auth fails, let the page load normally.
         return this.get('session').authenticate('authenticator:osf-cookie')

--- a/addon/mixins/osf-cookie-login-route.js
+++ b/addon/mixins/osf-cookie-login-route.js
@@ -22,6 +22,7 @@ export default Ember.Mixin.create(UnauthenticatedRouteMixin, {
         // determining whether the user has a cookie and should be improved in the future.
 
         // Block transition until auth attempt resolves. If auth fails, let the page load normally.
-        return this.get('session').authenticate('authenticator:osf-cookie').catch(err => console.log('Authentication failed: ', err));
+        return this.get('session').authenticate('authenticator:osf-cookie')
+            .catch(err => console.log('Authentication failed: ', err));
     }
 });

--- a/addon/mixins/osf-token-login-route.js
+++ b/addon/mixins/osf-token-login-route.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
 import config from 'ember-get-config';
 
@@ -18,7 +17,7 @@ import { getTokenFromHash } from 'ember-osf/utils/auth';
  * @class OsfTokenLoginRouteMixin
  * @extends Ember.Mixin
  */
-export default Ember.Mixin.create(UnauthenticatedRouteMixin, {
+export default Ember.Mixin.create({
     session: Ember.inject.service(),
     beforeModel() {
         var accessToken;
@@ -31,6 +30,9 @@ export default Ember.Mixin.create(UnauthenticatedRouteMixin, {
             }
             window.location.hash = '';
         }
+
+        // TODO: Should this check for resolution of a promise?
+        this._super(...arguments);
 
         return this.get('session').authenticate('authenticator:osf-token', accessToken)
             .catch(err => console.log('Authentication failed: ', err));

--- a/addon/mixins/osf-token-login-route.js
+++ b/addon/mixins/osf-token-login-route.js
@@ -33,6 +33,6 @@ export default Ember.Mixin.create(UnauthenticatedRouteMixin, {
         }
 
         return this.get('session').authenticate('authenticator:osf-token', accessToken)
-            .then(() => this.transitionTo('index'));
+            .catch(err => console.log('Authentication failed: ', err));
     }
 });

--- a/addon/mixins/osf-token-login-route.js
+++ b/addon/mixins/osf-token-login-route.js
@@ -20,6 +20,9 @@ import { getTokenFromHash } from 'ember-osf/utils/auth';
 export default Ember.Mixin.create({
     session: Ember.inject.service(),
     beforeModel() {
+        // TODO: Should this check for resolution of a promise?
+        this._super(...arguments);
+
         var accessToken;
         if (config.OSF.isLocal) {
             accessToken = config.OSF.accessToken;
@@ -30,9 +33,6 @@ export default Ember.Mixin.create({
             }
             window.location.hash = '';
         }
-
-        // TODO: Should this check for resolution of a promise?
-        this._super(...arguments);
 
         return this.get('session').authenticate('authenticator:osf-token', accessToken)
             .catch(err => console.log('Authentication failed: ', err));

--- a/addon/utils/auth.js
+++ b/addon/utils/auth.js
@@ -15,22 +15,32 @@ import config from 'ember-get-config';
  * Retrieve the correct URL for OAuth 2.0 authentication in the OSF, including any additional configurable parameters
  * @private
  * @method getOAuthUrl
+ * @param {string} nextUri Where to send the browser after a successful login request
  * @return {string}
  */
-function getOAuthUrl() {
-    return `${config.OSF.oauthUrl}?response_type=token&scope=${config.OSF.scope}&client_id=${config.OSF.clientId}&redirect_uri=${encodeURI(config.OSF.redirectUri)}`;
+function getOAuthUrl(nextUri) {
+    // OAuth requires that redirect URI match what was registered, exactly. We may need a parameter to signify next
+    //   transition, if the user wants to return to ember at the point where they left off before needing to log in.
+    // For now, we will put this in the `state` parameter (always returned unchanged) and implement that functionality in ember later.
+    // To avoid abuse, the application should forcibly truncate state, eg make it relative to the application rootURL
+    //   (should not be possible to use the ember app as just an external redirect service)
+    let uri = `${config.OSF.oauthUrl}?response_type=token&scope=${config.OSF.scope}&client_id=${config.OSF.clientId}&redirect_uri=${encodeURI(config.OSF.redirectUri)}`;
+    if (nextUri) {
+        uri += `&state=${encodeURI(nextUri)}`;
+    }
+    return uri;
 }
 
 /**
  * Retrieve the correct URL for cookie-based in the OSF, including any additional configurable parameters
  * @private
  * @method getCookieAuthUrl
- * @param {string} redirectUri Where to send the browser after a successful login request
+ * @param {string} nextUri Where to send the browser after a successful login request
  * @return {string}
  */
-function getCookieAuthUrl(redirectUri) {
-    redirectUri = redirectUri || config.OSF.redirectUri;
-    return `${config.OSF.cookieLoginUrl}?service=${redirectUri}&auto=true`;
+function getCookieAuthUrl(nextUri) {
+    nextUri = nextUri || config.OSF.redirectUri;
+    return `${config.OSF.cookieLoginUrl}?service=${encodeURI(nextUri)}&auto=true`;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -38,7 +38,6 @@ module.exports = {
             ENV.OSF.apiUrl = 'http://localhost:8000';
 
             // Where to direct the user for cookie-based authentication
-            // TODO: The CAS server won't allow cookie auth to staging from a local machine. Hence currently this is local-only.
             ENV.OSF.cookieLoginUrl = 'http://localhost:8080/login';
             // Where to direct the user for oauth2-based authentication
             ENV.OSF.oauthUrl = 'http://localhost:8080/oauth2/profile';
@@ -51,6 +50,7 @@ module.exports = {
         } else if (BACKEND === 'stage') {
             ENV.OSF.url = 'https://staging.osf.io/';
             ENV.OSF.apiUrl = 'https://staging-api.osf.io';
+            ENV.OSF.cookieLoginUrl = 'https://staging-accounts.osf.io/login';
             ENV.OSF.oauthUrl = 'https://staging-accounts.osf.io/oauth2/authorize';
             ENV.OSF.renderUrl = 'http://staging-mfr.osf.io/render';
             ENV.OSF.waterbutlerUrl = 'http://staging-files.osf.io/';
@@ -59,6 +59,7 @@ module.exports = {
         if (BACKEND === 'stage2') {
             ENV.OSF.url = 'https://staging2.osf.io/';
             ENV.OSF.apiUrl = 'https://staging2-api.osf.io';
+            ENV.OSF.cookieLoginUrl = 'https://staging2-accounts.osf.io/login';
             ENV.OSF.oauthUrl = 'https://staging2-accounts.osf.io/oauth2/authorize';
             ENV.OSF.renderUrl = 'http://staging2-mfr.osf.io/render';
             ENV.OSF.waterbutlerUrl = 'http://staging2-files.osf.io/';
@@ -67,6 +68,7 @@ module.exports = {
         if (BACKEND === 'test') {
             ENV.OSF.url = 'https://test.osf.io/';
             ENV.OSF.apiUrl = 'https://test-api.osf.io';
+            ENV.OSF.cookieLoginUrl = 'https://test-accounts.osf.io/login';
             ENV.OSF.oauthUrl = 'https://test-accounts.osf.io/oauth2/authorize';
             ENV.OSF.renderUrl = 'http://test-mfr.osf.io/render';
             ENV.OSF.waterbutlerUrl = 'http://test-files.osf.io/';
@@ -76,6 +78,7 @@ module.exports = {
             console.log(`WARNING: you\'ve specified production as a backend. Please do not use production for testing or development purposes`);
             ENV.OSF.url = 'https://osf.io/';
             ENV.OSF.apiUrl = 'https://api.osf.io';
+            ENV.OSF.cookieLoginUrl = 'https://accounts.osf.io/login';
             ENV.OSF.oauthUrl = 'https://accounts.osf.io/oauth2/authorize';
             ENV.OSF.renderUrl = 'http://mfr.osf.io/render';
             ENV.OSF.waterbutlerUrl = 'http://files.osf.io/';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{osf-navbar}}
+{{osf-navbar loginAction=(action 'login')}}
 {{title "OSF"}}
 <div id="main" class="container-fluid">
     <div class="row">

--- a/tests/integration/components/osf-navbar/component-test.js
+++ b/tests/integration/components/osf-navbar/component-test.js
@@ -9,9 +9,9 @@ test('it renders', function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
 
-    this.render(hbs`{{osf-navbar}}`);
+    this.set('loginAction', ()=>{});
+    this.render(hbs`{{osf-navbar loginAction=loginAction}}`);
 
-    //assert.equal(this.$().text().trim(), '');
+    assert.notEqual(this.$().text().trim(), '');
     // TODO: Implement tests that check a variety of different conditionals used by navbar to control what is displayed
-    assert.ok(true);
 });

--- a/tests/integration/components/osf-navbar/component-test.js
+++ b/tests/integration/components/osf-navbar/component-test.js
@@ -12,16 +12,6 @@ test('it renders', function(assert) {
     this.render(hbs`{{osf-navbar}}`);
 
     //assert.equal(this.$().text().trim(), '');
-
-
-    // Template block usage:
-    this.render(hbs`
-        {{#osf-navbar}}
-            template block text
-        {{/osf-navbar}}
-    `);
-
-    //assert.equal(this.$().text().trim(), 'template block text');
     // TODO: Implement tests that check a variety of different conditionals used by navbar to control what is displayed
     assert.ok(true);
 });

--- a/tests/unit/mixins/cas-authenticated-route-test.js
+++ b/tests/unit/mixins/cas-authenticated-route-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import CasAuthenticatedRouteMixin from 'ember-osf/mixins/cas-authenticated-route';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | cas authenticated route');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let CasAuthenticatedRouteObject = Ember.Object.extend(CasAuthenticatedRouteMixin);
+  let subject = CasAuthenticatedRouteObject.create();
+  assert.ok(subject);
+});

--- a/tests/unit/mixins/osf-agnostic-auth-controller-test.js
+++ b/tests/unit/mixins/osf-agnostic-auth-controller-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import OsfAgnosticAuthControllerMixin from 'ember-osf/mixins/osf-agnostic-auth-controller';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | osf agnostic auth controller');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let OsfAgnosticAuthControllerObject = Ember.Object.extend(OsfAgnosticAuthControllerMixin);
+  let subject = OsfAgnosticAuthControllerObject.create();
+  assert.ok(subject);
+});

--- a/tests/unit/mixins/osf-agnostic-auth-route-test.js
+++ b/tests/unit/mixins/osf-agnostic-auth-route-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import OsfAgnosticAuthRouteMixin from 'ember-osf/mixins/osf-agnostic-auth-route';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | osf agnostic auth route');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let OsfAgnosticAuthRouteObject = Ember.Object.extend(OsfAgnosticAuthRouteMixin);
+  let subject = OsfAgnosticAuthRouteObject.create();
+  assert.ok(subject);
+});


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/PREP-118

Companion ember-preprints PR to follow.

# Purpose
Allow a single application to support both cookie and token based auth. Sample use case is to run preprints from within the OSF, as well as branded on different domains.

Imports are evaluated before code, so a new `OsfAgnosticAuth*` set of mixins was needed to support making auth configurable based on the value of `authorizationType` in `config/environment.js`.

## Future (for separate ticket)
For now, the token auth login button forces the user to go wherever the app registered to be the REDIRECT_URI (eg, the homepage). We may want more fine-grained redirects in the future (return the user to the page they were on when they clicked the login button)

I did experiment with REDIRECT_URIs that contained additional query params, but in each case CAS rejected these with an "invalid redirect_uri" error.

# TODO

## Login flow
- [x] Decision: how do branded app users get told they need to log in? (Answer: if they need to log in, they go to the login page)
- [x] Ensure that all components currently used by preprints work with both token and cookie auth (see #114)
- [x] Ensure that any hard-coded mixins (like login-route/controller) are selected appropriately based on the specified environment configuration when app is created. Eg, make the choice of mixin happen dynamically.

## Style and functionality
- [x] Navbar login button should match OSF
- [x] Navbar sign in button should match OSF
- [x] Provide a way for routes to check that the user is logged in, and test with...
  - [x] Cookie auth
  - [x] Token auth
- [x] For pages that require authentication, ember-simple-auth should send user to login page, and make sure they return to correct (ember) page when done
  - [x] For cookie auth
  - [x] For token auth (plan: use state parameter?)
- [x] Pages that do not require authentication should show logged-in-user in navbar, or show logged-out state
- [ ] Navbar login button should adjust dynamically when route changes, but still be a clickable link. (computed property cached?)

## Internal refactorings
- [x] Replace various authUrl / action based login usages with redirect behavior
- [x] Make sure ember-osf dummy app still works after changes (mixins, authUrl usages, login buttons etc)
- [ ] Authenticated AJAX should abstract away some of the extra headers manipulation silliness, then verify that manual request widgets (dropzone and fileManager) work...
  - [ ] For token auth
  - [ ] For cookie auth

# Notes for Reviewers
To be written.



## Tips for testing
- When switching between token and cookie auth, you may need to tell ember simple auth that what it thinks of as your login is no longer valid. Use `localStorage.clear()` at the console.
- When BACKEND=local(host), ember-osf is hardcoded to use personal access tokens. Edit `config/local.yml` accordingly.
  - *DO NOT* commit your personal access tokens to github!
  - To use real CAS:
    - Specify a `CLIENT_ID` in local.yml
    - Comment out [these lines](https://github.com/abought/ember-osf/blob/4f3fe0ff11ed6c23c41bea3b132f8b3516a17685/index.js#L48-L49)
    - Change the suffix of your [oauthUrl](https://github.com/abought/ember-osf/blob/4f3fe0ff11ed6c23c41bea3b132f8b3516a17685/index.js#L43-L43) from `/profile` to `/authorize` (similar to url used for production)
- This works on port 5000. On port 4200, using token auth, you may see errors unless `localhost:4200` is added to the API CORS ORIGIN whitelist:
https://github.com/abought/osf.io/blob/f0bb77351322667d240c05b7230e944eab12094f/api/base/settings/defaults.py#L112-L111

## Routes Added/Updated
- Application route change: do not block loading of application if user is not logged in. (let other auth route mixins do that)
- Login route changes to follow