### PR TITLE
[EOSF-158] Make required on license widget match preprint form

### DIFF
--- a/addon/components/license-picker/template.hbs
+++ b/addon/components/license-picker/template.hbs
@@ -11,12 +11,26 @@
             <hr>
         </div>
         {{#if showYear}}
-            <p><label>Year {{if yearRequired '(Required)'}}:</label></p>
+            <p>
+                <label>
+                    Year:
+                    {{#if yearRequired }}
+                        <span style="color: #f99; font-weight: 400"> (required)</span>
+                    {{/if}}
+                </label>
+            </p>
             {{input class='form-control' value=year}}
         {{/if}}
         {{#if showCopyrightHolders}}
             <br>
-            <p><label>Copyright Holders {{if copyrightHoldersRequired '(Required)'}}:</label></p>
+            <p>
+                <label>
+                    Copyright Holders:
+                    {{#if copyrightHoldersRequired}}
+                        <span style="color: #f99; font-weight: 400"> (required)</span>
+                    {{/if}}
+                </label>
+            </p>
             {{input class='form-control' value=copyrightHolders}}
         {{/if}}
         <br>


### PR DESCRIPTION
## Purpose
Make the style of the word required match the preprint form,

## Changes
### Before:
![screen shot 2016-12-02 at 2 30 25 pm](https://cloud.githubusercontent.com/assets/6268982/20847404/e5f2d740-b89b-11e6-89f2-a28e771e0a8f.png)

### After:
![screen shot 2016-12-02 at 2 22 48 pm](https://cloud.githubusercontent.com/assets/6268982/20847407/ed815a5e-b89b-11e6-9185-afa19237156c.png)
