### PR TITLE
Feature/remove shareTotal request for branded preprint providers [EOSF-720]

### DIFF
--- a/addon/components/discover-page/template.hbs
+++ b/addon/components/discover-page/template.hbs
@@ -40,7 +40,9 @@
                 {{search-help-modal isOpen=showLuceneHelp}}
 
                 {{!NUMBER OF SEARCHABLE RESULTS}}
-                {{total-share-results}}
+                {{#if (not theme.isProvider)}}
+                    {{total-share-results}}
+                {{/if}}
             </div>
         </div>
 


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-720

# Purpose
Remove “X many preprints have been archived” from  Paleorxiv.

# Summary of changes
Now for branded preprint providers shareTotal is set to zero and there is no longer a request to grab the number of share results.

# Testing notes
Does Paleorxiv no longer show a “X many preprints have been archived.” Does it still show up on registries and the landing page.
