### PR TITLE
hotfix/Fix production's shareBaseURL: add trailing slash [EOSF-682]

### DIFF
--- a/config/backends.json
+++ b/config/backends.json
@@ -55,7 +55,7 @@
         "helpUrl": "http://help.osf.io",
         "cookieLoginUrl": "https://accounts.osf.io/login",
         "oauthUrl": "https://accounts.osf.io/oauth2/authorize",
-        "shareBaseUrl": "https://share.osf.io",
+        "shareBaseUrl": "https://share.osf.io/",
         "shareApiUrl": "https://share.osf.io/api/v2",
         "shareSearchUrl": "https://share.osf.io/api/v2/search/creativeworks/_search"
     },


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-682

# Purpose
Fix share links on preprint results entries.

# Summary of changes
Add trailing slash to production share url in config file.

# Testing notes
This problem only shows up on production. There will be no changes on staging.
