### PR TITLE
Add ability to have a redirect url after logout [PREP-253]

### DIFF
--- a/addon/authenticators/osf-cookie.js
+++ b/addon/authenticators/osf-cookie.js
@@ -51,8 +51,7 @@ export default Base.extend({
             // Can't do this via AJAX request because it redirects to CAS, and AJAX + redirect = CORS issue
 
             // Manually clear session before user leaves the page, since we aren't sticking around for ESA to do so later
-            this.get('session.session')._clear(true)
-                .then(() => window.location = `${config.OSF.url}logout/`);
+            return this.get('session.session')._clear(true);
         } else {
             // This branch is expected to be called when a test request reveals the user to lack permissions... so session should be wiped
             return Ember.RSVP.resolve();

--- a/addon/components/navbar-auth-dropdown/component.js
+++ b/addon/components/navbar-auth-dropdown/component.js
@@ -17,7 +17,7 @@ import config from 'ember-get-config';
  *   redirectUrl=redirectUrl}}
  * ```
  *
- * @class osf-navbar
+ * @class navbar-auth-dropdown
  */
 export default Ember.Component.extend({
     layout,
@@ -62,8 +62,8 @@ export default Ember.Component.extend({
     enableInstitutions: true,
     actions: {
         logout() {
-            const redirect_url = this.get('redirectUrl');
-            const query = redirect_url ? '?' + Ember.$.param({redirect_url}) : '';
+            const redirectUrl = this.get('redirectUrl');
+            const query = redirectUrl ? '?' + Ember.$.param({ redirect_url: redirectUrl }) : '';
             // TODO: May not work well if logging out from page that requires login- check?
             this.get('session').invalidate()
                 .then(() => window.location.href = `${config.OSF.url}logout/${query}`);

--- a/addon/components/navbar-auth-dropdown/component.js
+++ b/addon/components/navbar-auth-dropdown/component.js
@@ -13,7 +13,8 @@ import config from 'ember-get-config';
  * Sample usage:
  * ```handlebars
  * {{navbar-auth-dropdown
- *   loginAction=loginAction}}
+ *   loginAction=loginAction
+ *   redirectUrl=redirectUrl}}
  * ```
  *
  * @class osf-navbar
@@ -27,6 +28,7 @@ export default Ember.Component.extend({
     classNames: ['dropdown'],
     classNameBindings: ['notAuthenticated:sign-in'],
     notAuthenticated: Ember.computed.not('session.isAuthenticated'),
+    redirectUrl: null,
 
     /**
      * The URL to use for signup. May be overridden, eg for special campaign pages
@@ -60,8 +62,11 @@ export default Ember.Component.extend({
     enableInstitutions: true,
     actions: {
         logout() {
+            const redirect_url = this.get('redirectUrl');
+            const query = redirect_url ? '?' + Ember.$.param({redirect_url}) : '';
             // TODO: May not work well if logging out from page that requires login- check?
-            this.get('session').invalidate();
+            this.get('session').invalidate()
+                .then(() => window.location.href = `${config.OSF.url}logout/${query}`);
         },
     }
 });

--- a/addon/utils/auth.js
+++ b/addon/utils/auth.js
@@ -40,7 +40,7 @@ function getOAuthUrl(nextUri) {
  */
 function getCookieAuthUrl(nextUri) {
     nextUri = nextUri || config.OSF.redirectUri;
-    let loginUri = `${config.OSF.url}login?next=${encodeURIComponent(nextUri)}`;
+    const loginUri = `${config.OSF.url}login/?next=${encodeURIComponent(nextUri)}`;
     return `${config.OSF.cookieLoginUrl}?service=${encodeURIComponent(loginUri)}`;
 }
 


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/PREP-253

# Purpose
Needed for branded preprints redirects

# Notes for Reviewers
* redirect_url is appended to the logout page as a query param, if the value is set on the component. If not, it goes to the default logout page
* Add trailing slash after login for the login uri

## Routes Added/Updated
N/A

## Related
CenterForOpenScience/ember-preprints#190

