### PR TITLE
[EOSF-762] Prepend next url with window location origin

### DIFF
--- a/addon/mixins/cas-authenticated-route.js
+++ b/addon/mixins/cas-authenticated-route.js
@@ -40,7 +40,7 @@ export default Ember.Mixin.create({
             let routing = this.get('routing');
             let params = Object.values(transition.params).filter(param => Object.values(param).length);
             let url = routing.generateURL(transition.targetName, params, transition.queryParams);
-            window.location = getAuthUrl(url);
+            window.location = getAuthUrl(window.location.origin + url);
         } else {
             return this._super(...arguments);
         }


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-762

# Purpose

Fix next url for CAS when attempting to access a page that require authentication

# Summary of changes

Prepend next url with window location origin

# Testing notes

Make sure redirecting through CAS works properly when clicking "Add a preprint" and not logged for:
* unbranded preprints
* branded preprints
* branded preprint domains