### PR TITLE
[EOSF-696]Add style path to share logo on the provider's asset directory

### DIFF
--- a/addon/components/discover-page/template.hbs
+++ b/addon/components/discover-page/template.hbs
@@ -18,7 +18,7 @@
                         <h1> {{discoverHeader}} </h1>
                     {{/if}}
                     {{!POWERED BY SHARE}}
-                    <p class="lead">{{t 'eosf.components.discoverPage.poweredBy'}} <a href="https://share.osf.io/" id='share-logo' class="share-logo" title="SHARE" onclick={{action "click" "link" "Discover - SHARE Logo"}}></a></p>
+                    <p class="lead">{{t 'eosf.components.discoverPage.poweredBy'}} <a href="https://share.osf.io/" id='share-logo' style="background-image: url('./powered_by_share.png')" class="share-logo" title="SHARE" onclick={{action "click" "link" "Discover - SHARE Logo"}}></a></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-696

# Purpose
Use the same path for both white and black share logos, witht he provider directory having the asset wanted by the provider.

