### PR TITLE
[EOSF-772] Add 'Donate' link to navbar

### DIFF
--- a/addon/components/new-osf-navbar/template.hbs
+++ b/addon/components/new-osf-navbar/template.hbs
@@ -46,7 +46,7 @@
                             </li>
                         {{else}}
                             {{!SERVICE LINK}}
-                            {{#if (eq navLink.name.string "Donate")}}
+                            {{#if (eq navLink.type 'donateToCOS')}}
                                 <li class="navbar-donate-button">
                                     <a href="{{navLink.href}}">
                                         {{navLink.name}}

--- a/addon/components/new-osf-navbar/template.hbs
+++ b/addon/components/new-osf-navbar/template.hbs
@@ -46,20 +46,28 @@
                             </li>
                         {{else}}
                             {{!SERVICE LINK}}
-                            <li>
-                                <a href="{{navLink.href}}">
-                                    {{#if (eq navLink.type 'addAPreprint')}}
-                                        <span class="hidden-xs hidden-sm">
-                                            {{navLink.name}}
-                                        </span>
-                                        <span class="hidden-md hidden-lg hidden-xl">
-                                            {{t 'eosf.navbar.add'}}
-                                        </span>
-                                    {{else}}
+                            {{#if (eq navLink.name.string "Donate")}}
+                                <li class="navbar-donate-button">
+                                    <a href="{{navLink.href}}">
                                         {{navLink.name}}
-                                    {{/if}}
-                                </a>
-                            </li>
+                                    </a>
+                                </li>
+                            {{else}}
+                                <li>
+                                    <a href="{{navLink.href}}">
+                                        {{#if (eq navLink.type 'addAPreprint')}}
+                                            <span class="hidden-xs hidden-sm">
+                                                {{navLink.name}}
+                                            </span>
+                                            <span class="hidden-md hidden-lg hidden-xl">
+                                                {{t 'eosf.navbar.add'}}
+                                            </span>
+                                        {{else}}
+                                            {{navLink.name}}
+                                        {{/if}}
+                                    </a>
+                                </li>
+                            {{/if}}
                         {{/if}}
                     {{/each}}
                     {{!AUTH NAVBAR}}

--- a/addon/components/osf-navbar/style.scss
+++ b/addon/components/osf-navbar/style.scss
@@ -22,3 +22,7 @@ a.navbar-service::before {
     margin-top: 5px;
     line-height: 1.7;
 }
+
+.navbar-donate-button a {
+    color: #9cd59c !important;
+}

--- a/addon/helpers/build-secondary-nav-links.js
+++ b/addon/helpers/build-secondary-nav-links.js
@@ -33,7 +33,8 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                 },
                 {
                     name: i18n.t('eosf.navbar.donate'),
-                    href: 'https://cos.io/donate'
+                    href: 'https://cos.io/donate',
+                    type: 'donateToCOS'
                 },
 
             ],
@@ -53,7 +54,8 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                 },
                 {
                     name: i18n.t('eosf.navbar.donate'),
-                    href: 'https://cos.io/donate'
+                    href: 'https://cos.io/donate',
+                    type: 'donateToCOS'
                 },
 
             ],
@@ -68,7 +70,8 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                 },
                 {
                     name: i18n.t('eosf.navbar.donate'),
-                    href: 'https://cos.io/donate'
+                    href: 'https://cos.io/donate',
+                    type: 'donateToCOS'
                 },
 
             ],
@@ -79,7 +82,8 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                 },
                 {
                     name: i18n.t('eosf.navbar.donate'),
-                    href: 'https://cos.io/donate'
+                    href: 'https://cos.io/donate',
+                    type: 'donateToCOS'
                 },
 
             ]

--- a/addon/helpers/build-secondary-nav-links.js
+++ b/addon/helpers/build-secondary-nav-links.js
@@ -30,7 +30,11 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                 {
                     name: i18n.t('eosf.navbar.search'),
                     href: '#'
-                }
+                },
+                {
+                    name: i18n.t('eosf.navbar.donate'),
+                    href: 'https://cos.io/donate'
+                },
 
             ],
             PREPRINTS: [
@@ -47,6 +51,10 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                     name: i18n.t('eosf.navbar.support'),
                     href: serviceLinks.preprintsSupport
                 },
+                {
+                    name: i18n.t('eosf.navbar.donate'),
+                    href: 'https://cos.io/donate'
+                },
 
             ],
             REGISTRIES: [
@@ -58,13 +66,22 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                     name: i18n.t('eosf.navbar.support'),
                     href: serviceLinks.registriesSupport
                 },
+                {
+                    name: i18n.t('eosf.navbar.donate'),
+                    href: 'https://cos.io/donate'
+                },
 
             ],
             MEETINGS: [
                 {
                     name: i18n.t('eosf.navbar.search'),
                     href: serviceLinks.meetingsHome
-                }
+                },
+                {
+                    name: i18n.t('eosf.navbar.donate'),
+                    href: 'https://cos.io/donate'
+                },
+
             ]
         });
 

--- a/addon/locales/en/translations.js
+++ b/addon/locales/en/translations.js
@@ -24,6 +24,7 @@ export default {
             addAPreprint: 'Add a preprint',
             browse: 'Browse',
             cancelSearch: 'Cancel search',
+            donate: 'Donate',
             goHome: 'Go home',
             myProjects: 'My Projects',
             search: 'Search',


### PR DESCRIPTION

## Ticket

https://openscience.atlassian.net/browse/EOSF-772

# Purpose

To add a 'Donate' button to the ember side of the osf (preprints and registries).

# Summary of changes

Added the 'Donate' button to the navbar and added to some of the necessary files: 
- translate.js to make the 'Donate' word more standardized
- build-secondary-nav-links.js to add the 'Donate' button to the necessary arrays that are looped to determine what goes on the navbar

# Screenshots
<img width="1440" alt="screen shot 2017-07-27 at 12 57 27 pm" src="https://user-images.githubusercontent.com/19379783/28682645-a859705c-72cb-11e7-97ff-03fe74965cb3.png">

<img width="1440" alt="screen shot 2017-07-27 at 1 01 31 pm" src="https://user-images.githubusercontent.com/19379783/28682667-bd906868-72cb-11e7-91fe-8aaac1a5e36d.png">

![giphy 1](https://user-images.githubusercontent.com/19379783/28725947-2acc420a-738d-11e7-89d7-40b96630a41d.gif)
