### PR TITLE
[EOSF-541] Shorten "Add a preprint" to "Add" in navbar for small screens

### DIFF
--- a/addon/components/new-osf-navbar/template.hbs
+++ b/addon/components/new-osf-navbar/template.hbs
@@ -48,12 +48,12 @@
                             {{!SERVICE LINK}}
                             <li>
                                 <a href="{{navLink.href}}">
-                                    {{#if (eq navLink.name (t 'eosf.navbar.addAPreprint'))}}
+                                    {{#if (eq navLink.type 'addAPreprint')}}
                                         <span class="hidden-xs hidden-sm">
-                                            {{t 'eosf.navbar.add'}}
+                                            {{navLink.name}}
                                         </span>
                                         <span class="hidden-md hidden-lg hidden-xl">
-                                            {{navLink.name}}
+                                            {{t 'eosf.navbar.add'}}
                                         </span>
                                     {{else}}
                                         {{navLink.name}}

--- a/addon/components/new-osf-navbar/template.hbs
+++ b/addon/components/new-osf-navbar/template.hbs
@@ -46,7 +46,20 @@
                             </li>
                         {{else}}
                             {{!SERVICE LINK}}
-                            <li><a href="{{navLink.href}}"> {{navLink.name}}</a></li>
+                            <li>
+                                <a href="{{navLink.href}}">
+                                    {{#if (eq navLink.name (t 'eosf.navbar.addAPreprint'))}}
+                                        <span class="hidden-xs hidden-sm">
+                                            {{t 'eosf.navbar.add'}}
+                                        </span>
+                                        <span class="hidden-md hidden-lg hidden-xl">
+                                            {{navLink.name}}
+                                        </span>
+                                    {{else}}
+                                        {{navLink.name}}
+                                    {{/if}}
+                                </a>
+                            </li>
                         {{/if}}
                     {{/each}}
                     {{!AUTH NAVBAR}}

--- a/addon/helpers/build-secondary-nav-links.js
+++ b/addon/helpers/build-secondary-nav-links.js
@@ -36,7 +36,8 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
             PREPRINTS: [
                 {
                     name: i18n.t('eosf.navbar.addAPreprint'),
-                    href: serviceLinks.preprintsSubmit
+                    href: serviceLinks.preprintsSubmit,
+                    type: 'addAPreprint'
                 },
                 {
                     name: i18n.t('eosf.navbar.search'),

--- a/addon/locales/en/translations.js
+++ b/addon/locales/en/translations.js
@@ -20,6 +20,7 @@ export default {
             buttonSubmit: 'Create account'
         },
         navbar: {
+            add: 'Add',
             addAPreprint: 'Add a preprint',
             browse: 'Browse',
             cancelSearch: 'Cancel search',


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-541

# Purpose

Shorten "Add a preprint" to "Add" for small and xs screens"

# Summary of changes

Added template logic to display shortened version for small and xs screens.

# Testing notes

Breakpoint is at 992px wide