### PR TITLE
[EOSF-159] Allow enter to send action on license widget

### DIFF
--- a/addon/components/license-picker/component.js
+++ b/addon/components/license-picker/component.js
@@ -86,6 +86,9 @@ export default Ember.Component.extend({
                 !((this.get('yearRequired') && !values.year) || (this.get('copyrightHoldersRequired') && values.copyrightHolders.length === 0))
             );
         },
+        sendSubmit() {
+            this.sendAction('pressSubmit');
+        },
         dismiss() {
             this.attrs.dismiss();
         }

--- a/addon/components/license-picker/template.hbs
+++ b/addon/components/license-picker/template.hbs
@@ -20,7 +20,7 @@
                     {{/if}}
                 </label>
             </p>
-            {{input class='form-control' value=year}}
+            {{input class='form-control' value=year enter=(action 'sendSubmit')}}
         {{/if}}
         {{#if showCopyrightHolders}}
             <br>
@@ -32,7 +32,7 @@
                     {{/if}}
                 </label>
             </p>
-            {{input class='form-control' value=copyrightHolders}}
+            {{input class='form-control' value=copyrightHolders enter=(action 'sendSubmit')}}
         {{/if}}
         <br>
         {{#if toggleText}}


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-159

Related to:
https://openscience.atlassian.net/browse/EOSF-397

# Purpose
Send PressSubmit action up from the license widget if enter is pressed on the input fields.




