### PR TITLE
Update Google Plus and Facebook footer links [EOSF-669]

### DIFF
--- a/addon/components/osf-footer/template.hbs
+++ b/addon/components/osf-footer/template.hbs
@@ -27,10 +27,10 @@
             <div class="col-sm-4 col-md-3">
                 <h4>Socialize</h4>
                 <a href="http://twitter.com/OSFramework" aria-label="Twitter"><i class="fa fa-twitter fa-2x"></i></a>
-                <a href="https://www.facebook.com/OpenScienceFramework" aria-label="Facebook"><i class="fa fa-facebook fa-2x"></i></a>
+                <a href="https://www.facebook.com/CenterForOpenScience/" aria-label="Facebook"><i class="fa fa-facebook fa-2x"></i></a>
                 <a href="https://groups.google.com/forum/#!forum/openscienceframework" aria-label="Google Group"><i class="fa fa-group fa-2x"></i></a>
                 <a href="https://www.github.com/centerforopenscience" aria-label="GitHub"><i class="fa fa-github fa-2x"></i></a>
-                <a href="https://plus.google.com/103557785986281627994" aria-label="Google Plus" rel="publisher"><i class="fa fa-google-plus fa-2x"></i></a>
+                <a href="https://plus.google.com/104751442909573665859" aria-label="Google Plus" rel="publisher"><i class="fa fa-google-plus fa-2x"></i></a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-669

# Purpose
Facebook and Google Plus Links were changed, needed the ember footer to reflect this.

# Summary of changes
Changed the hyperlinks for the Google Plus and Facebook icons.

# Testing notes
None
