### PR TITLE
Added shareTitle property to taxonomy model [EOSF-753]

### DIFF
--- a/addon/models/taxonomy.js
+++ b/addon/models/taxonomy.js
@@ -14,6 +14,7 @@ import OsfModel from './osf-model';
  */
 export default OsfModel.extend({
     text: DS.attr('fixstring'),
+    shareTitle: DS.attr('string'),
     // TODO: Api implements this as a list field for now. This should be a relationship field in the future, when API supports it
     child_count: DS.attr(),
     parents: DS.attr()


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-753

# Purpose

Added shareTitle property to taxonomy model to use for querying SHARE.

# Summary of changes

Added shareTitle property to taxonomy model

# Testing notes

Make sure shareTitle property is populated once the API includes it.