### PR TITLE
[blocked] Add blogUrl as model field from APIv2 [EOSF-433]

### DIFF
--- a/addon/models/preprint-provider.js
+++ b/addon/models/preprint-provider.js
@@ -10,6 +10,7 @@ export default OsfModel.extend({
     advisoryBoard: DS.attr('string'),
     emailContact: DS.attr('fixstring'),
     emailSupport: DS.attr('fixstring'),
+    blogUrl: DS.attr('string'),
     socialTwitter: DS.attr('fixstring'),
     socialFacebook: DS.attr('fixstring'),
     socialInstagram: DS.attr('fixstring'),


### PR DESCRIPTION
:warning: :squid: Requires merge of https://github.com/CenterForOpenScience/osf.io/pull/6821/files (OSF-7405).

🐠 Companion to, and must be merged before, https://github.com/CenterForOpenScience/ember-preprints/pull/303

## Ticket
https://openscience.atlassian.net/browse/EOSF-433

# Purpose
Add "blog URL" field to preprint provider model. This will allow pages like psyarxiv to link to blogs from their footer.

# Notes for Reviewers
If https://github.com/CenterForOpenScience/ember-osf/pull/189 is merged first, I'll try to update the factories to reflect the new field.