### PR TITLE
[Ready to Review] Feature/Embed Root and Parent on User Nodes

### DIFF
--- a/addon/adapters/user.js
+++ b/addon/adapters/user.js
@@ -1,4 +1,24 @@
 import OsfAdapter from './osf-adapter';
+import Ember from 'ember';
 
 export default OsfAdapter.extend({
+    findHasMany(store, snapshot, url, relationship) {
+        var id = snapshot.id;
+        var type = snapshot.modelName;
+
+        url = this.urlPrefix(url, this.buildURL(type, id, null, 'findHasMany'));
+
+        // If fetching user nodes, will embed root and parent.
+        if (relationship.type === 'node') {
+            var embedParams = 'embed=parent&embed=root';
+            if (snapshot.record.get('query-params')) {
+                var queryParams = Ember.$.param(snapshot.record.get('query-params'));
+                url += '?' + queryParams;
+                url += '&' + embedParams;
+            } else {
+                url += '?' + embedParams;
+            }
+        }
+        return this.ajax(url, 'GET');
+    }
 });

--- a/addon/adapters/user.js
+++ b/addon/adapters/user.js
@@ -10,13 +10,9 @@ export default OsfAdapter.extend({
 
         // If fetching user nodes, will embed root and parent.
         if (relationship.type === 'node') {
-            var embedParams = 'embed=parent&embed=root';
+            url +='?embed=parent&embed=root';
             if (snapshot.record.get('query-params')) {
-                var queryParams = Ember.$.param(snapshot.record.get('query-params'));
-                url += '?' + queryParams;
-                url += '&' + embedParams;
-            } else {
-                url += '?' + embedParams;
+                url += '&' + Ember.$.param(snapshot.record.get('query-params'));
             }
         }
         return this.ajax(url, 'GET');

--- a/addon/adapters/user.js
+++ b/addon/adapters/user.js
@@ -10,7 +10,7 @@ export default OsfAdapter.extend({
 
         // If fetching user nodes, will embed root and parent.
         if (relationship.type === 'node') {
-            url +='?embed=parent&embed=root';
+            url += '?embed=parent&embed=root';
             if (snapshot.record.get('query-params')) {
                 url += '&' + Ember.$.param(snapshot.record.get('query-params'));
             }

--- a/addon/adapters/user.js
+++ b/addon/adapters/user.js
@@ -6,7 +6,7 @@ export default OsfAdapter.extend({
         var id = snapshot.id;
         var type = snapshot.modelName;
 
-        url = this.urlPrefix(url, this.buildURL(type, id, null, 'findHasMany'));
+        url = this.urlPrefix(url, this.buildURL(type, id, snapshot, 'findHasMany'));
 
         // If fetching user nodes, will embed root and parent.
         if (relationship.type === 'node') {

--- a/addon/models/osf-model.js
+++ b/addon/models/osf-model.js
@@ -17,6 +17,7 @@ import HasManyQuery from 'ember-data-has-many-query';
 export default DS.Model.extend(HasManyQuery.ModelMixin, {
     links: DS.attr('links'),
     embeds: DS.attr('embed'),
+    errors: DS.attr(),
 
     relationshipLinks: Ember.computed.alias('links.relationships'),
     _dirtyRelationships: null,

--- a/addon/models/osf-model.js
+++ b/addon/models/osf-model.js
@@ -17,7 +17,6 @@ import HasManyQuery from 'ember-data-has-many-query';
 export default DS.Model.extend(HasManyQuery.ModelMixin, {
     links: DS.attr('links'),
     embeds: DS.attr('embed'),
-    errors: DS.attr(),
 
     relationshipLinks: Ember.computed.alias('links.relationships'),
     _dirtyRelationships: null,

--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -39,7 +39,7 @@ export default DS.JSONAPISerializer.extend({
                 continue;
             }
             //TODO Pagination probably breaks here
-            let data = resourceHash.embeds[embedded].data;
+            let data = resourceHash.embeds[embedded].data || resourceHash.embeds[embedded];
             if (Array.isArray(data)) {
                 included = included.concat(data);
             } else {

--- a/addon/utils/load-relationship.js
+++ b/addon/utils/load-relationship.js
@@ -15,10 +15,9 @@ export default function loadAll(model, relationship, dest, options = {}) {
         var pageSize = results.meta.pagination.per_page;
         var remaining = total - (page * pageSize);
         if (remaining > 0) {
-            return loadAll(model, relationship, dest, {
-                'page[size]': pageSize,
-                page: page + 1
-            });
+            query.page = page + 1;
+            query['page[size]'] = pageSize;
+            return loadAll(model, relationship, dest, query);
         }
     });
 }

--- a/addon/utils/load-relationship.js
+++ b/addon/utils/load-relationship.js
@@ -7,7 +7,7 @@ export default function loadAll(model, relationship, dest, options = {}) {
         page: page
     };
     query = Ember.merge(query, options || {});
-    model.set('query-params', query);
+    Ember.set(model, 'query-params', query);
 
     return model.query(relationship, query).then(results => {
         dest.pushObjects(results.toArray());

--- a/addon/utils/load-relationship.js
+++ b/addon/utils/load-relationship.js
@@ -7,6 +7,7 @@ export default function loadAll(model, relationship, dest, options = {}) {
         page: page
     };
     query = Ember.merge(query, options || {});
+    model.set('query-params', query);
 
     return model.query(relationship, query).then(results => {
         dest.pushObjects(results.toArray());


### PR DESCRIPTION
## Ticket

Needed for https://github.com/CenterForOpenScience/ember-preprints/pull/141

Selecting existing project for preprints - need to get format to resemble dashboard format.  For example,  Project / ... / Private / Component, instead of Component".  

# Purpose

Changes 
- [x] Initial query params were not getting passed into subsequent recursive calls on loadAll
- [x] Allow user to embed both root and parent when fetching userNodes 
- [x]  Allow embedding of data with errors (for example fetching private parent)
- [x] Allow discernment of whether not request failed with 403 or 404. (This is so I can distinguish whether a parent doesn't exist or it's private in preprints and can be formatted appropriately. (@hmoco's ember-preprints changes take care of this so you don't need to distinguish between errors)

# Notes for Reviewers

## Routes Added/Updated


