### PR TITLE
[PREP-274] add required to choose license and remove line break, move faq link p…

### DIFF
--- a/addon/components/license-picker/template.hbs
+++ b/addon/components/license-picker/template.hbs
@@ -5,10 +5,11 @@
         {{/if}}
         <div class="form-inline">
             <div class="form-group">
-                <label> Choose a license: <small><a target='_blank' href='http://help.osf.io/m/60347/l/611430-licensing'>License FAQ</a></small></label>
+                <label> Choose a license: <span style="color: #f99; font-weight: 400"> (required)</span></label>
                 {{license-list licenses=licensesAvailable currentLicense=nodeLicense showCategories=showCategories select=(action 'selectLicense')}}
+                <small><a target='_blank' href='http://help.osf.io/m/60347/l/611430-licensing'>License FAQ</a></small>
             </div>
-            <hr>
+            <br>
         </div>
         {{#if showYear}}
             <p>


### PR DESCRIPTION
…osition as well

## Ticket
https://openscience.atlassian.net/browse/PREP-274

# Purpose
Clean up the license widget UI, adding (required), removing line break, and moving the FAQ link beneath the license selection. 
Changes can be seen on screenshots posted here: https://github.com/CenterForOpenScience/ember-preprints/pull/215
