### PR TITLE
[EOSF-631] extract DOI utility and helper

### DIFF
--- a/addon/helpers/extract-doi.js
+++ b/addon/helpers/extract-doi.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import extractDoiFromString from '../utils/extract-doi-from-string';
+
+export function extractDoi(params) {
+  return extractDoiFromString(params[0]);
+}
+
+export default Ember.Helper.helper(extractDoi);

--- a/addon/utils/extract-doi-from-string.js
+++ b/addon/utils/extract-doi-from-string.js
@@ -1,0 +1,11 @@
+export default function extractDoiFromString(doi) {
+    // Attempts to Extracts a DOI from a string.
+    // For example, given "https://dx.doi.org/10.12345/hello" returns "10.12345/hello"
+    // If no DOI is found, the original string is returned.
+    const doiRegex = /\b(10\.\d{4,}(?:\.\d+)*\/\S+(?:(?!["&\'<>])\S))\b/;
+    if (doi) {
+        const doiOnly = doiRegex.exec(doi);
+        return doiOnly !== null ? doiOnly[0] : doi;
+    }
+    return doi;
+}

--- a/app/helpers/extract-doi.js
+++ b/app/helpers/extract-doi.js
@@ -1,0 +1,1 @@
+export { default, extractDoi } from 'ember-osf/helpers/extract-doi';

--- a/app/utils/extract-doi-from-string.js
+++ b/app/utils/extract-doi-from-string.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/utils/extract-doi-from-string';

--- a/tests/unit/helpers/extract-doi-test.js
+++ b/tests/unit/helpers/extract-doi-test.js
@@ -1,0 +1,13 @@
+
+import { extractDoi } from 'dummy/helpers/extract-doi';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | extract doi');
+
+test('DOI successfully extracted', function(assert) {
+    assert.equal(
+        extractDoi(['http://dx.doi.org/10.1000/182']),
+        '10.1000/182',
+        'Expected DOI to be extracted'
+    );
+});

--- a/tests/unit/utils/extract-doi-from-string-test.js
+++ b/tests/unit/utils/extract-doi-from-string-test.js
@@ -1,0 +1,25 @@
+import extractDoiFromString from 'dummy/utils/extract-doi-from-string';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | extract doi from string');
+
+test('return DOI when DOI found', function(assert) {
+    assert.equal(
+        extractDoiFromString('http://dx.doi.org/10.1000/182'),
+        '10.1000/182',
+        'Expected DOI for DOI URL containing valid DOI'
+    );
+    assert.equal(
+        extractDoiFromString('doi:10.1000/182'),
+        '10.1000/182',
+        'Expected DOI for prefixed valid DOI'
+    );
+});
+
+test('return original string when no DOI found', function(assert) {
+    assert.equal(
+        extractDoiFromString('12345'),
+        '12345',
+        'Expected original string for string without valid DOI'
+    );
+});


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-631

# Purpose

Moved method for extracting a DOI from a string into a utility and wrapped it with a helper.

# Summary of changes

Added utils/extract-doi-from-string and helpers/extract-doi

# Testing notes

Internally used utility. Should be tested in interfaces that parse DOIs from strings (e.g. preprint submission).