### PR TITLE
[WIP] Feature/Mint DOI's Widget [EOSF-513]

### DIFF
--- a/addon/components/doi-minter/component.js
+++ b/addon/components/doi-minter/component.js
@@ -1,0 +1,43 @@
+import Ember from 'ember';
+import layout from './template';
+
+/**
+ * @module ember-osf
+ * @submodule components
+ */
+
+/**
+ * DOI Minter
+ *
+ * Sample usage:
+ * ```handlebars
+ * {{doi-minter
+ *      model=model (preprint or node)
+ *}}
+ * ```
+ * @class doi-minter
+ */
+export default Ember.Component.extend({
+    layout,
+    isOpen: false,
+    model: null,
+    resourceType: Ember.computed('model', function() {
+        // Default is preprint.  For display in confirmation modal.
+        let type = this.get('model._internalModel.modelName') || 'preprint';
+        if (type === 'node') {
+            return 'project';
+        }
+        return type;
+    }),
+    actions: {
+        close() {
+            this.set('isOpen', false);
+        },
+        toggleDOIModal() {
+            this.toggleProperty('isOpen');
+        },
+        createDOI() {
+            // TODO
+        }
+    }
+});

--- a/addon/components/doi-minter/template.hbs
+++ b/addon/components/doi-minter/template.hbs
@@ -1,0 +1,17 @@
+<a href="#" {{action 'toggleDOIModal'}}> Create DOI </a>
+
+{{#bs-modal open=isOpen body=false header=false footer=false}}
+    {{#bs-modal-header}}
+        <h3 class="modal-title">Create identifiers</h3>
+    {{/bs-modal-header}}
+    {{#bs-modal-body}}
+        Are you sure you want to create a DOI for this {{resourceType}}? DOI identifiers are persistent and will always resolve to this {{resourceType}}.
+    {{/bs-modal-body}}
+
+    {{#bs-modal-footer}}
+        <div align="right">
+            <button {{action 'close'}} class="btn btn-default"> Cancel </button>
+            <button class="btn btn-primary" {{action 'createDOI' resourceId}}> Create </button>
+        </div>
+    {{/bs-modal-footer}}
+{{/bs-modal}}

--- a/addon/components/doi-minter/template.hbs
+++ b/addon/components/doi-minter/template.hbs
@@ -1,17 +1,21 @@
 <a href="#" {{action 'toggleDOIModal'}}> Create DOI </a>
 
-{{#bs-modal open=isOpen body=false header=false footer=false}}
-    {{#bs-modal-header}}
-        <h3 class="modal-title">Create identifiers</h3>
-    {{/bs-modal-header}}
-    {{#bs-modal-body}}
-        Are you sure you want to create a DOI for this {{resourceType}}? DOI identifiers are persistent and will always resolve to this {{resourceType}}.
-    {{/bs-modal-body}}
+<div id="ember-bootstrap-modal-container">
+    {{#bs-modal open=isOpen body=false header=false footer=false}}
+        {{#bs-modal-header}}
+            <h3 class="modal-title">Create identifiers</h3>
+        {{/bs-modal-header}}
+        {{#bs-modal-body}}
+            Are you sure you want to create a DOI for this {{resourceType}}? DOI identifiers are persistent and will always resolve to this {{resourceType}}.
+        {{/bs-modal-body}}
 
-    {{#bs-modal-footer}}
-        <div align="right">
-            <button {{action 'close'}} class="btn btn-default"> Cancel </button>
-            <button class="btn btn-primary" {{action 'createDOI'}}> Create </button>
-        </div>
-    {{/bs-modal-footer}}
-{{/bs-modal}}
+        {{#bs-modal-footer}}
+            <div align="right">
+                <button {{action 'close'}} class="btn btn-default"> Cancel </button>
+                <button class="btn btn-primary" {{action 'createDOI'}}> Create </button>
+            </div>
+        {{/bs-modal-footer}}
+    {{/bs-modal}}
+
+</div>
+

--- a/addon/components/doi-minter/template.hbs
+++ b/addon/components/doi-minter/template.hbs
@@ -11,7 +11,7 @@
     {{#bs-modal-footer}}
         <div align="right">
             <button {{action 'close'}} class="btn btn-default"> Cancel </button>
-            <button class="btn btn-primary" {{action 'createDOI' resourceId}}> Create </button>
+            <button class="btn btn-primary" {{action 'createDOI'}}> Create </button>
         </div>
     {{/bs-modal-footer}}
 {{/bs-modal}}

--- a/app/components/doi-minter/component.js
+++ b/app/components/doi-minter/component.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/components/doi-minter/component';

--- a/tests/dummy/app/templates/nodes/detail/index.hbs
+++ b/tests/dummy/app/templates/nodes/detail/index.hbs
@@ -25,6 +25,7 @@
     <ul>
         {{#each model.preprints as |prep|}}
             <li><a href='{{host}}{{prep.id}}/'>{{prep.node.title}} (Preprint)</a></li>
+             {{doi-minter model=prep}}
         {{/each}}
     </ul>
     <hr>

--- a/tests/dummy/app/templates/nodes/detail/index.hbs
+++ b/tests/dummy/app/templates/nodes/detail/index.hbs
@@ -25,7 +25,7 @@
     <ul>
         {{#each model.preprints as |prep|}}
             <li><a href='{{host}}{{prep.id}}/'>{{prep.node.title}} (Preprint)</a></li>
-             {{doi-minter model=prep}}
+            {{doi-minter model=prep}}
         {{/each}}
     </ul>
     <hr>

--- a/tests/integration/components/doi-minter/component-test.js
+++ b/tests/integration/components/doi-minter/component-test.js
@@ -12,14 +12,5 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{doi-minter}}`);
 
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#doi-minter}}
-      template block text
-    {{/doi-minter}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$()[0].innerText.trim(), 'Create DOI');
 });

--- a/tests/integration/components/doi-minter/component-test.js
+++ b/tests/integration/components/doi-minter/component-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('doi-minter', 'Integration | Component | doi minter', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{doi-minter}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#doi-minter}}
+      template block text
+    {{/doi-minter}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-513

❗️ WIP just have bare-bones UI here - not yet functional. Need api endpoint.

# Purpose

We will be adding minting DOIs to preprints in the near future, so we should preempt that by building the widget. Create the current minting DOI (used on OSF Projects and Registrations) in an Ember widget. Where a user in the preprint submission form can click to mint a preprint DOI.

# Notes for Reviewers

## Routes Added/Updated


