### PR TITLE
[EOSF-481] Formatting on Full License Text Widget for Preprints

### DIFF
--- a/addon/components/license-picker/template.hbs
+++ b/addon/components/license-picker/template.hbs
@@ -40,7 +40,7 @@
         {{/if}}
 
         {{#if (or showText (not toggleText))}}
-            <pre style='white-space: pre-wrap; border:none; width:100%; text-align:justify; max-height: 300px;'>{{nodeLicenseText}}</pre>
+            <pre style='white-space: pre-wrap; word-break: normal; border:none; width:100%; text-align:justify; max-height: 300px;'>{{nodeLicenseText}}</pre>
         {{/if}}
         {{#unless autosave}}
             <button class='btn btn-success pull-right' {{action 'save'}}>Save</button>


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-481

# Purpose
To fix in-line styling on the full license text widget.  Prevents the text from breaking mid-word if it needs to break to a new line.

# Notes for Reviewers
None

## Routes Added/Updated
None