### PR TITLE
Use custom OSF signup page URL

### DIFF
--- a/addon/components/osf-navbar/component.js
+++ b/addon/components/osf-navbar/component.js
@@ -11,15 +11,13 @@ import config from 'ember-get-config';
  * Display the OSF navbar
  *
  * Sample usage:
- * {{osf-navbar loginAction=loginAction}}
- *
- * @class osf-navbar
- * Sample usage:
  * ```handlebars
  * {{osf-navbar
- *   hideSearch=true
- *  }}
+ *   loginAction=loginAction
+ *   hideSearch=true}}
  * ```
+ *
+ * @class osf-navbar
  */
 export default Ember.Component.extend({
     layout,
@@ -32,6 +30,15 @@ export default Ember.Component.extend({
      * @type {Boolean}
      */
     hideSearch: false,
+
+    /**
+     * The URL to use for signup. May be overridden, eg for special campaign pages
+     *
+     * @property signupUrl
+     * @type {String}
+     */
+    signupUrl: config.OSF.url + 'register',
+
     gravatarUrl: Ember.computed('user', function() {
         let imgLink = this.get('user.links.profile_image');
         if (imgLink) {

--- a/addon/components/osf-navbar/template.hbs
+++ b/addon/components/osf-navbar/template.hbs
@@ -91,7 +91,7 @@
                         {{else}}
                             <li class="dropdown sign-in">
                                 <div class="col-sm-12">
-                                    <a href="/register/" class="btn btn-success btn-top-signup m-r-xs">Sign Up</a>
+                                    <a href="{{signupUrl}}" class="btn btn-success btn-top-signup m-r-xs">Sign Up</a>
                                     <a {{action loginAction}} class="btn btn-info btn-top-signup m-r-xs">Sign in</a>
                                 </div>
                             </li>


### PR DESCRIPTION
# Purpose
Let users customize url used for navbar signup button.

(default url is still the normal OSF register page)