### PR TITLE
Use headless chrome for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 
 sudo: required
 dist: trusty
+addons:
+  chrome: stable
 
 env:
   global:

--- a/testem.json
+++ b/testem.json
@@ -3,10 +3,16 @@
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [
-    "PhantomJS"
+    "Chrome"
   ],
   "launch_in_dev": [
-    "PhantomJS",
     "Chrome"
-  ]
+  ],
+  "browser_args": {
+    "Chrome": [
+      "--headless",
+      "--disable-gpu",
+      "--remote-debugging-port=9222"
+    ]
+  }
 }


### PR DESCRIPTION
## Ticket

N/A

# Purpose

Use headless Chrome for tests

# Summary of changes

Added chrome:stable addon for Travis and configure testem to use headless Chrome

# Testing notes

