### PR TITLE
Add children field to taxonomy model [EOSF-491]

### DIFF
--- a/addon/models/taxonomy.js
+++ b/addon/models/taxonomy.js
@@ -16,5 +16,6 @@ export default OsfModel.extend({
     text: DS.attr('fixstring'),
     // TODO: Api implements this as a list field for now. This should be a relationship field in the future, when API supports it
     child_count: DS.attr(),
+    children: DS.attr(),
     parents: DS.attr()
 });


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-491

# Purpose
When hovering over top-level discipline in the index page, a tooltip shows an example of subdisciplines. Currently, the subdisciplines are hard-coded, causing the display of one or more subjects that are not used (allowed) by the provider.

This PR is part of the solution presented in PR [326](https://github.com/CenterForOpenScience/ember-preprints/pull/326)
This solution requires updating the OSF API and returning subject children with each request. 
# Notes for Reviewers

## Routes Added/Updated


