### PR TITLE
HOLD+WIP - OSF file detail page in ember

### DIFF
--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -21,13 +21,16 @@ import config from 'ember-get-config';
 export default Ember.Component.extend({
     layout,
     download: null,
+    version: null,
     width: '100%',
     height: '100%',
     allowfullscreen: true,
-    mfrUrl: Ember.computed('download', function() {
-        var base = config.OSF.renderUrl;
-        var download = this.get('download');
-        var renderUrl = base + '?url=' + encodeURIComponent(download + '?direct&mode=render&initialWidth=766');
-        return renderUrl;
+    mfrUrl: Ember.computed('download', 'version', function() {
+        const base = config.OSF.renderUrl;
+        const download = this.get('download');
+        const version = this.get('version') ? `&version=${this.get('version')}` : '';
+        const url = encodeURIComponent(`${download}?direct&mode=render&initialWidth=766${version}`);
+
+        return `${base}?url=${url}`;
     })
 });

--- a/addon/components/file-version/component.js
+++ b/addon/components/file-version/component.js
@@ -22,9 +22,33 @@ export default Ember.Component.extend({
     classNames: ['file-version'],
     tagName: 'tr',
 
+    classNameBindings: ['isActive:active'],
+
+    isActive: Ember.computed('version.id', 'activeVersion', function() {
+        return this.get('version.id') === this.get('activeVersion');
+    }),
+
     actions: {
         downloadVersion(version) {
             this.sendAction('download', version);
+        },
+
+        copy(className) {
+            this.$(`.${className}`).select();
+            document.execCommand('copy');
         }
+    },
+
+    didInsertElement: function() {
+        Ember.run.scheduleOnce('afterRender', this, function() {
+            // console.log(this.$('.fa-question-circle').popover());
+            this.$('.fa-question-circle')
+                .each(function() {
+                    $(this).popover();
+                });
+            // this.$('button[data-clipboard-text]').on('click', () => {
+            //     console.log('test');
+            // });
+        });
     }
 });

--- a/addon/components/file-version/template.hbs
+++ b/addon/components/file-version/template.hbs
@@ -1,3 +1,52 @@
-<td>{{version.id}}</td>
-<td>{{version.size}}</td>
-<td><button {{action 'downloadVersion' version.id}}>{{fa-icon 'download'}}</button></td>
+<td>
+    {{#if isActive}}
+        {{version.id}}
+    {{else}}
+        {{#link-to 'file-detail' (query-params version=version.id)}}{{version.id}}{{/link-to}}
+    {{/if}}
+</td>
+<td>{{date-format version.dateModified}}</td>
+<td><a href="/{{version.creator.id}}/">{{version.creator.fullName}}</a></td>
+<td>
+    <div class="badge">{{version.extra.downloads}}</div>
+</td>
+<td>
+    <button {{action 'downloadVersion' version.id}}
+            class="btn btn-primary btn-sm file-download">
+        {{fa-icon 'download'}}
+    </button>
+</td>
+<td>
+    <div style="width: 180px;" class="input-group">
+        <span class="input-group-btn">
+            <button type="button"
+                    class="btn btn-default btn-sm"
+                    data-clipboard-text={{version.extra.hashes.md5}}
+                    {{action 'copy' 'md5'}}>
+                <div class="fa fa-copy"></div>
+            </button>
+        </span>
+        <input type="text"
+               class="md5"
+               readonly="readonly"
+               style="float:left; height: 30px;"
+               value={{version.extra.hashes.md5}}>
+    </div>
+</td>
+<td>
+    <div style="width: 180px;" class="input-group">
+        <span class="input-group-btn">
+            <button type="button"
+                    class="btn btn-default btn-sm"
+                    data-clipboard-text={{version.extra.hashes.sha256}}
+                    {{action 'copy' 'sha256'}}>
+                <div class="fa fa-copy"></div>
+            </button>
+        </span>
+        <input type="text"
+               class="sha256"
+               readonly="readonly"
+               style="float:left; height: 30px;"
+               value={{version.extra.hashes.sha256}}>
+    </div>
+</td>

--- a/addon/helpers/date-format.js
+++ b/addon/helpers/date-format.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+/**
+ * @module ember-osf
+ * @submodule helpers
+ */
+
+/**
+ * Generate a unique HTML element ID for this element. Given "someid" for component instance 123, returns "ember123-someid"
+ *
+ * Useful to ensure unique IDs, eg for when component is reused in page.
+ * @class date-format
+ * @param {Ember.Object} obj The instance with ID to use
+ * @param {Ember.suffix} suffix The base attribute to name
+ */
+export function dateFormat(date) {
+    return new Date(date).toLocaleString();
+}
+
+export default Ember.Helper.helper(dateFormat);

--- a/addon/models/file-version.js
+++ b/addon/models/file-version.js
@@ -17,5 +17,10 @@ import OsfModel from './osf-model';
 */
 export default OsfModel.extend({
     size: DS.attr('number'),
-    contentType: DS.attr('string')
+    contentType: DS.attr('string'),
+    dateModified: DS.attr('date'),
+    extra: DS.attr(),
+    creator: DS.belongsTo('user', {
+        inverse: null
+    })
 });

--- a/addon/services/file-manager.js
+++ b/addon/services/file-manager.js
@@ -354,17 +354,21 @@ export default Ember.Service.extend({
             this._reloadingUrls[reloadUrl] = true;
         }
 
-        return model.reload().then((freshModel) => {
-            if (reloadUrl) {
-                delete this._reloadingUrls[reloadUrl];
-            }
-            return freshModel;
-        }).catch((error) => {
-            if (reloadUrl) {
-                delete this._reloadingUrls[reloadUrl];
-            }
-            throw error;
-        });
+        model.get('versions').reload();
+
+        return model.reload()
+            .then((freshModel) => {
+                if (reloadUrl) {
+                    delete this._reloadingUrls[reloadUrl];
+                }
+                return freshModel;
+            })
+            .catch((error) => {
+                if (reloadUrl) {
+                    delete this._reloadingUrls[reloadUrl];
+                }
+                throw error;
+            });
     },
 
     /**

--- a/app/helpers/date-format.js
+++ b/app/helpers/date-format.js
@@ -1,0 +1,1 @@
+export { default, dateFormat } from 'ember-osf/helpers/date-format';


### PR DESCRIPTION
# Purpose

Porting OSF (Flask/Mithril) file view page to Ember. These changes coincide with **pattisdr/osf.io#7**. The APIv2 changes are required the file-version model to pull the in the correct data. 
# Notes for Reviewers

The file version view should behave like the ember-view
