### PR TITLE
Feature/Discover Page Changes for ASU Repository [EOSF-680]

### DIFF
--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -48,6 +48,7 @@ import { getUniqueList, getSplitParams, encodeParams } from '../../utils/elastic
  *    showActiveFilters=showActiveFilters
  *    sortOptions=sortOptions
  *    subject=subject
+ *    themeProvider=themeProvider
 * }}
  * ```
  * @class discover-page
@@ -286,6 +287,12 @@ export default Ember.Component.extend(Analytics, hostAppName, {
      * @default ''
      */
     tags: '',
+    /**
+     * themeProvider
+     * @property {Object} Preprint provider loaded from theme servicer
+     * @default ''
+     */
+    themeProvider: null,
     took: 0,
     /**
      * type query parameter.  If "type" is one of your query params, it must be passed to the component so it can be reflected in the URL.
@@ -477,11 +484,13 @@ export default Ember.Component.extend(Analytics, hostAppName, {
             });
         });
 
-        // For PREPRINTS and REGISTRIES. If theme.isProvider, add this provider to the query body
-        if (this.get('theme.isProvider') && this.get('providerName') !== null) {
+        // For PREPRINTS and REGISTRIES. If theme.isProvider, add provider(s) to query body
+        if (this.get('theme.isProvider') && this.get('themeProvider.name') !== null) {
+            const themeProvider = this.get('themeProvider');
+            const sources = (themeProvider.get('additionalProviders') || []).length ? themeProvider.get('additionalProviders') : [themeProvider.get('name')];
             filters.push({
                 terms: {
-                    sources: [this.get('providerName')]
+                    sources: sources
                 }
             });
         }

--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -108,11 +108,11 @@ export default Ember.Component.extend(Analytics, hostAppName, {
             { key: 'contributors', title: 'People', component: 'search-facet-typeahead', base: 'agents', type: 'person' }
         ]
      */
-    facets: Ember.computed('processedTypes', function() {
+    facets: Ember.computed(function() {
         return [
             { key: 'sources', title: `${this.get('i18n').t('eosf.components.discoverPage.source')}`, component: 'search-facet-source' },
             { key: 'date', title: `${this.get('i18n').t('eosf.components.discoverPage.date')}`, component: 'search-facet-daterange' },
-            { key: 'type', title: `${this.get('i18n').t('eosf.components.discoverPage.type')}`, component: 'search-facet-worktype', data: this.get('processedTypes') },
+            { key: 'type', title: `${this.get('i18n').t('eosf.components.discoverPage.type')}`, component: 'search-facet-worktype', },
             { key: 'tags', title: `${this.get('i18n').t('eosf.components.discoverPage.tag')}`, component: 'search-facet-typeahead' },
             { key: 'publishers', title: `${this.get('i18n').t('eosf.components.discoverPage.publisher')}`, component: 'search-facet-typeahead', base: 'agents', type: 'publisher' },
             { key: 'funders', title: `${this.get('i18n').t('eosf.components.discoverPage.funder')}`, component: 'search-facet-typeahead', base: 'agents', type: 'funder' },
@@ -354,11 +354,6 @@ export default Ember.Component.extend(Analytics, hostAppName, {
             this.setActiveFiltersAndReload('activeFilters.providers', filter.split('OR'));
         }
     })),
-    processedTypes: Ember.computed('types', function() {
-        // Ember-SHARE property
-        const types = this.get('types') && this.get('types').CreativeWork ? this.get('types').CreativeWork.children : {};
-        return this.transformTypes(types);
-    }),
     reloadSearch: Ember.observer('activeFilters.providers.@each', 'activeFilters.subjects.@each', 'activeFilters.types.@each', function() {
         // For PREPRINTS and REGISTRIES.  Reloads page if activeFilters change.
         this.set('page', 1);
@@ -526,26 +521,12 @@ export default Ember.Component.extend(Analytics, hostAppName, {
         this.set('displayQueryBody', { query });
         return this.set('queryBody', queryBody);
     },
-    getTypes() {
-        // Ember-SHARE method
-        return Ember.$.ajax({
-            url: config.OSF.shareApiUrl + '/schema/creativework/hierarchy/',
-            crossDomain: true,
-            type: 'GET',
-            contentType: 'application/vnd.api+json',
-        }).then((json) => {
-            if (json.data) {
-                this.set('types', json.data);
-            }
-        });
-    },
     init() {
         //TODO Sort initial results on date_modified
         // Runs on initial render.
         this._super(...arguments);
         this.set('firstLoad', true);
         this.set('facetFilters', Ember.Object.create());
-        this.getTypes();
         this.getCounts();
         this.loadPage();
     },
@@ -671,21 +652,6 @@ export default Ember.Component.extend(Analytics, hostAppName, {
                 extra: this.get('q')
 
             });
-    },
-    transformTypes(obj) {
-        // Ember-SHARE method
-        if (typeof (obj) !== 'object') {
-            return obj;
-        }
-
-        for (let key in obj) {
-            let lowKey = key.replace(/([A-Z])/g, ' $1').trim().toLowerCase();
-            obj[lowKey] = this.transformTypes(obj[key]);
-            if (key !== lowKey) {
-                delete obj[key];
-            }
-        }
-        return obj;
     },
     actions: {
         addFilter(type, filterValue) {

--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -179,7 +179,6 @@ export default Ember.Component.extend(Analytics, hostAppName, {
      * @default ''
      */
     provider: '',
-    providerName: null, // For PREPRINTS and REGISTRIES. Provider name, if theme.isProvider, ex: psyarxiv
     /**
      * Publishers query parameter.  If "publishers" is one of your query params, it must be passed to the component so it can be reflected in the URL.
      * @property {String} publishers
@@ -539,7 +538,6 @@ export default Ember.Component.extend(Analytics, hostAppName, {
         this.set('facetFilters', Ember.Object.create());
         this.getTypes();
         this.getCounts();
-        this.loadProvider();
         this.loadPage();
     },
     loadPage() {
@@ -633,16 +631,6 @@ export default Ember.Component.extend(Analytics, hostAppName, {
             jqDeferred.done((value) => resolve(value));
             jqDeferred.fail((reason) => reject(reason));
         });
-    },
-    loadProvider() {
-        // For PREPRINTS and REGISTRIES - Loads preprint provider if theme.isProvider
-        // Needed because theme's provider was not loading before SHARE was queried.
-        if (this.get('theme.isProvider')) {
-            this.get('theme.provider').then(provider => {
-                this.set('providerName', provider.get('name'));
-                this.loadPage();
-            });
-        }
     },
     scrollToResults() {
         // Scrolls to top of search results

--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -482,6 +482,8 @@ export default Ember.Component.extend(Analytics, hostAppName, {
         // For PREPRINTS and REGISTRIES. If theme.isProvider, add provider(s) to query body
         if (this.get('theme.isProvider') && this.get('themeProvider.name') !== null) {
             const themeProvider = this.get('themeProvider');
+            // Regular preprint providers will have their search results restricted to the one provider.
+            // If the provider has additionalProviders, all of these providers will be added to the "sources" SHARE query
             const sources = (themeProvider.get('additionalProviders') || []).length ? themeProvider.get('additionalProviders') : [themeProvider.get('name')];
             filters.push({
                 terms: {

--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -289,7 +289,7 @@ export default Ember.Component.extend(Analytics, hostAppName, {
     tags: '',
     /**
      * themeProvider
-     * @property {Object} Preprint provider loaded from theme servicer
+     * @property {Object} Preprint provider loaded from theme service. Should be passed into component so it is loaded before SHARE is queried.
      * @default ''
      */
     themeProvider: null,

--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -289,7 +289,7 @@ export default Ember.Component.extend(Analytics, hostAppName, {
     tags: '',
     /**
      * themeProvider
-     * @property {Object} Preprint provider loaded from theme service. Should be passed into component so it is loaded before SHARE is queried.
+     * @property {Object} Preprint provider loaded from theme service. Should be passed from consuming service so it is loaded before SHARE is queried.
      * @default ''
      */
     themeProvider: null,

--- a/addon/components/discover-page/template.hbs
+++ b/addon/components/discover-page/template.hbs
@@ -156,7 +156,7 @@
                     {{#if numberOfResults}} {{!RESULTS FOUND}}
                         <div class="results-top">
                             {{#each results as |result|}}
-                                {{search-result queryParams=queryParams detailRoute=detailRoute filterReplace=filterReplace addFilter='addFilter' updateFilters=(action 'updateFilters') result=result currentService=currentService}}
+                                {{search-result themeProvider=themeProvider queryParams=queryParams detailRoute=detailRoute filterReplace=filterReplace addFilter='addFilter' updateFilters=(action 'updateFilters') result=result currentService=currentService}}
                             {{/each}}
                         </div>
                         <div class="pull-right text-right">

--- a/addon/components/discover-page/template.hbs
+++ b/addon/components/discover-page/template.hbs
@@ -141,7 +141,7 @@
                 }}
 
                 {{!ADD PREPRINT BUTTON - Preprints Only }}
-                {{#if (eq hostAppName 'Preprints')}}
+                {{#if (and (eq hostAppName 'Preprints') themeProvider.allowSubmissions)}}
                     {{add-preprint-box}}
                 {{/if}}
 

--- a/addon/components/search-facet-worktype/template.hbs
+++ b/addon/components/search-facet-worktype/template.hbs
@@ -1,7 +1,7 @@
 {{!Copied from Ember-SHARE}}
 <div class='filter-block'>
     {{search-facet-worktype-hierarchy state=state defaultCollapsed=true
-        data=data onClick=(action 'toggle')}}
+        data=processedTypes onClick=(action 'toggle')}}
     <div class='indent row'>
         {{search-facet-worktype-button type='creative work' collapsible=false
                 selectedTypes=selected onClick=(action 'toggle') toggleState=toggleState

--- a/addon/components/search-result/component.js
+++ b/addon/components/search-result/component.js
@@ -43,7 +43,12 @@ export default Ember.Component.extend(Analytics, hostAppName, {
      * Name of detail route for consuming application, if you want search result to link to a route in the consuming spp
      * @property {String} detailRoute
      */
-    detailRoute: null,
+     detailRoute: null,
+    /**
+     * Provider loaded from theme service. Passed in from consuming application.
+    * @property {Object} themeProvider
+    */
+    themeProvider: null,
     footerIcon: Ember.computed('showBody', function() {
         return this.get('showBody') ? 'caret-up' : 'caret-down';
     }),
@@ -121,9 +126,10 @@ export default Ember.Component.extend(Analytics, hostAppName, {
 
         return identifiers[0];
     }),
-    // Determines whether tags in search results should be links - preprints and registries are not using tag filter right now
-    tagsInQueryParams: Ember.computed('queryParams', function() {
-        return (this.get('queryParams') || []).includes('tags');
+    // Determines whether tags in search results should be links - preprints and registries are not using tag filter right now.
+    // NEW: Preprint providers with additionalProviders are using tags, however.
+    tagsInQueryParams: Ember.computed('queryParams', 'themeProvider', function() {
+        return (this.get('queryParams') || []).includes('tags') && (this.get('themeProvider.additionalProviders') || []).length;
     }),
     didRender() {
         MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.$()[0]]);  // jshint ignore: line

--- a/tests/integration/components/search-facet-worktype/component-test.js
+++ b/tests/integration/components/search-facet-worktype/component-test.js
@@ -11,7 +11,7 @@ test('it renders', function(assert) {
     this.set('state', ['Publication']);
     this.set('filter', '');
     this.set('onChange', () => {});
-    this.set('data', {'presentation': {} });
+    this.set('processedTypes', {'presentation': {} });
 
     this.render(hbs`{{search-facet-worktype
         key=key
@@ -19,7 +19,7 @@ test('it renders', function(assert) {
         filter=filter
         onChange=(action onChange)
         selected=selected
-        data=data
+        processedTypes=processedTypes
     }}`);
 
   assert.equal(this.$('.type-filter-option')[0].innerText.trim(), 'Presentation');


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-680
❗️ is needed for https://github.com/CenterForOpenScience/ember-preprints/pull/383

# Purpose
Make changes to the discover-page widget that are needed for the ASU repository.


# Summary of changes
- Provider is passed into component
- Search-facet-worktype component is now taking care of building the list of types itself, instead of passing them into the component.  This allows preprints to be able to use this facet.
- Only show add preprint box on submissions page allowSubmissions is true.
- Conditionally modify search query.  If additionalProviders exist, pass all providers (like ASU, Symbiota, etc. into query). Otherwise, just pass single provider like engrxiv.
- Tags on search result are conditionally clickable (allowed if additionalProviders exist, because repositories with additionalProviders are using the tags facet)


# Testing notes

