### PR TITLE
[EOSF-551] Add dateCreated to file version model

### DIFF
--- a/addon/models/file-version.js
+++ b/addon/models/file-version.js
@@ -17,5 +17,6 @@ import OsfModel from './osf-model';
 */
 export default OsfModel.extend({
     size: DS.attr('number'),
+    dateCreated: DS.attr('date'),
     contentType: DS.attr('fixstring')
 });


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-551

# Purpose 
Needed for APIv1 parity and to be able to show previous version dates in preprints

❗️Needs:
* CenterForOpenScience/osf.io#6947

Needed by:
* CenterForOpenScience/ember-preprints#285

# Notes for Reviewers

Minor change just to the model so that preprints can get the date created from file versions.

## Routes Added/Updated
N/A

