### PR TITLE
Feature/Manually update store as reordering contributors

### DIFF
--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -38,7 +38,7 @@ export default Ember.Component.extend({
         let drop = new Dropzone(`#${this.elementId}`, {  // jshint ignore:line
             url: file => typeof this.get('buildUrl') === 'function' ? this.get('buildUrl')(file) : this.get('buildUrl'),
             autoProcessQueue: false,
-            dictDefaultMessage: this.get('defaultMessage') || "Drop files here to upload"
+            dictDefaultMessage: this.get('defaultMessage') || 'Drop files here to upload'
         });
 
         // Set osf session header

--- a/addon/mixins/cas-authenticated-route.js
+++ b/addon/mixins/cas-authenticated-route.js
@@ -38,9 +38,7 @@ export default Ember.Mixin.create({
         if (!this.get('session.isAuthenticated')) {
             // Reference: http://stackoverflow.com/a/39054607/414097
             let routing = this.get('routing');
-            let params = Object.values(transition.params).filter(param => {
-                return Object.values(param).length;
-            });
+            let params = Object.values(transition.params).filter(param => Object.values(param).length);
             let url = routing.generateURL(transition.targetName, params, transition.queryParams);
             window.location = getAuthUrl(url);
         } else {

--- a/addon/mixins/node-actions.js
+++ b/addon/mixins/node-actions.js
@@ -166,7 +166,7 @@ export default Ember.Mixin.create({
                             permission: contrib.get('permission'),
                             bibliographic: contrib.get('bibliographic'),
                             index: index
-                        }
+                        };
                         payload.data.id = contrib.get('id');
                         this.store.pushPayload(payload);
                     }

--- a/addon/utils/auth.js
+++ b/addon/utils/auth.js
@@ -40,7 +40,7 @@ function getOAuthUrl(nextUri) {
  */
 function getCookieAuthUrl(nextUri) {
     nextUri = nextUri || config.OSF.redirectUri;
-    let loginUri = `${config.OSF.url}login?next=${encodeURIComponent(nextUri)}`
+    let loginUri = `${config.OSF.url}login?next=${encodeURIComponent(nextUri)}`;
     return `${config.OSF.cookieLoginUrl}?service=${encodeURIComponent(loginUri)}`;
 }
 


### PR DESCRIPTION
❗ Needed for https://github.com/CenterForOpenScience/ember-preprints/pull/113
# Purpose

APIv2 reordering contributor only takes in contributor you are modifying and that contributor's new index.  Ember store was only being updated with that particular contributor's index - no other contributors were changing which could lead to this case:

![screen shot 2016-08-29 at 7 11 50 am](https://cloud.githubusercontent.com/assets/9755598/18054392/9effa738-6dd1-11e6-825d-41aa613aec71.png)

So one index is correct, the other is incorrect. 

# Changes
Manually updates remaining contributors in the store with correct index.  Thanks to @samchrisinger for talking through this with me.


# Notes for Reviewers

## Routes Added/Updated



