### PR TITLE
Hacky fix for logout race condition

### DIFF
--- a/addon/authenticators/osf-cookie.js
+++ b/addon/authenticators/osf-cookie.js
@@ -41,14 +41,17 @@ export default Base.extend({
      * @method invalidate
      */
     invalidate(data) {
-        // If the user is logged in and data is not a response with the status unauthorized
-        // Actually log them out
-        if (data.id && data.status !== 401) {
+        if (!data || data.id && data.status !== 401) {
+            // If invalidate is called when loading the page to check if a cookie has permissions, don't redirect the user
+            // But if invalidate is called without arguments, or for any other reason, interpret this as a straight logout request
+            //   (and let the session get invalidated next time at the start of first page load)
             // Can't do this via AJAX request because it redirects to CAS, and AJAX + redirect = CORS issue
             window.location = `${config.OSF.url}logout/`;
+        } else {
+            // This branch is expected to be called when a test request reveals the user to lack permissions... so session should be wiped
+            return Ember.RSVP.resolve();
         }
-
-        return Ember.RSVP.resolve();
+        // FIXME: Possible race condition where returning resolved promise after window.location change calls logout to fail
     },
     /**
      * For now, simply verify that a token is present and can be used


### PR DESCRIPTION
# Purpose
Fix an issue with cookie auth, where clicking logout button in the OSF navbar reloaded the page, but did not invalidate the session.

# Notes on the issue
This fix is kind of a hack. It seems to be a race condition. The code hits the `window.location` branch of the if statement, then goes to the next line with a resolved promise- and upon resolution, the navbar logout action happens to call `window.location.reload`.

This fix tells simple-auth to stop the normal invalidation process if redirecting (so that the redirect is actually the last line of code to be run, and it does not move on and obey a reload instead)

At last check this reload was the easiest way to ensure state was cleaned up for both token and cookie auth- clean reset of the page. In any event, since this seems to be a race condition, the authenticator has to deal with never really knowing *what* someone does after the resolution of `.invalidate`.

# Situations to test
1. Log in to the OSF, then click "log out" on the navbar. The user should be logged out correctly.
2. Log in to the ember app. In another window, log out of the OSF. When the ember app is reloaded (refreshed), it should clear the session on next page load- hence the navbar will correctly show the user as logged out.

# Open questions
Testing revealed another issue (which always existed):
- Since we validate the cookie at first page load, if the user logs out via the flask app in another window, the ember app must be reloaded before the app realizes that the user is logged out
- Trying to do something on a logged out page seems to yank the user to the goodbye page, which is strange