### PR TITLE
Feature/Preprint Adapter Changes [EOSF-160]

### DIFF
--- a/addon/adapters/preprint.js
+++ b/addon/adapters/preprint.js
@@ -1,19 +1,17 @@
 import OsfAdapter from './osf-adapter';
 
 export default OsfAdapter.extend({
-    // Override _buildRelationshipURL on ember-osf.  Instead of relationship link, need a PATCH to self link
-    _buildRelationshipURL(snapshot) {
-        if (snapshot.record.get('links.self')) {
-            return snapshot.record.get('links.self');
-        }
-        return null;
-    },
-    // Override _doRelatedRequest on ember-osf.  Need to serializer preprint instead of file.
-    _doRelatedRequest(store, snapshot, relatedSnapshots, relationship, url) {
-        return this.ajax(url, 'PATCH', {
-            data: store.serializerFor('preprint').serialize(snapshot),
-            isBulk: false
-        });
-    }
+    // Overrides updateRecord on OsfAdapter. Is identical to JSONAPIAdapter > Update Record (parent's parent method).
+    // Updates to preprints do not need special handling.
+    updateRecord(store, type, snapshot) {
+        var data = {};
+        var serializer = store.serializerFor(type.modelName);
 
+        serializer.serializeIntoHash(data, type, snapshot, { includeId: true });
+
+        var id = snapshot.id;
+        var url = this.buildURL(type.modelName, id, snapshot, 'updateRecord');
+
+        return this.ajax(url, 'PATCH', { data: data });
+        }
 });

--- a/addon/adapters/preprint.js
+++ b/addon/adapters/preprint.js
@@ -13,5 +13,5 @@ export default OsfAdapter.extend({
         var url = this.buildURL(type.modelName, id, snapshot, 'updateRecord');
 
         return this.ajax(url, 'PATCH', { data: data });
-        }
+    }
 });


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-160

Related to:
https://openscience.atlassian.net/browse/EOSF-187

# Purpose

Two requests are being sent to update preprint licenses, which sometimes results in extra logs.  The OSF Adapter overrides updateRecord to handle changed relationships and changed attributes separately.  Multiple requests will be sent for these items.  However, preprints PATCH requests from the API can have both relationships and attributes in the request - one request is meant to be sent to PATCH the preprint directly, not multiple requests to different resources.

# Changes

One request sent to PATCH preprint instead of two. Since preprints PATCH requests seem to be more along the lines of what Ember expects, instead of overriding overrides in the Preprints Adapter to get it to work, restores the JSONAPIAdapter's `updateRecord` method.  Then, when updating preprints, one request will be sent to the preprint itself.

# Notes for Reviewers

## Routes Added/Updated


