### PR TITLE
Make add a preprint not use preprintWords

### DIFF
--- a/addon/locales/en/translations.js
+++ b/addon/locales/en/translations.js
@@ -47,7 +47,7 @@ export default {
         },
         navbar: {
             add: 'Add',
-            addAPreprint: 'Add a {{preprintWords.preprint}}',
+            addAPreprint: 'Add a preprint',
             browse: 'Browse',
             cancelSearch: 'Cancel search',
             donate: 'Donate',


### PR DESCRIPTION
# Purpose
Fixes small bug that cant find preprint words to replace preprint in this instance due to how navbar access `t` helper


