### PR TITLE
[api-change] Improve taggable mixin by removing hard-coded path to taggable resource

### DIFF
--- a/addon/components/tags-widget/component.js
+++ b/addon/components/tags-widget/component.js
@@ -49,15 +49,20 @@ export default Ember.Component.extend({
                     this.send('removeATag', tag);
                 }
             });
-            // Populate the widget with the default tags passed in
-            let tags = this.get('tags');
-            this.$().importTags(tags.join(', '));
         });
+    }),
+
+    _doPopulateTags: Ember.observer('tags', function() {
+        // Rerender the list of tags whenever the node model changes. Useful if node.tags is not defined when page loads.
+        // Provide a default value in case tags weren't defined when component first rendered
+        this.$().importTags('');
+        let tags = this.get('tags') || [];
+        this.$().importTags(tags.join(', '));
     }),
 
     actions: {
         addATag(tag) {
-            //Calls a curried closure action which was provided the model
+            // Calls a curried closure action which was provided the model
             this.attrs.addATag(tag);
         },
         removeATag(tag) {
@@ -65,7 +70,7 @@ export default Ember.Component.extend({
             if (!tag) {
                 return false;
             }
-            this.sendAction('removeATag', tag);
+            this.attrs.removeATag(tag);
         }
     }
 });

--- a/addon/components/tags-widget/component.js
+++ b/addon/components/tags-widget/component.js
@@ -14,8 +14,8 @@ import layout from './template';
  *
  * ```handlebars
  * {{tags-widget
- *   addATag=(action 'addATag')
- *   removeATag=(action 'removeATag')
+ *   addATag=(action 'addATag' model)
+ *   removeATag=(action 'removeATag' model)
  *   tags=model.tags}}
  * ```
  * @class tags-widget
