### PR TITLE
Feature/Add Scrolling to File Renderer

### DIFF
--- a/addon/components/file-renderer/template.hbs
+++ b/addon/components/file-renderer/template.hbs
@@ -1,4 +1,4 @@
 {{#if download}}
-    <iframe src={{mfrUrl}} width={{width}} height={{height}} scrolling="no" marginheight="0" frameborder="0">
+    <iframe src={{mfrUrl}} width={{width}} height={{height}} scrolling="yes" marginheight="0" frameborder="0">
     </iframe>
 {{/if}}


### PR DESCRIPTION
## Ticket
https://trello.com/c/Rv8Flwut/144-txt-file-on-preprint-not-rendering-properly
# Purpose

Text files are getting cut off. Quick fix is to add scrolling to file renderer. Next steps will add dynamically resizing height based on height of content.

# Notes for Reviewers

## Routes Added/Updated


