### PR TITLE
Feature/Remove File Header from File Browser Component

### DIFF
--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -1,6 +1,3 @@
-<div class='file-browser-header'>
-    <h3>Files</h3>
-</div>
 <ol class='breadcrumb'>
     {{#each breadcrumbs as |item|}}
         <li>

--- a/addon/models/node.js
+++ b/addon/models/node.js
@@ -153,9 +153,8 @@ export default OsfModel.extend(FileItemMixin, {
         return child.save();
     },
 
-    addContributor(userId, permission, isBibliographic, fullName, email, index = Number.MAX_SAFE_INTEGER) {
+    addContributor(userId, permission, isBibliographic, fullName, email) {
         let contrib = this.store.createRecord('contributor', {
-            index: index,
             permission: permission,
             bibliographic: isBibliographic,
             nodeId: this.get('id'),


### PR DESCRIPTION
# Purpose

- Removes "File" header from file-browser component. User should be able to determine their own label.

- Remove index from addContributor action.  More work will be needed ember side to support index on create.
