### PR TITLE
Add service option to navbar template

### DIFF
--- a/addon/components/osf-navbar/style.scss
+++ b/addon/components/osf-navbar/style.scss
@@ -3,3 +3,9 @@
     border-radius: 13px;
     margin-right: 5px;
 }
+
+a.navbar-service::before {
+    content: "/";
+    padding-right: 8px;
+    color: #ccc;
+}

--- a/addon/components/osf-navbar/template.hbs
+++ b/addon/components/osf-navbar/template.hbs
@@ -17,6 +17,9 @@
                 {{/unless}}
                 <a class="navbar-brand hidden-sm hidden-xs" href="/"><span class="osf-navbar-logo" width="27"></span> Open Science Framework</a>
                 <a class="navbar-brand visible-sm visible-xs" href="/"><span class="osf-navbar-logo" width="27"></span> OSF</a>
+                {{#if service}}
+                    <a class="navbar-brand navbar-service" href="{{serviceUrl}}"> {{service}}</a>
+                {{/if}}
             </div>
             <div id="navbar" class="navbar-collapse collapse navbar-right">
                 <ul class="nav navbar-nav">


### PR DESCRIPTION
# Purpose
Add option to navigation bar to show link to Service if a service exists; such as Preprints

# Notes for Reviewers
Initial implementation to work with Preprints. May need further considerations down the line. 
Should not affect the cases where no service is provided 

## Routes Added/Updated
None


