### PR TITLE
Detecting Consuming Application in Ember-OSF [EOSF-553]

### DIFF
--- a/addon/helpers/host-service-name.js
+++ b/addon/helpers/host-service-name.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+import hostServiceName from '../utils/host-service-name';
+
+/**
+ Use the `host-service-name` utility function to retrieve the host application name.
+ Usage example:
+ ```handlebars
+ This is text we want to do: {{host-service-name}}
+ ```
+ @class host-service-name-helper
+ @uses host-service-name
+ */
+
+export function hostServiceNameHelper() {
+    return hostServiceName();
+}
+
+export default Ember.Helper.helper(hostServiceNameHelper);

--- a/addon/utils/host-service-name.js
+++ b/addon/utils/host-service-name.js
@@ -6,14 +6,14 @@ import config from 'ember-get-config';
  */
 
 /**
- * @class host-service-name-helper
+ * @class host-service-name
  */
 
 /**
  * This function is useful for retrieving the hostname from the environment.js for the hosting app. This is needed to
  * allow ember-osf addons identify their hosting apps.
  *
- * @method hostservicename
+ * @method hostServiceName
  * @return {String}
  */
 export default function hostServiceName() {

--- a/addon/utils/host-service-name.js
+++ b/addon/utils/host-service-name.js
@@ -1,0 +1,23 @@
+import config from 'ember-get-config';
+
+/**
+ * @module ember-osf
+ * @submodule utils
+ */
+
+/**
+ * @class host-service-name-helper
+ */
+
+/**
+ * This function is useful for retrieving the hostname from the environment.js for the hosting app. This is needed to
+ * allow ember-osf addons identify their hosting apps.
+ *
+ * @method hostservicename
+ * @return {String}
+ */
+export default function hostServiceName() {
+    return config.modulePrefix;
+}
+
+export { hostServiceName };

--- a/app/helpers/host-service-name.js
+++ b/app/helpers/host-service-name.js
@@ -1,0 +1,1 @@
+export { default, hostServiceNameHelper } from 'ember-osf/helpers/host-service-name';

--- a/app/utils/host-service-name.js
+++ b/app/utils/host-service-name.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/utils/host-service-name';

--- a/tests/unit/helpers/host-service-name-test.js
+++ b/tests/unit/helpers/host-service-name-test.js
@@ -1,0 +1,10 @@
+import { hostServiceNameHelper } from 'dummy/helpers/host-service-name';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | host service name helper');
+
+
+test('#hostServiceNameHelper uses hostServiceName', function(assert) {
+    let res = hostServiceNameHelper();
+    assert.strictEqual(res, 'dummy');
+});

--- a/tests/unit/utils/host-service-name-test.js
+++ b/tests/unit/utils/host-service-name-test.js
@@ -1,0 +1,10 @@
+import hostServiceName from 'dummy/utils/host-service-name';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | host service name');
+
+
+test('#fhostServiceName retrieves the current host app name', function(assert) {
+    let res = hostServiceName();
+    assert.strictEqual(res, 'dummy');
+});


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-553

# Purpose
Sometimes in Ember-OSF, we need to know the consuming application - to handle things differently for preprints or registries, for example. Right now we pass in a string, like "PREPRINTS", to the ember-osf component. 

{{ osf-navbar signupUrl=theme.signupUrl loginAction=(action 'login') currentService='PREPRINTS' }}

A new utility and helper (with unit tests) are added to ember-osf, to allow retrieving host application name from config. The helper is using the utility function.

The host app name can be passed to the component now through the template handlebar
{{ osf-navbar signupUrl=theme.signupUrl loginAction=(action 'login') currentService=(host-service-name)}}

or can be retrieved at the component controller by importing the utility function.

# Notes for Reviewers

## Routes Added/Updated


