### PR TITLE
Added missing preprint provider serializer

### DIFF
--- a/addon/serializers/preprint-provider.js
+++ b/addon/serializers/preprint-provider.js
@@ -1,0 +1,4 @@
+import OsfSerializer from './osf-serializer';
+
+export default OsfSerializer.extend({
+});

--- a/app/serializers/preprint-provider.js
+++ b/app/serializers/preprint-provider.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/serializers/preprint-provider';

--- a/tests/unit/serializers/preprint-provider-test.js
+++ b/tests/unit/serializers/preprint-provider-test.js
@@ -1,0 +1,19 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('preprint-provider', 'Unit | Serializer | preprint provider', {
+    needs: [
+        'serializer:preprint-provider',
+        'model:taxonomy',
+        'model:preprint',
+        'model:license'
+    ]
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+    let record = this.subject();
+
+    let serializedRecord = record.serialize();
+
+    assert.ok(serializedRecord);
+});


### PR DESCRIPTION
## Ticket

N/A

# Purpose

Add missing preprint-provider serializer, which simply inherits osf-serializer.

# Summary of changes

Added preprint-provider serializer and auto-generated "it serializes" test.

# Testing notes

Things using multi-word preprint-provider properties should work now.