### PR TITLE
Feature/Handling API Unregistered Contributor changes

### DIFF
--- a/addon/adapters/contributor.js
+++ b/addon/adapters/contributor.js
@@ -1,9 +1,6 @@
 import OsfAdapter from './osf-adapter';
 
 export default OsfAdapter.extend({
-    generateIdForRecord: function(_, __, inputProperties) {
-        return inputProperties.nodeId + '-' + inputProperties.userId;
-    },
     buildURL(modelName, id, snapshot, requestType) { // jshint ignore:line
         if (requestType === 'createRecord' || requestType === 'findRecord') {
             var nodeId;

--- a/addon/mixins/node-actions.js
+++ b/addon/mixins/node-actions.js
@@ -108,17 +108,6 @@ export default Ember.Mixin.create({
             return this.get('_node').addContributor(...arguments);
         },
         /**
-         * Add unregistered contributor to a node.  Creates a user and then adds that user as a contributor.
-         *
-         * @method addUnregisteredContributor
-         * @param {String} fullName Full name of user
-         * @param {String} email User's email
-         * @return {Promise} Returns a promise that resolves to the created contributor
-         */
-        addUnregisteredContributor(fullName, email, permission, isBibliographic) {  // jshint ignore:line
-            return this.get('_node').addUnregisteredContributor(...arguments);
-        },
-        /**
          * Remove a contributor from a node
          *
          * @method removeContributor

--- a/addon/models/contributor.js
+++ b/addon/models/contributor.js
@@ -48,6 +48,8 @@ export default OsfModel.extend({
     users: DS.belongsTo('user'),
     unregisteredContributor: DS.attr('string'),
     index: DS.attr('number'),
+    fullName: DS.attr('string'),
+    email: DS.attr('string'),
 
     node: DS.belongsTo('node', {
         inverse: 'contributors'

--- a/addon/models/node.js
+++ b/addon/models/node.js
@@ -164,13 +164,17 @@ export default OsfModel.extend(FileItemMixin, {
     },
 
     addContributor(userId, permission, isBibliographic, index = Number.MAX_SAFE_INTEGER) {
+    addContributor(userId, permission, isBibliographic, fullName, email, index = Number.MAX_SAFE_INTEGER) {
         let contrib = this.store.createRecord('contributor', {
             index: index,
             permission: permission,
             bibliographic: isBibliographic,
             nodeId: this.get('id'),
-            userId: userId
+            userId: userId,
+            fullName: fullName,
+            email: email
         });
+
         return contrib.save();
     },
 

--- a/addon/models/node.js
+++ b/addon/models/node.js
@@ -153,17 +153,6 @@ export default OsfModel.extend(FileItemMixin, {
         return child.save();
     },
 
-    addUnregisteredContributor(fullName, email, permission, isBibliographic, index = Number.MAX_SAFE_INTEGER) {
-        let user = this.store.createRecord('user', {
-            fullName: fullName,
-            username: email
-        });
-        // After user has been saved, add user as a contributor
-        return user.save().then(user => this.addContributor(user.id, permission, isBibliographic, index));
-
-    },
-
-    addContributor(userId, permission, isBibliographic, index = Number.MAX_SAFE_INTEGER) {
     addContributor(userId, permission, isBibliographic, fullName, email, index = Number.MAX_SAFE_INTEGER) {
         let contrib = this.store.createRecord('contributor', {
             index: index,

--- a/addon/serializers/contributor.js
+++ b/addon/serializers/contributor.js
@@ -6,9 +6,13 @@ export default OsfSerializer.extend({
         // Restore relationships to serialized data
         var serialized = this._super(snapshot, options);
 
-        var opts = {
-            includeUser: true
-        };
+        var opts = {};
+
+        if (snapshot.record.get('isNew')) {
+            opts = {
+                includeUser: true
+            };
+        }
         Ember.merge(opts, options);
 
         // APIv2 expects contributor information to be nested under relationships.


### PR DESCRIPTION
# Purpose

Accommodates API changes to how unregistered contributors are created, https://github.com/CenterForOpenScience/osf.io/pull/6157.

Fixes PATCH contributors, (updating permissions/bibliographic, reordering contribs were not working because user id instead of contrib id in response).

# Notes for Reviewers

## Routes Added/Updated


