### PR TITLE
[EOSF-694] Discover search on 'enter' instead of onkeypress

### DIFF
--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -761,17 +761,6 @@ export default Ember.Component.extend(Analytics, hostAppName, {
             // Toggles display of Lucene Search help modal
             this.toggleProperty('showLuceneHelp');
         },
-        typing(val, event) {
-             // Fires on keyup in search bar
-             // Ignores all keycodes that don't result in the value changing
-             // 8 == Backspace, 32 == Space
-            if (event.keyCode < 49 && !(event.keyCode === 8 || event.keyCode === 32)) {
-                return;
-            }
-            // Tracks search on keypress, debounced
-            Ember.run.debounce(this, this.trackDebouncedSearch, 3000);
-            this.search();
-        },
         updateFilters(filterType, item) {
             // For PREPRINTS and REGISTRIES.  Modifies activeFilters.
             item = typeof item === 'object' ? item.text : item;

--- a/addon/components/discover-page/template.hbs
+++ b/addon/components/discover-page/template.hbs
@@ -28,7 +28,7 @@
             <div class="col-xs-12 col-sm-8 col-sm-offset-2">
                 {{!SEARCH BAR}}
                 <div class="input-group input-group-lg">
-                    {{input id="searchBox" value=q class="form-control" key-up='typing' placeholder=searchPlaceholder}}
+                    {{input id="searchBox" value=q class="form-control" enter="search" placeholder=searchPlaceholder}}
                     <span class="input-group-btn">
                         {{!HELP BUTTON}}
                         <button class="btn btn-default" type="button" aria-label={{t 'eosf.components.discoverPage.luceneHelp'}} {{action 'toggleShowLuceneHelp'}}> <i class="fa fa-question text-muted"></i></button>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-694

# Purpose

Instant search is currently being implemented on the discover search page for Registries and Preprints.  This is clashing with the new Lucene search syntax that has recently been implemented.  The purpose of this ticket is to remove the instant search feature so that the user can fully type in their search criteria before getting back results.

# Summary of changes

The search bar is now directly calling the search action on enter keypress or when the search button is called.  The instant search function has been removed, so now the user has to fully enter their phrase before getting back any results.

Before the changes, if the user typed some Lucene syntax into the search bar it would return an error with notes on Lucene syntax:
<img width="1163" alt="screen shot 2017-06-26 at 1 58 11 pm" src="https://user-images.githubusercontent.com/19379783/27553052-896f43e0-5a77-11e7-8187-f641baa695bb.png">

Now that it waits for the user to enter in everything and submit manually, there isn't any error returned:
<img width="1136" alt="screen shot 2017-06-26 at 1 59 10 pm" src="https://user-images.githubusercontent.com/19379783/27553105-a88155de-5a77-11e7-85d9-8f20ffe26a3a.png">