@@ -57,6 +57,7 @@ export default Ember.Component.extend({
 
     actions: {
         addATag(tag) {
+            //Calls a curried closure action which was provided the model
             this.attrs.addATag(tag);
         },
         removeATag(tag) {

--- a/addon/components/tags-widget/component.js
+++ b/addon/components/tags-widget/component.js
@@ -55,8 +55,8 @@ export default Ember.Component.extend({
     didRender() {
         // Rerender the list of tags whenever the node model changes. Useful if node.tags is not defined when page loads.
         // Provide a default value in case tags weren't defined when component first rendered
-        this.$().importTags('');
         let tags = this.get('tags') || [];
+        // Reset & replace existing tag list with new items
         this.$().importTags(tags.join(', '));
     },
 

--- a/addon/components/tags-widget/component.js
+++ b/addon/components/tags-widget/component.js
@@ -52,13 +52,13 @@ export default Ember.Component.extend({
         });
     }),
 
-    _doPopulateTags: Ember.observer('tags', function() {
+    didRender() {
         // Rerender the list of tags whenever the node model changes. Useful if node.tags is not defined when page loads.
         // Provide a default value in case tags weren't defined when component first rendered
         this.$().importTags('');
         let tags = this.get('tags') || [];
         this.$().importTags(tags.join(', '));
-    }),
+    },
 
     actions: {
         addATag(tag) {

--- a/addon/mixins/taggable-mixin.js
+++ b/addon/mixins/taggable-mixin.js
@@ -18,28 +18,28 @@ export default Ember.Mixin.create({
          * as the modified copy.
          *
          * @method addATag
+         * @param {DS.Model} model A model instance that supports tags functionality
          * @param {String} tag New tag to be added to list.
          */
-        addATag(tag) {
-            var resource = this.get('model');
-            var currentTags = resource.get('tags').slice(0);
+        addATag(model, tag) {
+            var currentTags = model.get('tags').slice(0);
             Ember.A(currentTags);
             currentTags.pushObject(tag);
-            resource.set('tags', currentTags);
-            return resource.save();
+            model.set('tags', currentTags);
+            return model.save();
         },
         /**
          * Removes a tag from the current array of tags on the resource.
          *
          * @method removeATag
+         * @param {DS.Model} model A model instance that supports tags functionality
          * @param {String} tag Tag to be removed from list.
          */
-        removeATag(tag) {
-            var resource = this.get('model');
-            var currentTags = resource.get('tags').slice(0);
+        removeATag(model, tag) {
+            var currentTags = model.get('tags').slice(0);
             currentTags.splice(currentTags.indexOf(tag), 1);
-            resource.set('tags', currentTags);
-            resource.save();
+            model.set('tags', currentTags);
+            model.save();
         }
     }
 });

--- a/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
+++ b/tests/dummy/app/templates/nodes/detail/files/provider/file.hbs
@@ -50,7 +50,7 @@
         }}
         <div>
             <p><label> Tags </label></p>
-            {{tags-widget addATag=(action 'addATag') removeATag=(action 'removeATag') tags=model.tags}}
+            {{tags-widget addATag=(action 'addATag' model) removeATag=(action 'removeATag' model) tags=model.tags}}
         </div>
     </div>
     <div class='col-md-9'>

--- a/tests/dummy/app/templates/nodes/detail/index.hbs
+++ b/tests/dummy/app/templates/nodes/detail/index.hbs
@@ -15,7 +15,7 @@
     <p><label>Date Modified:</label> {{moment-format model.dateModified}}</p>
     <p><label>Public </label> {{model.public}} </p>
     <p><label> Tags </label></p>
-    {{tags-widget addATag=(action 'addATag') removeATag=(action 'removeATag') tags=model.tags}}
+    {{tags-widget addATag=(action 'addATag' model) removeATag=(action 'removeATag' model) tags=model.tags}}
     <hr>
     <p>
         <a href="{{model.links.html}}" target="_blank" class="btn btn-primary">

--- a/tests/integration/components/tags-widget/component-test.js
+++ b/tests/integration/components/tags-widget/component-test.js
@@ -11,5 +11,7 @@ test('it renders a tag', function(assert) {
     this.set('tags', ['hello']);
 
     this.render(hbs`{{tags-widget tags=tags}}`);
-    assert.ok(this.$('input[type="text"]').tagExist('hello'));
+
+    assert.ok(this.$('input[type="text"]').tagExist('hello'),
+        'Tag was not correctly rendered');
 });

--- a/tests/unit/controllers/file-test.js
+++ b/tests/unit/controllers/file-test.js
@@ -23,7 +23,7 @@ test('add a file tag', function(assert) {
     ctrl.set('model', model);
     ctrl.set('model.save', function() {return;});
     Ember.run(function() {
-        ctrl.send('addATag', 'new tag');
+        ctrl.send('addATag', model, 'new tag');
     });
     assert.deepEqual(ctrl.model.get('tags'), ['one', 'new tag']);
 });
@@ -33,6 +33,6 @@ test('remove a file tag', function(assert) {
     let model = FactoryGuy.make('file', {tags: ['one', 'two']});
     ctrl.set('model', model);
     ctrl.set('model.save', function() {return;});
-    Ember.run(function() {ctrl.send('removeATag', 'one');});
+    Ember.run(function() {ctrl.send('removeATag', model, 'one');});
     assert.deepEqual(ctrl.model.get('tags'), ['two']);
 });

--- a/tests/unit/controllers/node-test.js
+++ b/tests/unit/controllers/node-test.js
@@ -23,7 +23,7 @@ test('add a node tag', function(assert) {
     ctrl.set('model', model);
     ctrl.set('model.save', function() {return;});
     Ember.run(function() {
-        ctrl.send('addATag', 'new tag');
+        ctrl.send('addATag', model, 'new tag');
     });
     assert.deepEqual(ctrl.model.get('tags'), ['one', 'new tag']);
 });
@@ -34,7 +34,7 @@ test('remove a node tag', function(assert) {
     ctrl.set('model', model);
     ctrl.set('model.save', function() {return;});
     Ember.run(function() {
-        ctrl.send('removeATag', 'one');
+        ctrl.send('removeATag', model, 'one');
     });
     assert.deepEqual(ctrl.model.get('tags'), ['two']);
 });


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/PREP-55

❗ This PR is a dependency for https://github.com/CenterForOpenScience/ember-preprints/pull/46

⚠️ This is a backwards-incompatible change. It changes the call signature of actions on the TaggableMixin.

# Purpose
Supports tagging on pages where the thing to tag is not defined in the `model` hook of the route.

Changes how the `addATag` and `removeATag` mixins are used. Instead of passing `addATag=(action 'addATag')`, curry it so that the first argument is always implicitly there for any components (like `tags-widget`) that need it:

`addATag=(action 'addATag' model)`

This makes the mixin less tied to how variables are named on the route. (widgets only have to decide to do with tag text, not figure out what model to use)

# Notes for Reviewers
This will break any consuming apps that use the taggable mixin, until usages are updated. Sorry about that, but it's in a good cause...

Ultimately, we will probably want all usages of the mixin to work this way.

## Routes Added/Updated
Dummy app:
- File detail
- Node detail

Ember preprints:
- /submit

Audited other COS ember apps but none appeared to be using mixin yet.