### PR TITLE
[rfr] Default authorizationType (and document secret config param) [#EOSF-105]

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ If for some reason you don't have a config/local.yml you can generate one. To do
 ember generate ember-osf
 ```
 
+#### Advanced usage: Selecting an authorization type
+We expect that most projects based on `ember-osf` will authenticate via OAuth 2.0 ("Token Login"); the addon is 
+configured to use this out of the box, so long as you provide your own login page based on the appropriate mixins.
+
+If you are developing an application that will be hosted under the `osf.io` domain, you may wish to use cookie-based 
+authentication instead. In that rare case, add the following lines to your `config/environment.js` file:
+
+```javascript
+    ENV.authorizationType = 'cookie';
+    
+    ENV['ember-simple-auth'] = {
+        authorizer: `authorizer:osf-${defaultAuthorizationType}`,
+        authenticator: `authenticator:osf-${defaultAuthorizationType}`
+    };
+```
+
 ## Usage
 
 #### Ember Data: Using the OSF models

--- a/README.md
+++ b/README.md
@@ -86,11 +86,12 @@ If you are developing an application that will be hosted under the `osf.io` doma
 authentication instead. In that rare case, add the following lines to your `config/environment.js` file:
 
 ```javascript
-    ENV.authorizationType = 'cookie';
+    var authorizationType = 'cookie';
+    ENV.authorizationType = authorizationType;
     
     ENV['ember-simple-auth'] = {
-        authorizer: `authorizer:osf-${defaultAuthorizationType}`,
-        authenticator: `authenticator:osf-${defaultAuthorizationType}`
+        authorizer: `authorizer:osf-${authorizationType}`,
+        authenticator: `authenticator:osf-${authorizationType}`
     };
 ```
 

--- a/index.js
+++ b/index.js
@@ -96,8 +96,13 @@ module.exports = {
             ENV.OSF.helpUrl = 'http://help.osf.io';
 
         }
+
+        const defaultAuthorizationType = 'token';
+        ENV.authorizationType = defaultAuthorizationType;
+
         ENV['ember-simple-auth'] = {
-            authorizer: 'authorizer:osf-token'
+            authorizer: `authorizer:osf-${defaultAuthorizationType}`,
+            authenticator: `authenticator:osf-${defaultAuthorizationType}`
         };
     },
     afterInstall: function(options) {


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-105

# Purpose
Ember-osf is designed to work with two types of authorization: cookies and tokens.

Previously, getting a new app to work required manually setting a secret config parameter, `authorizationType`.

This PR allows the addon to set a [default value](https://ember-cli.com/api/classes/Addon.html#method_config) to that consuming apps don't need more boilerplate to use OAuth 2.0. For internal COS products based on cookie auth, we add documentation of the configuration changes needed to get things working.

# Notes for Reviewers
## How to test this
This PR is about the new developer experience- so the best way to test it is using a fresh ember app. You can probably test this by modifying the `ember-osf` dummy app [config file](https://github.com/abought/ember-osf/blob/5ccb027abe248e3d4fa7f8fc15b1d9cac168f3fc/tests/dummy/config/environment.js#L6-L6). For a more rigorous test, I have created a [standalone dummy app](https://github.com/abought/demo-ember-osf/) that may be useful. Either way...

To test this PR:
1. Clone `ember-osf` and check out this branch locally.
2. Either remove the default value from the dummy app config file, or if using a fresh app, make sure that`package.json` points to the code for this PR on your local computer: `"ember-osf": "file:../ember-osf",`
3. Start the server, go to, eg, `localhost:4200/login`, and try to click the login button with no `authorizationType` provided. It should just work.
4. Point the app at an old version of ember-osf. Before this PR, a missing value of `authorizationType` would cause a JS console error and prevent the user from logging in. With this change, login should work.

## See also
- To verify the docs, see: [Example of cookies being used with ember-osf](https://github.com/abought/ember-preprints/blob/1999349631e98a09f368b469b91193e8b2c57fc3/config/environment.js#L4-L4)

## Routes Added/Updated
n/a

