### PR TITLE
[EOSF-625] Fix date updated/modified on preprints search

### DIFF
--- a/addon/components/search-result/component.js
+++ b/addon/components/search-result/component.js
@@ -3,6 +3,7 @@ import layout from './template';
 import Analytics from '../../mixins/analytics';
 import hostAppName from '../../mixins/host-app-name';
 import providerRegex from 'ember-osf/const/providerRegex';
+import moment from 'moment';
 
 /**
  * Adapted from Ember-SHARE and Ember Preprints
@@ -124,6 +125,9 @@ export default Ember.Component.extend(Analytics, hostAppName, {
     // Determines whether tags in search results should be links - preprints and registries are not using tag filter right now
     tagsInQueryParams: Ember.computed('queryParams', function() {
         return (this.get('queryParams') || []).includes('tags');
+    }),
+    dateUpdated: Ember.computed('result.date_updated', function() {
+        return moment(this.get('result.date_updated')).utc().format('YYYY-MM-DD');
     }),
     didRender() {
         MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.$()[0]]);  // jshint ignore: line

--- a/addon/components/search-result/template.hbs
+++ b/addon/components/search-result/template.hbs
@@ -34,7 +34,7 @@
 
             {{!Last edited on on}}
             {{#if result.date_updated}}
-                <div class="m-t-sm"> <em> {{t "eosf.components.searchResult.lastEdited"}}: {{moment-format result.date_updated 'YYYY-MM-DD'}} </em> </div>
+                <div class="m-t-sm"> <em> {{t "eosf.components.searchResult.lastEdited"}}: {{dateUpdated}} </em> </div>
             {{/if}}
 
             {{!Disciplines}}

--- a/addon/components/search-result/template.hbs
+++ b/addon/components/search-result/template.hbs
@@ -34,7 +34,7 @@
 
             {{!Last edited on on}}
             {{#if result.date_updated}}
-                <div class="m-t-sm"> <em> {{t "eosf.components.searchResult.lastEdited"}}: {{dateUpdated}} </em> </div>
+                <div class="m-t-sm"> <em> {{t "eosf.components.searchResult.lastEdited"}}: {{dateUpdated}} (UTC) </em> </div>
             {{/if}}
 
             {{!Disciplines}}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-625

# Purpose

On preprints search, the dates from SHARE are not being displayed properly.  
For example, on this preprint the date modified shows 2017-06-04:
<img width="754" alt="screen shot 2017-06-06 at 3 38 43 pm" src="https://user-images.githubusercontent.com/19379783/26848413-5ccf1a08-4ace-11e7-872b-ace9d5084c58.png">

But when you look at the date_updated in the elastic search results it shows 2017-06-05:
<img width="391" alt="screen shot 2017-06-06 at 3 40 53 pm" src="https://user-images.githubusercontent.com/19379783/26848480-9a29cb3c-4ace-11e7-846a-0df28bca16e1.png">

The issue is coming from the moment-format function used in the template.  After the fix, the date_updated shown in the search results match the elastic search results:
<img width="749" alt="screen shot 2017-06-06 at 3 42 32 pm" src="https://user-images.githubusercontent.com/19379783/26848534-c8805b9a-4ace-11e7-9e6b-6f37a22446ad.png">


# Summary of changes

The main issue comes from the moment-format function trying to update the date being given to match the current time zone.  The primary change was to create a computed function that handles the format of the date instead of the old moment-format function.

(UTC) has also been added to the end of the timestamp label so that users know exactly what date the changes took place.

<img width="746" alt="screen shot 2017-06-13 at 3 05 18 pm" src="https://user-images.githubusercontent.com/19379783/27099882-4aed0562-504a-11e7-96dd-6d90487857fb.png">
