### PR TITLE
[EOSF-95] Remove unneeded comment serializer logic

### DIFF
--- a/addon/serializers/comment.js
+++ b/addon/serializers/comment.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import OsfSerializer from './osf-serializer';
 
 export default OsfSerializer.extend({
@@ -24,11 +23,5 @@ export default OsfSerializer.extend({
             };
         }
         return serialized;
-    },
-    extractRelationships(modelClass, resourceHash) {
-        // TODO: remove when https://openscience.atlassian.net/browse/OSF-6646 is done
-        resourceHash = this._super(modelClass, resourceHash);
-        resourceHash.replies.links.related = Ember.copy(resourceHash.replies.links.self);
-        return resourceHash;
     }
 });

--- a/addon/serializers/comment.js
+++ b/addon/serializers/comment.js
@@ -1,16 +1,12 @@
 import OsfSerializer from './osf-serializer';
 
 export default OsfSerializer.extend({
-    serialize(snapshot, options) {  // jshint ignore:line
+    serialize(snapshot) {
         // Add relationships field to identify comment target
-        let serialized = this._super(...arguments);
+        const serialized = this._super(...arguments);
 
-        // For POST requests specifically, two additional fields are needed
-        let targetID = snapshot.record.get('targetID');
-        let targetType = snapshot.record.get('targetType');
-        // TODO: Find a better way to detect request type, so this can enforce fields that are needed for creation (but not for editing)
-        //Ember.assert('Must provide target ID', targetID);
-        //Ember.assert('Must provide target type', targetType);
+        const targetID = snapshot.record.get('targetID');
+        const targetType = snapshot.record.get('targetType');
 
         if (targetID && targetType) {
             serialized.data.relationships = {


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-95

# Purpose
Logic in the comment serializer is no longer needed (I actually think it was preventing it from working properly)


