### PR TITLE
Add new model field for the about link [EOSF-497]

### DIFF
--- a/addon/models/preprint-provider.js
+++ b/addon/models/preprint-provider.js
@@ -13,6 +13,7 @@ export default OsfModel.extend({
     socialTwitter: DS.attr('fixstring'),
     socialFacebook: DS.attr('fixstring'),
     socialInstagram: DS.attr('fixstring'),
+    aboutLink: DS.attr('fixstring'),
     headerText: DS.attr('fixstring'),
     subjectsAcceptable: DS.attr(),
     // Relationships


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-497

# Purpose
On branded preprints, communities need a way to give 'About' information to users.
A new model field is needed to hold the link information.




