### PR TITLE
Add emailSupport back to the preprint provider model [EOSF-713]

### DIFF
--- a/addon/models/preprint-provider.js
+++ b/addon/models/preprint-provider.js
@@ -8,6 +8,7 @@ export default OsfModel.extend({
     domainRedirectEnabled: DS.attr('boolean'),
     example: DS.attr('fixstring'),
     advisoryBoard: DS.attr('string'),
+    emailSupport: DS.attr('fixstring'),
     subjectsAcceptable: DS.attr(),
     footerLinks: DS.attr('string'),
     allowSubmissions: DS.attr('boolean'),


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-713

# Purpose

emailSupport was removed from the API and the ember model, but it is used by the 404 page for branded preprints.

# Summary of changes

Added emailSupport back to the preprint provider model.

# Testing notes

Make sure email address and link appear for branded preprint 404 pages.