### PR TITLE
[EOSF-756] Add < and > to special escaped characters

### DIFF
--- a/addon/utils/fix-special-char.js
+++ b/addon/utils/fix-special-char.js
@@ -9,15 +9,17 @@
 
 /**
  * This function is useful for fixing a bad API behavior. In certain cases the server will insert HTML escape
- * sequences into text, and this will replace `&amp;` sequences with `&`. Template helper and ember-data field versions
- * of this function are available.
+ * sequences into text, and this will replace `&amp;` sequences with `&`, `&lt;` with `<` and `&gt;` with `>`.
+ * Template helper and ember-data field versions of this function are available.
  *
  * @method fixSpecialChar
  * @param {String} inputString A string value to be transformed
  * @return {String|null}
  */
 export default function fixSpecialChar(inputString) {
-    return inputString ? inputString.replace(/&amp;/g, '&') : inputString;
+    return inputString ? inputString.replace(/&amp;/g, '&')
+                                    .replace(/&lt;/g, '<')
+                                    .replace(/&gt;/g, '>') : inputString;
 }
 
 export { fixSpecialChar };

--- a/tests/fixtures/specialChars.js
+++ b/tests/fixtures/specialChars.js
@@ -2,8 +2,9 @@
 const fixStringTestCases = [
     ['a regular string', 'a regular string'],
     ['multiple &amp; sequences all become &amp;', 'multiple & sequences all become &'],
+    ['also the brackets &lt; and &gt; are changed', 'also the brackets < and > are changed'],
     ['', ''],
-    ['for now, intentionally limit which characters are fixed &amp; &lt; &gt;', 'for now, intentionally limit which characters are fixed & &lt; &gt;'],
+    ['for now, intentionally limit which characters are fixed &amp; &lt; &gt;', 'for now, intentionally limit which characters are fixed & < >'],
     [null, null]
 ];
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-756

# Purpose

To escape < and > in preprint abstracts.

# Summary of changes

Added the < and > symbols to the characters being escaped in the `fix-special-char` helper.
The < and > symbols now show up right in both the abstract and in the tags.

# Screenshot

<img width="558" alt="screen shot 2017-08-04 at 3 42 09 pm" src="https://user-images.githubusercontent.com/19379783/28984349-8c473e06-792b-11e7-812c-69dd32de0cba.png">

