### PR TITLE
[EOSF-733] Fix search facet worktype expand button in FF & Safari

### DIFF
--- a/addon/components/search-facet-worktype-button/style.scss
+++ b/addon/components/search-facet-worktype-button/style.scss
@@ -25,9 +25,9 @@
     background-color: white;
     border: .5px solid #ccc;
     border-radius: 10px;
-    padding-left: 8px;
-    padding-right: 8px;
-    margin-left: -9px;
+    padding-left: 6px;
+    padding-right: 6px;
+    margin-left: -7px;
 }
 
 .type-filter-option {
@@ -36,17 +36,15 @@
         background: none;
         border: none;
         display: inline;
-        font: inherit;
         outline:none;
         margin: 0;
         padding: 0;
         outline-offset: 0;
     }
-}
-
-.expand-icon {
-    font-size: 10px;
-    color: dimgray;
-    margin-left: -15px;
-    padding-right: 3px;
+    .expand-icon {
+        font-size: 10px;
+        color: dimgray;
+        margin-left: -18px;
+        margin-right: 6px;
+    }
 }

--- a/addon/components/search-facet-worktype-button/template.hbs
+++ b/addon/components/search-facet-worktype-button/template.hbs
@@ -1,9 +1,10 @@
 {{!Adapted from Ember-SHARE}}
 <div class='type-filter-option {{if selected 'active'}}'>
     {{#if collapsible}}
-        <button class="btn-link"  {{action 'toggleBody'}} aria-label={{t 'eosf.components.searchFacetWorktypeButton.expandWorktype'}}>
-            <i class='fa expand-icon clickable {{if toggleState 'fa-plus' 'fa-minus'}}'></i>
-        </button>
+        <button
+            class="btn-link fa expand-icon clickable {{if toggleState 'fa-plus' 'fa-minus'}}"
+            {{action 'toggleBody'}}
+            aria-label={{t 'eosf.components.searchFacetWorktypeButton.expandWorktype'}} />
     {{/if}}
     <span class={{if selected 'bubble'}}>
         <button class='clickable btn-link' {{action 'click'}}>{{label}}</button>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-733

# Purpose

Fix search facet worktype expand button in FF & Safari

# Summary of changes

Moved font awesome icon classes to button itself to avoid zero-width button in Firefox and Safari

# Testing notes

Make sure this also works in IE.