### PR TITLE
Fix typo in docs for search-dropdown component 

### DIFF
--- a/addon/components/search-dropdown/component.js
+++ b/addon/components/search-dropdown/component.js
@@ -12,7 +12,7 @@ import config from 'ember-get-config';
  *
  * Sample usage:
  * ```handlebars
- *   {{#search-dropdown action='toggleSearch'}}
+ *   {{search-dropdown action='toggleSearch'}}
  * ```
  * @class search-dropdown
  */


### PR DESCRIPTION
## Ticket
N/A

# Purpose
Make documentation better. This component doesn't work if you use it the way the sample suggests.

h/t @atelic

# Summary of changes
Does the same thing as PR #200, but fixes the original file rather than autogenerated artifact.

# Testing notes
No user facing changes. Documentation should be slightly more useful.
