### PR TITLE
[EOSF-622] Add domainRedirectEnabled to preprint-provider model

### DIFF
--- a/addon/models/preprint-provider.js
+++ b/addon/models/preprint-provider.js
@@ -7,6 +7,7 @@ export default OsfModel.extend({
     bannerPath: DS.attr('string'),
     description: DS.attr('fixstring'),
     domain: DS.attr('string'),
+    domainRedirectEnabled: DS.attr('boolean'),
     example: DS.attr('fixstring'),
     advisoryBoard: DS.attr('string'),
     emailContact: DS.attr('fixstring'),


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-622

# Purpose

Brings Preprint Provider model in parity with OSF API Model

# Notes for Reviewers

One-line change, addition to model

## Routes Added/Updated
N/A

Relates to: CenterForOpenScience/osf.io#6793

