### PR TITLE
Feature/C3 and D3 Package Versions [EOSF-511]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,8 @@
     "font-awesome": "~4.5.0",
     "typeahead.js": "^0.11.1",
     "jquery.tagsinput": "^1.3.6",
-    "c3": "^0.4.11",
-    "d3": "~3.5.0",
+    "c3": "0.4.11",
+    "d3": "3.5.17",
     "bootstrap-daterangepicker": "^2.1.23"
 
 


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-511

# Purpose
Current ember-osf develop build was failing.  Cause was C3 and D3 package versions "~" - thanks @binoculars for figuring this out!

# Summary of changes
Pinned to specific C3 and D3 versions


# Testing notes

