### PR TITLE
[EOSF-659] Make fa-icon a button rather than an i inside a button

### DIFF
--- a/addon/components/discover-page/style.scss
+++ b/addon/components/discover-page/style.scss
@@ -77,7 +77,7 @@
     }
 }
 
-button.removeActiveFilter {
+.removeActiveFilter button {
     border: none;
     outline: none;
     background-color: transparent;

--- a/addon/components/discover-page/template.hbs
+++ b/addon/components/discover-page/template.hbs
@@ -108,17 +108,17 @@
                                     {{filter-replace filter filterReplace}}
                                     {{#unless theme.isProvider}}
                                         {{!ACTIVE PROVIDER FILTERS}}
-                                        <button class='removeActiveFilter' aria-label={{t 'eosf.components.discoverPage.removeProvider'}}>{{fa-icon 'times-circle' ariaHidden=false click=(action 'updateFilters' 'providers' filter)}}</button>
+                                        <span class='removeActiveFilter' aria-label={{t 'eosf.components.discoverPage.removeProvider'}}>{{fa-icon 'times-circle' ariaHidden=false tagName='button' click=(action 'updateFilters' 'providers' filter)}}</span>
                                     {{/unless}}
                                 </span>
                             {{/each}}
                             {{#each activeFilters.subjects as |filter|}}
                                 {{!ACTIVE SUBJECT FILTERS}}
-                                <span class='preprint-filter subject-filter'>{{filter}} <button class='removeActiveFilter' aria-label={{t 'eosf.components.discoverPage.removeSubject'}}>{{fa-icon 'times-circle' ariaHidden=false click=(action 'updateFilters' 'subjects' filter)}}</button></span>
+                                <span class='preprint-filter subject-filter'>{{filter}} <span class='removeActiveFilter' aria-label={{t 'eosf.components.discoverPage.removeSubject'}}>{{fa-icon 'times-circle' ariaHidden=false tagName='button' click=(action 'updateFilters' 'subjects' filter)}}</span></span>
                             {{/each}}
                             {{!ACTIVE TYPE FILTERS}}
                             {{#each activeFilters.types as |filter|}}
-                                <span class='preprint-filter type-filter'>{{filter}} <button class='removeActiveFilter' aria-label={{t 'eosf.components.discoverPage.removeRegistrationType'}}>{{fa-icon 'times-circle' ariaHidden=false click=(action 'updateFilters' 'types' filter)}}</button></span>
+                                <span class='preprint-filter type-filter'>{{filter}} <span class='removeActiveFilter' aria-label={{t 'eosf.components.discoverPage.removeRegistrationType'}}>{{fa-icon 'times-circle' ariaHidden=false tagName='button' click=(action 'updateFilters' 'types' filter)}}</span></span>
                             {{/each}}
                         </div>
                     </div>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-659

# Purpose

Fix inability to click x to remove active filter in Firefox

# Summary of changes

Made the fa-icon a button tag instead of the default i tag and changed containing tag to be a span.

# Testing notes

Need to check in all browsers. Tested in Chrome, FF, and Safari on Mac.

Note: In Firefox the click event is attached to the button, even when the button contains another object. This differs from Chrome and Safari (unsure about IE). Try https://jsfiddle.net/5pvLez34/ in various browsers.