### PR TITLE
Add the ability to pass along sendEmail=False when adding a contributor

### DIFF
--- a/addon/adapters/contributor.js
+++ b/addon/adapters/contributor.js
@@ -7,7 +7,7 @@ export default OsfAdapter.extend({
             var sendEmail = true;
             if (snapshot) {
                 nodeId = snapshot.record.get('nodeId');
-                sendEmail = snapshot.record.get('sendEmail')
+                sendEmail = snapshot.record.get('sendEmail');
             } else {
                 nodeId = id.split('-').shift();
             }

--- a/addon/adapters/contributor.js
+++ b/addon/adapters/contributor.js
@@ -4,8 +4,10 @@ export default OsfAdapter.extend({
     buildURL(modelName, id, snapshot, requestType) { // jshint ignore:line
         if (requestType === 'createRecord' || requestType === 'findRecord') {
             var nodeId;
+            var sendEmail = true;
             if (snapshot) {
                 nodeId = snapshot.record.get('nodeId');
+                sendEmail = snapshot.record.get('sendEmail')
             } else {
                 nodeId = id.split('-').shift();
             }
@@ -21,8 +23,14 @@ export default OsfAdapter.extend({
                     return `${base}${id.split('-').pop()}/`;
                 }
 
+                var requestUrl = `${base}?embed=node`;
+
+                if (!sendEmail) {
+                    requestUrl += `&send_email=false`;
+                }
+
                 // Needed for Ember Data to update the inverse record's (the node's) relationship
-                return `${base}?embed=node`;
+                return requestUrl;
             } else {
                 throw new Error('Trying to add a contributor to a Node that hasn\'t been loaded into the store');
             }

--- a/addon/adapters/contributor.js
+++ b/addon/adapters/contributor.js
@@ -23,13 +23,13 @@ export default OsfAdapter.extend({
                     return `${base}${id.split('-').pop()}/`;
                 }
 
+                // Needed for Ember Data to update the inverse record's (the node's) relationship
                 var requestUrl = `${base}?embed=node`;
 
                 if (!sendEmail) {
                     requestUrl += `&send_email=false`;
                 }
 
-                // Needed for Ember Data to update the inverse record's (the node's) relationship
                 return requestUrl;
             } else {
                 throw new Error('Trying to add a contributor to a Node that hasn\'t been loaded into the store');

--- a/addon/mixins/node-actions.js
+++ b/addon/mixins/node-actions.js
@@ -102,9 +102,10 @@ export default Ember.Mixin.create({
          * @param {String} userId ID of user that will be a contributor on the node
          * @param {String} permission User permission level. One of "read", "write", or "admin". Default: "write".
          * @param {Boolean} isBibliographic Whether user will be included in citations for the node. "default: true"
+         * @param {Boolean} sendEmail Whether user will receive an email when added. "default: true"
          * @return {Promise} Returns a promise that resolves to the newly created contributor object.
          */
-        addContributor(userId, permission, isBibliographic) { // jshint ignore:line
+        addContributor(userId, permission, isBibliographic, sendEmail) { // jshint ignore:line
             return this.get('_node').addContributor(...arguments);
         },
         /**

--- a/addon/models/contributor.js
+++ b/addon/models/contributor.js
@@ -50,6 +50,7 @@ export default OsfModel.extend({
     index: DS.attr('number'),
     fullName: DS.attr('string'),
     email: DS.attr('string'),
+    sendEmail: DS.attr('boolean'),
 
     node: DS.belongsTo('node', {
         inverse: 'contributors'

--- a/addon/models/node.js
+++ b/addon/models/node.js
@@ -153,10 +153,11 @@ export default OsfModel.extend(FileItemMixin, {
         return child.save();
     },
 
-    addContributor(userId, permission, isBibliographic, fullName, email) {
+    addContributor(userId, permission, isBibliographic, sendEmail, fullName, email) {
         let contrib = this.store.createRecord('contributor', {
             permission: permission,
             bibliographic: isBibliographic,
+            sendEmail: sendEmail,
             nodeId: this.get('id'),
             userId: userId,
             fullName: fullName,

--- a/tests/dummy/app/components/contrib-manager/component.js
+++ b/tests/dummy/app/components/contrib-manager/component.js
@@ -11,8 +11,8 @@ export default Ember.Component.extend({
     permissionChanges: {},
     bibliographicChanges: {},
     actions: {
-        addContributor(userId, permission, isBibliographic) {
-            this.sendAction('addContributor', userId, permission, isBibliographic);
+        addContributor(userId, permission, isBibliographic, sendEmail) {
+            this.sendAction('addContributor', userId, permission, isBibliographic, sendEmail);
         },
         removeContributor(contrib) {
             this.sendAction('removeContributor', contrib);


### PR DESCRIPTION
## Ticket
Vaguely related to Preprints Ticket - https://openscience.atlassian.net/browse/PREP-130

# Purpose
Preprints needed the ability to send an email to preprint authors after the whole preprint process has been completed, which does not happen until after a normal project has been created and contributors added to it. So, we needed a way to pass along OSF API v2's query parameter `send_email=False` when creating a contributor from Ember OSF through the preprints interface! 

Then, the email can be sent after the whole preprint process is completed, and users unfamiliar with the OSF can receive an email with language about the preprint and not an unanticipated "project."

# Notes for Reviewers
- I am very new to ember, so style, testing, really any improvement pointers welcome!
- I also may very well have broken other places within ember OSF that use the addContributor method (tho I tried to cover the bases). Is there a way to add a default parameter? This has been locally tested with ember-preprints, but have not done functional testing on ember-osf. 
- Does SHARE call this method ever? In its curation interface maybe?

## Routes Added/Updated
- Adapter for contributor to pass along `?send_email=false` when adding a contributor with that set.
- send along the query parameter in the node-actions mixin
- `sendEmail` added to the contributor model
- pass along `sendEmail` in the node model
- also in the contrib-manager component test