### PR TITLE
[EOSF-655] Hotfix/0.8.2

### DIFF
--- a/addon/instance-initializers/ember-osf.js
+++ b/addon/instance-initializers/ember-osf.js
@@ -4,26 +4,24 @@ Automatically expose translations for addon in a way that can be merged in with 
  */
 import Ember from 'ember';
 import en from 'ember-osf/locales/en/translations';
-import tHelper from 'ember-i18n/helper';
-
 
 export function initialize(appInstance) {
-    tHelper.reopen({
+    const i18n = appInstance.lookup('service:i18n');
+    i18n.reopen({
         theme: Ember.inject.service(),
-        compute(_, params) {
-            let translations = this.get('i18n._locale.translations');
+        t(_, data) {
+            let translations = this.get('_locale.translations');
             let preprintWord = this.get('theme.provider.preprintWord') || 'preprint';
-            params = params || {};
-            params.preprintWords = {
+            data = data || {};
+            data.preprintWords = {
                 preprint: translations[`preprintWords.${preprintWord}.preprint`],
                 preprints: translations[`preprintWords.${preprintWord}.preprints`],
                 Preprint: translations[`preprintWords.${preprintWord}.Preprint`],
                 Preprints: translations[`preprintWords.${preprintWord}.Preprints`]
             };
-            return this._super(_, params);
+            return this._super(_, data);
         }
     });
-    const i18n = appInstance.lookup('service:i18n');
     i18n.addTranslations('en', en);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centerforopenscience/ember-osf",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Reusable ember models and components for interacting with the Open Science Framework",
   "directories": {
     "doc": "docs",


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-655

# Purpose

Hotfix for ability to interpolate preprintWords in i18n.t method instead of just the t helper.

# Summary of changes

Override i18n.t method instead of t helper to inject preprintWords at a lower level.

# Testing notes

Make sure everywhere that should say preprint(s) does (or alternate text for that provider). One example fixed with this PR is the "Add a preprint" link in the unbranded navbar.