### PR TITLE
Add allowfullscreen as default in file-renderer [PREP-147]

### DIFF
--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -23,7 +23,7 @@ export default Ember.Component.extend({
     download: null,
     width: '100%',
     height: '100%',
-    allowfullscreen : true,
+    allowfullscreen: true,
     mfrUrl: Ember.computed('download', function() {
         var base = config.OSF.renderUrl;
         var download = this.get('download');

--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -14,7 +14,7 @@ import config from 'ember-get-config';
  * ```handlebars
  * {{file-renderer
  *   download=model.links.download
- *     width="800" height="1000"}}
+ *     width="800" height="1000" allowfullscreen=true}}
  * ```
  * @class file-renderer
  */

--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -23,6 +23,7 @@ export default Ember.Component.extend({
     download: null,
     width: '100%',
     height: '100%',
+    allowfullscreen : true,
     mfrUrl: Ember.computed('download', function() {
         var base = config.OSF.renderUrl;
         var download = this.get('download');

--- a/addon/components/file-renderer/template.hbs
+++ b/addon/components/file-renderer/template.hbs
@@ -1,4 +1,4 @@
 {{#if download}}
-    <iframe src={{mfrUrl}} width={{width}} height={{height}} scrolling="yes" marginheight="0" frameborder="0">
+    <iframe src={{mfrUrl}} width={{width}} height={{height}} scrolling="yes" marginheight="0" frameborder="0" allowfullscreen={{allowfullscreen}}>
     </iframe>
 {{/if}}


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/PREP-147

# Purpose
It looks like the mfr options do not include allowing full screen as default. This is useful for preprints and I think it would be a good default to have. 

# Notes for Reviewers
I don't know if the optionality of this needs to be worked out more. I did add it as a variable and did not hard code it in but it's the default. 

## Routes Added/Updated
NA



