### PR TITLE
[EOSF-699] Use sudo:required in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 
-sudo: false
+sudo: required
 dist: trusty
 
 env:


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-699

# Purpose

Use "sudo: required" in Travis to get a build environment with more memory

# Summary of changes

Changed to "sudo: required" in .travis.yml

# Testing notes

