### PR TITLE
Feature/Remove White Space from SHARE Resource Type [EOSF-680]

### DIFF
--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -555,7 +555,7 @@ export default Ember.Component.extend(Analytics, hostAppName, {
                     hyperLinks: [// Links that are hyperlinks from hit._source.lists.links
                         {
                             type: 'share',
-                            url: config.OSF.shareBaseUrl + `${hit._source.type}` + '/' + hit._id
+                            url: config.OSF.shareBaseUrl + `${hit._source.type.replace(/ /g,'')}` + '/' + hit._id
                         }
                     ],
                     infoLinks: [], // Links that are not hyperlinks  hit._source.lists.links


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-680

# Purpose
When building hyperlinks from returned SHARE search, "creative work" results were being returned, and the url is built from the type. Remove white space from type.


# Summary of changes
URL's being returned should look like: https://staging-share.osf.io/creativework/46107-45A-314

# Testing notes

