### PR TITLE
Feature/Upgrade to use APIv2.3 [PREP-246]

### DIFF
--- a/addon/adapters/osf-adapter.js
+++ b/addon/adapters/osf-adapter.js
@@ -23,6 +23,9 @@ import {
  * @uses GenericDataAdapterMixin
  */
 export default DS.JSONAPIAdapter.extend(HasManyQuery.RESTAdapterMixin, GenericDataAdapterMixin, {
+    headers: {
+        'ACCEPT':'application/vnd.api+json; version=2.3'
+    },
     authorizer: config['ember-simple-auth'].authorizer,
     host: config.OSF.apiUrl,
     namespace: config.OSF.apiNamespace,

--- a/addon/adapters/osf-adapter.js
+++ b/addon/adapters/osf-adapter.js
@@ -223,7 +223,7 @@ export default DS.JSONAPIAdapter.extend(HasManyQuery.RESTAdapterMixin, GenericDa
             data: data,
             isBulk: isBulk
         }).then(res => {
-            if (!Ember.$.isArray(res.data)) {
+            if (res && !Ember.$.isArray(res.data)) {
                 res.data = [res.data];
             }
             return res;

--- a/addon/adapters/osf-adapter.js
+++ b/addon/adapters/osf-adapter.js
@@ -24,7 +24,7 @@ import {
  */
 export default DS.JSONAPIAdapter.extend(HasManyQuery.RESTAdapterMixin, GenericDataAdapterMixin, {
     headers: {
-        'ACCEPT':'application/vnd.api+json; version=2.3'
+        ACCEPT: 'application/vnd.api+json; version=2.3'
     },
     authorizer: config['ember-simple-auth'].authorizer,
     host: config.OSF.apiUrl,

--- a/addon/mixins/node-actions.js
+++ b/addon/mixins/node-actions.js
@@ -197,30 +197,32 @@ export default Ember.Mixin.create({
             return this.get('_node').addChild(title, description, category);
         },
         /**
-         * Add a node link (pointer) to another node
+         * Adds a relationship to another node, called a linkedNode.
          *
          * @method addNodeLink
-         * @param {String} targetNodeId ID of the node for which you wish to create a pointer
-         * @return {Promise} Returns a promise that resolves to model for the newly created NodeLink
+         * @param {String} targetNodeId ID of the node for which you wish to create a link
+         * @return {Promise} Returns a promise that resolves to the newly updated node
          */
         addNodeLink(targetNodeId) {
             var node = this.get('_node');
-            var nodeLink = this.store.createRecord('node-link', {
-                target: targetNodeId
+            return this.store.findRecord('node', targetNodeId).then(linkedNode => {
+                node.get('linkedNodes').pushObject(linkedNode);
+                return node.save();
             });
-            node.get('nodeLinks').pushObject(nodeLink);
-            return node.save().then(() => nodeLink);
+
         },
         /**
-         * Remove a node link (pointer) to another node
+         * Removes the linkedNode relationship to another node. Does not remove the linked node itself.
          *
          * @method removeNodeLink
-         * @param {Object} nodeLink nodeLink record to be destroyed.
-         * @return {Promise} Returns a promise that resolves after the node link has been removed.  This does not delete
-         * the target node itself.
+         * @param {Object} linkedNode linkedNode relationship to be destroyed.
+         * @return {Promise} Returns a promise that resolves to the newly updated node
          */
-        removeNodeLink(nodeLink) {
-            return nodeLink.destroyRecord();
+        removeNodeLink(linkedNode) {
+            var node = this.get('_node');
+            node.get('linkedNodes').removeObject(linkedNode);
+            return node.save();
         }
+
     }
 });

--- a/addon/models/collection.js
+++ b/addon/models/collection.js
@@ -19,9 +19,6 @@ export default OsfModel.extend({
     dateCreated: DS.attr('date'),
     dateModified: DS.attr('date'),
     bookmarks: DS.attr('boolean'),
-    // nodeLinks: DS.hasMany('node-links', {
-    //     inverse:null
-    // }),
     linkedNodes: DS.hasMany('nodes', {
         inverse: null,
         serializerType: 'linked-node'

--- a/addon/models/collection.js
+++ b/addon/models/collection.js
@@ -22,6 +22,10 @@ export default OsfModel.extend({
     linkedNodes: DS.hasMany('nodes', {
         inverse: null,
         serializerType: 'linked-node'
+    }),
+    linkedRegistrations: DS.hasMany('registrations', {
+        inverse: null,
+        serializerType: 'linked-node'
     })
 
 });

--- a/addon/models/node.js
+++ b/addon/models/node.js
@@ -66,6 +66,10 @@ export default OsfModel.extend(FileItemMixin, {
     nodeLinks: DS.hasMany('node-links', {
         inverse: null
     }),
+    linkedNodes: DS.hasMany('nodes', {
+        inverse: null,
+        serializerType: 'linked-node'
+    }),
     registrations: DS.hasMany('registrations', {
         inverse: 'registeredFrom'
     }),

--- a/addon/models/node.js
+++ b/addon/models/node.js
@@ -63,9 +63,6 @@ export default OsfModel.extend(FileItemMixin, {
 
     files: DS.hasMany('file-provider'),
     //forkedFrom: DS.belongsTo('node'),
-    nodeLinks: DS.hasMany('node-links', {
-        inverse: null
-    }),
     linkedNodes: DS.hasMany('nodes', {
         inverse: null,
         serializerType: 'linked-node'

--- a/addon/serializers/linked-node.js
+++ b/addon/serializers/linked-node.js
@@ -7,7 +7,7 @@ export default OsfSerializer.extend({
         if (options.forRelationship) {
             hash.data = [{
                 id: snapshot.record.get('id'),
-                type: 'linked_nodes'
+                type: typeClass.modelName === 'registration' ? 'linked_registrations' : 'linked_nodes'
             }];
             return hash;
         }

--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -116,7 +116,7 @@ export default DS.JSONAPISerializer.extend({
         //  links.meta from the payload links section, and add to the model metadata manually.
         let documentHash = this._super(...arguments);
         documentHash.meta = documentHash.meta || {};
-        documentHash.meta.pagination = Ember.get(payload || {}, 'links.meta');
+        documentHash.meta.pagination = Ember.get(payload || {}, 'meta');
         documentHash.meta.total = Math.ceil(documentHash.meta.pagination.total / documentHash.meta.pagination.per_page);
         return documentHash;
     }

--- a/tests/dummy/app/routes/collections/detail.js
+++ b/tests/dummy/app/routes/collections/detail.js
@@ -18,7 +18,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
             this.store.findRecord('node', projectId).then(node => {
                 var collection = this.modelFor(this.routeName);
                 collection.get('linkedNodes').pushObject(node);
-                collection.save();
+                return collection.save();
             });
         },
         /**
@@ -32,35 +32,35 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
         removeNodeFromCollection(project) {
             var collection = this.modelFor(this.routeName);
             collection.get('linkedNodes').removeObject(project);
-            collection.save();
+            return collection.save();
         },
         /**
-        * Add node to a collection
+        * Add registration to a collection
         *
-        * @method addNodeToCollection
-        * @param {String} projectId, ID of node (linkedNode) to be added to the collection
+        * @method addRegistrationToCollection
+        * @param {String} registrationId, ID of registration (linkedRegistration) to be added to the collection
         * @return {Promise} Returns a promise that resolves to the updated collection
-        * with the new linkedNodes relationship
+        * with the new linkedRegistration relationship
         */
         addRegistrationToCollection(registrationId) {
             this.store.findRecord('registration', registrationId).then(registration => {
                 var collection = this.modelFor(this.routeName);
                 collection.get('linkedRegistrations').pushObject(registration);
-                collection.save();
+                return collection.save();
             });
         },
         /**
-        * Remove node from a collection
+        * Remove registration from a collection
         *
-        * @method removeNodeFromCollection
-        * @param {Object} project Node(linkedNode) relationship to be removed from collection
+        * @method removeRegistrationFromCollection
+        * @param {Object} registration linkedRegistration to be removed from collection
         * @return {Promise} Returns a promise that resolves to the updated collection
-        * with the linkedNode relationship removed.  The node itself is not removed.
+        * with the linkedRegistration relationship removed.  The registration itself is not deleted.
         */
         removeRegistrationFromCollection(registration) {
             var collection = this.modelFor(this.routeName);
             collection.get('linkedRegistrations').removeObject(registration);
-            collection.save();
+            return collection.save();
         },
     }
 });

--- a/tests/dummy/app/routes/collections/detail.js
+++ b/tests/dummy/app/routes/collections/detail.js
@@ -34,5 +34,33 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
             collection.get('linkedNodes').removeObject(project);
             collection.save();
         },
+        /**
+        * Add node to a collection
+        *
+        * @method addNodeToCollection
+        * @param {String} projectId, ID of node (linkedNode) to be added to the collection
+        * @return {Promise} Returns a promise that resolves to the updated collection
+        * with the new linkedNodes relationship
+        */
+        addRegistrationToCollection(registrationId) {
+            this.store.findRecord('registration', registrationId).then(registration => {
+                var collection = this.modelFor(this.routeName);
+                collection.get('linkedRegistrations').pushObject(registration);
+                collection.save();
+            });
+        },
+        /**
+        * Remove node from a collection
+        *
+        * @method removeNodeFromCollection
+        * @param {Object} project Node(linkedNode) relationship to be removed from collection
+        * @return {Promise} Returns a promise that resolves to the updated collection
+        * with the linkedNode relationship removed.  The node itself is not removed.
+        */
+        removeRegistrationFromCollection(registration) {
+            var collection = this.modelFor(this.routeName);
+            collection.get('linkedRegistrations').removeObject(registration);
+            collection.save();
+        },
     }
 });

--- a/tests/dummy/app/templates/collections/detail.hbs
+++ b/tests/dummy/app/templates/collections/detail.hbs
@@ -21,7 +21,7 @@
                 <td><button {{action "removeNodeFromCollection" linkedNode}} class="btn btn-danger">Remove project</button> </td>
             </tr>
         {{/each}}
-         {{#each model.linkedRegistrations as |linkedRegistration|}}
+        {{#each model.linkedRegistrations as |linkedRegistration|}}
             <tr>
                 <td>{{link-to linkedRegistration.title 'nodes.detail' linkedRegistration.id }} </td>
                 <td>{{moment-format linkedRegistration.dateModified}} </td>

--- a/tests/dummy/app/templates/collections/detail.hbs
+++ b/tests/dummy/app/templates/collections/detail.hbs
@@ -21,11 +21,23 @@
                 <td><button {{action "removeNodeFromCollection" linkedNode}} class="btn btn-danger">Remove project</button> </td>
             </tr>
         {{/each}}
+         {{#each model.linkedRegistrations as |linkedRegistration|}}
+            <tr>
+                <td>{{link-to linkedRegistration.title 'nodes.detail' linkedRegistration.id }} </td>
+                <td>{{moment-format linkedRegistration.dateModified}} </td>
+                <td><button {{action "removeRegistrationFromCollection" linkedRegistration}} class="btn btn-danger">Remove registration</button> </td>
+            </tr>
+        {{/each}}
     </table>
 
-    <h3>Add project to collection</h3>
+    <h3>Add project to collection </h3>
     <label> Project id </label> {{input value=projectId}}
     <button {{action "addNodeToCollection" projectId}} class="btn btn-primary">Add</button>
+
+    <h3>Add registration to collection </h3>
+    <label> Registration id </label> {{input value=registrationId}}
+    <button {{action "addRegistrationToCollection" registrationId}} class="btn btn-primary">Add</button>
+
 
 
 </div>

--- a/tests/dummy/app/templates/nodes/detail/index.hbs
+++ b/tests/dummy/app/templates/nodes/detail/index.hbs
@@ -116,25 +116,25 @@
     </div>
     <hr>
 
-    <h2>Node links </h2>
+    <h2>Linked Nodes (formerly node links.  After API v2.1, node links have been deprecated). </h2>
     <table class="table">
-        {{#if model.nodeLinks}}
+        {{#if model.linkedNodes}}
             <tr>
                 <th> Id </th>
                 <th> Name </th>
                 <th> </th>
             </tr>
-            {{#each model.nodeLinks as |nodelink|}}
+            {{#each model.linkedNodes as |node|}}
                 <tr>
-                    <td> {{nodelink.targetNode.id}} </td>
-                    <td> {{link-to nodelink.targetNode.title 'nodes.detail' nodelink.targetNode.id}} </td>
-                    <td> <button {{action "removeNodeLink" nodelink}} class="btn btn-danger"> Remove </button> </td>
+                    <td> {{node.id}} </td>
+                    <td> {{link-to node.title 'nodes.detail' node.id}} </td>
+                    <td> <button {{action "removeNodeLink" node}} class="btn btn-danger"> Remove </button> </td>
                 </tr>
             {{/each}}
         {{/if}}
     </table>
     <hr>
-    <h3>Add link</h3>
+    <h3>Add linked node relationship</h3>
     <label> Target node id </label> {{input value=targetNodeId}}
     <button {{action "addNodeLink" targetNodeId}} class="btn btn-primary">Add</button>
 

--- a/tests/unit/models/collections-test.js
+++ b/tests/unit/models/collections-test.js
@@ -2,7 +2,7 @@ import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('collection', 'Unit | Model | collection', {
   // Specify the other units that are required for this test.
-  needs: ['model:collection', 'model:node']
+  needs: ['model:collection', 'model:node', 'model:registration']
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/serializers/collection-test.js
+++ b/tests/unit/serializers/collection-test.js
@@ -2,7 +2,7 @@ import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('collection', 'Unit | Serializer | collection', {
   // Specify the other units that are required for this test.
-  needs: ['serializer:collection', 'model:node']
+  needs: ['serializer:collection', 'model:node', 'model:registration']
 });
 
 // Replace this with your real tests.

--- a/tests/unit/serializers/node-link-test.js
+++ b/tests/unit/serializers/node-link-test.js
@@ -2,7 +2,7 @@ import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('node-link', 'Unit | Serializer | node link', {
   // Specify the other units that are required for this test.
-  needs: ['serializer:node-link', 'serializer:node']
+  needs: ['serializer:node-link', 'serializer:node', 'model:node']
 });
 
 // Replace this with your real tests.


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/PREP-246

❗️ Must be accompanied by https://github.com/CenterForOpenScience/osf.io/pull/6563

# Purpose

The latest version of the API will be 2.3 once the above PR is merged. In order for preprints to use this latest version of the API, ember-osf needs to be upgraded.  This affects things like pagination links, linked nodes, linked registrations, institution components, and merged users.

TODO
- [x] Expect meta information to be a top-level member
- [x] Fix bug where removing certain types of relationships, the API request would succeed but Ember would not think the relationship was removed.  So you could never add the the relationship back.  Ember would think you were trying to restore a relationship that was already present.
- [x] Remove node links in favor of linked nodes
- [x] Demonstrate linked nodes and linked registrations in dummy app
- [x] ~~Add linked registrations to nodes ( waiting on https://github.com/CenterForOpenScience/osf.io/pull/6580, can be a follow-up PR)~~


# Notes for Reviewers
Are there other places that will be affected by this version change?  Breaking API changes are listed [here]( https://osf.io/y9jdt/wiki/Changelog/?view).  Version 2.3 (pending) will prevent merged users from being returned in `GET /v2/users/`.  

There needs to be a bigger discussion regarding how we are updating Ember-OSF.  Which groups are using ember-osf?  Will they be affected by these changes?  How will we communicate breaking changes?  

## Routes Added/Updated


