### PR TITLE
Change query param from 'next_url' to 'next' for logout redirect [EOSF-633]

### DIFF
--- a/addon/components/navbar-auth-dropdown/component.js
+++ b/addon/components/navbar-auth-dropdown/component.js
@@ -63,7 +63,7 @@ export default Ember.Component.extend({
     actions: {
         logout() {
             const redirectUrl = this.get('redirectUrl');
-            const query = redirectUrl ? '?' + Ember.$.param({ next_url: redirectUrl }) : '';
+            const query = redirectUrl ? '?' + Ember.$.param({ next: redirectUrl }) : '';
             // TODO: May not work well if logging out from page that requires login- check?
             this.get('session').invalidate()
                 .then(() => window.location.href = `${config.OSF.url}logout/${query}`);


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-633

# Purpose
When one logs out when on a branded preprint service, they will stay on the lading page instead be redirected to the OSF logout page.

# Summary of changes
Corrected the query param from 'next_url' to 'next'.

# Testing notes
None

