### PR TITLE
[EOSF-754] Fix display of custom taxonomy subjects

### DIFF
--- a/addon/components/discover-page/template.hbs
+++ b/addon/components/discover-page/template.hbs
@@ -123,7 +123,7 @@
                             {{/each}}
                             {{#each activeFilters.subjects as |filter|}}
                                 {{!ACTIVE SUBJECT FILTERS}}
-                                <span class='preprint-filter subject-filter'>{{filter}} <span class='removeActiveFilter' aria-label={{t 'eosf.components.discoverPage.removeSubject'}}>{{fa-icon 'times-circle' ariaHidden=false tagName='button' click=(action 'updateFilters' 'subjects' filter)}}</span></span>
+                                <span class='preprint-filter subject-filter'>{{custom-taxonomy-filter filter}} <span class='removeActiveFilter' aria-label={{t 'eosf.components.discoverPage.removeSubject'}}>{{fa-icon 'times-circle' ariaHidden=false tagName='button' click=(action 'updateFilters' 'subjects' filter)}}</span></span>
                             {{/each}}
                             {{!ACTIVE TYPE FILTERS}}
                             {{#each activeFilters.types as |filter|}}

--- a/addon/components/search-result/component.js
+++ b/addon/components/search-result/component.js
@@ -90,12 +90,12 @@ export default Ember.Component.extend(Analytics, hostAppName, {
         let uniqueSubs = {}
         subs.map(e => {
             let tax, subjects;
-            [tax, ...subjects] = e.text.split('/');
+            [tax, ...subjects] = e.text.split('|');
             if (subjects.length) { //accounting for non-custom taxonomy subjects, if we ever get back to that
                 for (var i = 0; i < subjects.length; i++) {
                     uniqueSubs[subjects[i]] = {
                         text: subjects[i],
-                        value: [tax, ...subjects.slice(0, i+1)].join('/'),
+                        value: [tax, ...subjects.slice(0, i+1)].join('|'),
                         taxonomy: tax
                     }
                 }

--- a/addon/components/search-result/component.js
+++ b/addon/components/search-result/component.js
@@ -86,18 +86,25 @@ export default Ember.Component.extend(Analytics, hostAppName, {
         return (this.get('result.tags') || []).slice(0, this.get('maxTags'));
     }),
     subjects: Ember.computed('result.subjects', function() {
-        // TODO: how to check if this app actually uses custom taxonomies
         let subs = this.get('result.subjects');
         let uniqueSubs = {}
         subs.map(e => {
             let tax, subjects;
             [tax, ...subjects] = e.text.split('/');
-            for (var i = 0; i < subjects.length; i++) {
-                uniqueSubs[subjects[i]] = {
-                    text: subjects[i],
-                    value: [tax, ...subjects.slice(0, i+1)].join('/'),
-                    taxonomy: tax
+            if (subjects.length) { //accounting for non-custom taxonomy subjects, if we ever get back to that
+                for (var i = 0; i < subjects.length; i++) {
+                    uniqueSubs[subjects[i]] = {
+                        text: subjects[i],
+                        value: [tax, ...subjects.slice(0, i+1)].join('/'),
+                        taxonomy: tax
+                    }
                 }
+            } else {
+                uniqueSubs[e.text] = {
+                    text: e.text,
+                    value: e.text,
+                    taxonomy: null
+                };
             }
         });
         uniqueSubs = Object.keys(uniqueSubs).map(e => uniqueSubs[e]);

--- a/addon/components/search-result/component.js
+++ b/addon/components/search-result/component.js
@@ -86,7 +86,22 @@ export default Ember.Component.extend(Analytics, hostAppName, {
         return (this.get('result.tags') || []).slice(0, this.get('maxTags'));
     }),
     subjects: Ember.computed('result.subjects', function() {
-        return (this.get('result.subjects') || []).slice(0, this.get('maxSubjects'));
+        // TODO: how to check if this app actually uses custom taxonomies
+        let subs = this.get('result.subjects');
+        let uniqueSubs = {}
+        subs.map(e => {
+            let tax, subjects;
+            [tax, ...subjects] = e.text.split('/');
+            for (var i = 0; i < subjects.length; i++) {
+                uniqueSubs[subjects[i]] = {
+                    text: subjects[i],
+                    value: [tax, ...subjects.slice(0, i+1)].join('/'),
+                    taxonomy: tax
+                }
+            }
+        });
+        uniqueSubs = Object.keys(uniqueSubs).map(e => uniqueSubs[e]);
+        return (uniqueSubs || []).slice(0, this.get('maxSubjects'));
     }),
     extraSubjects: Ember.computed('result.subjects', function() {
         return (this.get('result.subjects') || []).slice(this.get('maxSubjects'));

--- a/addon/components/search-result/template.hbs
+++ b/addon/components/search-result/template.hbs
@@ -42,7 +42,7 @@
             {{#if subjects}}
                 <div class="m-t-sm">
                     {{#each subjects as |subject|}}
-                        <span role="button" class="subject-preview pointer" onclick={{action updateFilters 'subjects' subject.text}}>
+                        <span role="button" class="subject-preview pointer" onclick={{action updateFilters 'subjects' (or subject.value subject.text)}}>
                             {{subject.text}}
                         </span>
                     {{/each}}

--- a/addon/helpers/custom-taxonomy-filter.js
+++ b/addon/helpers/custom-taxonomy-filter.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+var customTaxonomies = ['bepress'];
+
+export function customTaxonomyFilter(params/*, hash*/) {
+    let words = params[0].split('/');
+    if (customTaxonomies.indexOf(words[0]) !== -1 && words.length > 1) {
+        return words[words.length - 1];
+    }
+    return params[0];
+}
+
+export default Ember.Helper.helper(customTaxonomyFilter);

--- a/addon/helpers/custom-taxonomy-filter.js
+++ b/addon/helpers/custom-taxonomy-filter.js
@@ -3,11 +3,8 @@ import Ember from 'ember';
 var customTaxonomies = ['bepress'];
 
 export function customTaxonomyFilter(params/*, hash*/) {
-    let words = params[0].split('/');
-    if (customTaxonomies.indexOf(words[0]) !== -1 && words.length > 1) {
-        return words[words.length - 1];
-    }
-    return params[0];
+    let words = params[0].split('|');
+    return words.length > 1 ? words[words.length - 1] : params[0];
 }
 
 export default Ember.Helper.helper(customTaxonomyFilter);

--- a/app/helpers/custom-taxonomy-filter.js
+++ b/app/helpers/custom-taxonomy-filter.js
@@ -1,0 +1,1 @@
+export { default, customTaxonomyFilter } from 'ember-osf/helpers/custom-taxonomy-filter';

--- a/tests/unit/helpers/custom-taxonomy-filter-test.js
+++ b/tests/unit/helpers/custom-taxonomy-filter-test.js
@@ -4,12 +4,12 @@ import { module, test } from 'qunit';
 module('Unit | Helper | custom taxonomy filter');
 
 test('replace very deep custom taxonomy hierarchy with just final subject name', function(assert) {
-    let result = customTaxonomyFilter(['bepress/Fruits/Bananas/Green Bananas/Small Green Bananas/Small Green Bananas with Polka Dots']);
+    let result = customTaxonomyFilter(['bepress|Fruits|Bananas|Green Bananas|Small / Green Bananas|Small Green Bananas with Polka Dots']);
     assert.equal(result, 'Small Green Bananas with Polka Dots');
 });
 
 test('replace shallow custom taxonomy with just final subject name', function(assert) {
-    let result = customTaxonomyFilter(['bepress/Fruits']);
+    let result = customTaxonomyFilter(['bepress|Fruits']);
     assert.equal(result, 'Fruits');
 });
 
@@ -18,7 +18,7 @@ test('return original subject if not a custom taxonomy', function(assert) {
     assert.equal(result, 'Fruits and Bananas');
 });
 
-test('return original subject if not a recognized custom taxonomy', function(assert) {
+test('return original subject if separated with slashes', function(assert) {
     let result = customTaxonomyFilter(['osf/Fruits/Bananas']);
     assert.equal(result, 'osf/Fruits/Bananas');
 });

--- a/tests/unit/helpers/custom-taxonomy-filter-test.js
+++ b/tests/unit/helpers/custom-taxonomy-filter-test.js
@@ -1,12 +1,24 @@
-
 import { customTaxonomyFilter } from 'dummy/helpers/custom-taxonomy-filter';
 import { module, test } from 'qunit';
 
 module('Unit | Helper | custom taxonomy filter');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
-  let result = customTaxonomyFilter([42]);
-  assert.ok(result);
+test('replace very deep custom taxonomy hierarchy with just final subject name', function(assert) {
+    let result = customTaxonomyFilter(['bepress/Fruits/Bananas/Green Bananas/Small Green Bananas/Small Green Bananas with Polka Dots']);
+    assert.equal(result, 'Small Green Bananas with Polka Dots');
 });
 
+test('replace shallow custom taxonomy with just final subject name', function(assert) {
+    let result = customTaxonomyFilter(['bepress/Fruits']);
+    assert.equal(result, 'Fruits');
+});
+
+test('return original subject if not a custom taxonomy', function(assert) {
+    let result = customTaxonomyFilter(['Fruits and Bananas']);
+    assert.equal(result, 'Fruits and Bananas');
+});
+
+test('return original subject if not a recognized custom taxonomy', function(assert) {
+    let result = customTaxonomyFilter(['osf/Fruits/Bananas']);
+    assert.equal(result, 'osf/Fruits/Bananas');
+});

--- a/tests/unit/helpers/custom-taxonomy-filter-test.js
+++ b/tests/unit/helpers/custom-taxonomy-filter-test.js
@@ -1,0 +1,12 @@
+
+import { customTaxonomyFilter } from 'dummy/helpers/custom-taxonomy-filter';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | custom taxonomy filter');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = customTaxonomyFilter([42]);
+  assert.ok(result);
+});
+


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-754

# Purpose
Subjects are now being passed back from SHARE as strings contained their hierarchy. We want to show to the user the same things we used to (deduplicated parents and children as separate 'tag'-like subjects), but retain the hierarchy and taxonomy tag (i.e. 'bepress'), so they can be filtered properly.

# Summary of changes
Add custom taxonomy helper so filters can be shown properly

Add logic to separate out and deduplicate all subjects in a search result, to be displayed as such but also filtering using their original value

### Before:
<img width="799" alt="screen shot 2017-07-12 at 2 29 57 pm" src="https://user-images.githubusercontent.com/6268982/28133622-9ff805c2-670e-11e7-95f5-8ab24c5b7d17.png">

### After:
<img width="402" alt="screen shot 2017-07-12 at 2 29 24 pm" src="https://user-images.githubusercontent.com/6268982/28133625-a2904100-670e-11e7-889a-672a5004186e.png">
<img width="646" alt="screen shot 2017-07-12 at 2 29 33 pm" src="https://user-images.githubusercontent.com/6268982/28133633-a6078bae-670e-11e7-8071-e563a033bd98.png">
