### PR TITLE
Update link for [PREP-244]

### DIFF
--- a/addon/components/osf-copyright/template.hbs
+++ b/addon/components/osf-copyright/template.hbs
@@ -3,7 +3,7 @@
         <div class="col-md-12">
             <p>
                 Copyright &copy; 2011-2016
-                <a href="http://centerforopenscience.org">Center for Open Science</a> |
+                <a href="https://cos.io">Center for Open Science</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms of Use</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
             </p>


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/PREP-244

# Purpose
See ticket

# Notes for Reviewers
`Center for Open Science` now goes to https://cos.io instead of http://centerforopenscience.org



