### PR TITLE
Bump version & remove legacy doc deployment process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-osf",
-  "version": "0.0.1",
-  "description": "Ember Data models for the OSF APIv2",
+  "version": "0.1.0",
+  "description": "Reusable ember models and components for interacting with the Open Science Framework",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -9,7 +9,6 @@
   "scripts": {
     "build": "ember build",
     "docs": "yuidoc",
-    "docs-deploy": "yuidoc && ghp-import -r origin -p -b gh-pages docs/",
     "start": "ember server",
     "test": "ember test",
     "check-style": "./node_modules/jscs/bin/jscs ."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-ghp-import


### PR DESCRIPTION
# Purpose
- Bump version to match release tags on master
- Remove usage of a python script that deployed docs to gh-pages; we now commit directly to `docs/` folder of master branch instead.

