### PR TITLE
[PREP-278] CopyrightHolders should always return a string to the controller

### DIFF
--- a/addon/components/license-picker/component.js
+++ b/addon/components/license-picker/component.js
@@ -79,7 +79,7 @@ export default Ember.Component.extend({
             let values = {
                 licenseType: this.get('nodeLicense'),
                 year: this.get('year'),
-                copyrightHolders: this.get('copyrightHolders') ? this.get('copyrightHolders') : []
+                copyrightHolders: this.get('copyrightHolders') ? this.get('copyrightHolders') : ''
             };
             this.attrs.editLicense(
                 values,


### PR DESCRIPTION
## Purpose
From the perspective of the component, copyrightHolders it should be only a string, never an array. This helps fix licenseChanged not always being accurate on preprints edit.
