### PR TITLE
[hotfix] Feature/Total Number of Results being Overridden

### DIFF
--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -119,7 +119,8 @@ export default DS.JSONAPISerializer.extend({
         //  links.meta from the payload links section, and add to the model metadata manually.
         let documentHash = this._super(...arguments);
         documentHash.meta = documentHash.meta || {};
-        documentHash.meta.pagination = Ember.get(payload || {}, 'meta');
+        documentHash.meta.pagination =  Ember.$.extend(true, {}, Ember.get(payload || {}, 'meta'));
+        documentHash.meta.total = Math.ceil(documentHash.meta.pagination.total / documentHash.meta.pagination.per_page);
         return documentHash;
     }
 });

--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -119,7 +119,7 @@ export default DS.JSONAPISerializer.extend({
         //  links.meta from the payload links section, and add to the model metadata manually.
         let documentHash = this._super(...arguments);
         documentHash.meta = documentHash.meta || {};
-        documentHash.meta.pagination =  Ember.$.extend(true, {}, Ember.get(payload || {}, 'meta'));
+        documentHash.meta.pagination = Ember.$.extend(true, {}, Ember.get(payload || {}, 'meta'));
         documentHash.meta.total = Math.ceil(documentHash.meta.pagination.total / documentHash.meta.pagination.per_page);
         return documentHash;
     }

--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -120,7 +120,6 @@ export default DS.JSONAPISerializer.extend({
         let documentHash = this._super(...arguments);
         documentHash.meta = documentHash.meta || {};
         documentHash.meta.pagination = Ember.get(payload || {}, 'meta');
-        documentHash.meta.total = Math.ceil(documentHash.meta.pagination.total / documentHash.meta.pagination.per_page);
         return documentHash;
     }
 });

--- a/addon/serializers/osf-serializer.js
+++ b/addon/serializers/osf-serializer.js
@@ -115,8 +115,8 @@ export default DS.JSONAPISerializer.extend({
     },
 
     normalizeArrayResponse(store, primaryModelClass, payload, id, requestType) { // jshint ignore:line
-        // Ember data does not yet support pagination. For any request that returns more than one result, extract
-        //  links.meta from the payload links section, and add to the model metadata manually.
+        // Ember data does not yet support pagination. For any request that returns more than one result, add pagination data
+        // under meta, and then calculate total pages to be loaded.
         let documentHash = this._super(...arguments);
         documentHash.meta = documentHash.meta || {};
         documentHash.meta.pagination = Ember.$.extend(true, {}, Ember.get(payload || {}, 'meta'));


### PR DESCRIPTION
## Ticket

# Purpose

Only ten results are loading for project dropdown on preprints.  This is caused by the Ember-OSF recent upgrade to APIv2.3 https://github.com/CenterForOpenScience/ember-osf/pull/153.  Meta information was previously under links, but newer versions of the API have meta as a top-level object.  Ember-osf > osf-serializer adds a field to meta which specifies how many pages are to be loaded. However, a shallow copy is used, so when calculating total pages to be loaded, the total number of results to be loaded is overridden.  Before, when meta was under links, this shallow copy was not a problem.

# Changes

Deep copy payload information, so total number of results is not overridden by total number of pages.   
This is visible in preprints, where all valid projects should load on project dropdown.

# Notes for Reviewers

## Routes Added/Updated


