### PR TITLE
[EOSF-786] Use subject_synonyms if available and on unbranded discover page

### DIFF
--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -568,6 +568,7 @@ export default Ember.Component.extend(Analytics, hostAppName, {
                     workType: hit._source['@type'],
                     abstract: hit._source.description,
                     subjects: hit._source.subjects.map(each => ({ text: each })),
+                    subject_synonyms: hit._source.subject_synonyms.map(each => ({ text: each })),
                     providers: hit._source.sources.map(item => ({ name: item })), // For PREPRINTS, REGISTRIES
                     hyperLinks: [// Links that are hyperlinks from hit._source.lists.links
                         {

--- a/addon/components/search-result/component.js
+++ b/addon/components/search-result/component.js
@@ -85,8 +85,8 @@ export default Ember.Component.extend(Analytics, hostAppName, {
     tags: Ember.computed('result.tags', function() {
         return (this.get('result.tags') || []).slice(0, this.get('maxTags'));
     }),
-    subjects: Ember.computed('result.subjects', function() {
-        let subs = this.get('result.subjects');
+    subjects: Ember.computed('result.subjects', 'result.subject_synonyms', 'themeProvider', function() {
+        let subs = this.get('themeProvider.id') === 'osf' && this.get('result.subject_synonyms').length ? this.get('result.subject_synonyms') : this.get('result.subjects');
         let uniqueSubs = {}
         subs.map(e => {
             let tax, subjects;


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-786

# Purpose

When on the unbranded aggregate discover page, use subject_synonyms (if available) instead of subjects.

# Summary of changes

* Add subject_synonyms to results map
* Add logic to use subject_synonyms when appropriate

# Testing notes

Make sure bepress subjects are used on unbranded aggregate discover page and custom taxonomy subjects are used on branded provider discover page. Make sure subject tags for preprints without custom taxonomies work properly.