### PR TITLE
Separate tags in the model when pasted as a comma-delmited list [PREP-155]

### DIFF
--- a/addon/components/tags-widget/component.js
+++ b/addon/components/tags-widget/component.js
@@ -62,8 +62,13 @@ export default Ember.Component.extend({
 
     actions: {
         addATag(tag) {
+            const splitTags = tag
+                .split(/[,]+/)
+                .map(item => item.trim());
+
             // Calls a curried closure action which was provided the model
-            this.attrs.addATag(tag);
+            for (let splitTag of splitTags)
+                this.attrs.addATag(splitTag);
         },
         removeATag(tag) {
             // Don't try to delete a blank tag (would result in a server error)


### PR DESCRIPTION
# Purpose
This is to fix the preprint submission form for pasting multiple tags in a comma-delimited list. 

# Notes for Reviewers
The bug is detailed in PREP-155. It is not apparent until the Preprint is submitted.

To link the project for Preprints locally:
```bash
cd $PROJECT_DIR/ember-osf && npm link
cd $PROJECT_DIR/ember-preprints && npm link ember-osf
ember serve
```

it should now have the tags separated out when you submit a preprint after pasting a comma-delimited list of tags:
![image](https://cloud.githubusercontent.com/assets/3374510/18961880/85eafe5e-863c-11e6-936d-a7dc18e53a83.png)



