### PR TITLE
Reproducibility Projects, FAQ/Explore links in footer redirect incorrectly [EOSF-524]

### DIFF
--- a/addon/components/osf-footer/template.hbs
+++ b/addon/components/osf-footer/template.hbs
@@ -5,11 +5,11 @@
             <div class="col-sm-2 col-md-3 col-md-offset-1">
                 <h4>OSF</h4>
                 <ul>
-                    <li><a href="explore/activity/">Explore</a></li>
+                    <li><a href="/explore/activity/">Explore</a></li>
                     <li>
                         {{{supportEmail}}}
                     </li>
-                    <li><a href="support">FAQ/Guides</a></li>
+                    <li><a href="/support">FAQ/Guides</a></li>
                     <li><a href="https://api.osf.io/v2/docs/">API</a></li>
                     <li><a href="https://github.com/CenterForOpenScience/osf.io">Source Code</a></li>
                 </ul>
@@ -18,8 +18,8 @@
                 <h4>Center for Open Science</h4>
                 <ul>
                     <li><a href="http://cos.io">Home</a></li>
-                    <li><a href="ezcuj/wiki/home/">Reproducibility Project: Psychology</a></li>
-                    <li><a href="e81xl/wiki/home/">Reproducibility Project: Cancer Biology</a></li>
+                    <li><a href="/ezcuj/wiki/home/">Reproducibility Project: Psychology</a></li>
+                    <li><a href="/e81xl/wiki/home/">Reproducibility Project: Cancer Biology</a></li>
                     <li><a href="http://cos.io/top/">TOP Guidelines</a></li>
                     <li><a href="https://www.givinglibrary.org/organizations/center-for-open-science">Donate</a></li>
                 </ul>


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-524

# Purpose
 - The links for the Reproducibility Projects in the Ember footer lead to https://osf.io/preprints/ezcuj/wiki/home/ and https://osf.io/preprints/e81xl/wiki/home/, respectively, which just leads to "Page not found." The word "preprints" should not be in the url.
The same issue is occurring with the "FAQ/Guides" and "Explore" links as well.

 - href for the mentioned links are updated to point to the site root.

# Notes for Reviewers

## Routes Added/Updated


