### PR TITLE
[EOSF-771] Branded domain redirects

### DIFF
--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -125,6 +125,14 @@ export default Ember.Component.extend(Analytics, hostAppName, {
      * @property {Object} fetchedProviders
      */
     fetchedProviders: null,
+    filteredProviders: Ember.computed(function() {
+        let list = [];
+        let providers = this.get('fetchedProviders');
+        for (let x = 0; x < providers.length; x++)
+            if (providers[x].get('domain') && providers[x].get('domainRedirectEnabled') == true)
+                list.push(providers[x].get('domain'));
+        return list;
+    }),
     /**
      * For PREPRINTS and REGISTRIES. A mapping of activeFilters to facet names expected by SHARE. Ex. {'providers': 'sources'}
      * @property {Object} filterMap

--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -125,13 +125,15 @@ export default Ember.Component.extend(Analytics, hostAppName, {
      * @property {Object} fetchedProviders
      */
     fetchedProviders: null,
-    filteredProviders: Ember.computed(function() {
-        let list = [];
+    domainRedirectProviders: Ember.computed(function() {
+        let providerDomains = [];
         let providers = this.get('fetchedProviders');
-        for (let x = 0; x < providers.length; x++)
-            if (providers[x].get('domain') && providers[x].get('domainRedirectEnabled') == true)
-                list.push(providers[x].get('domain'));
-        return list;
+        for (let providerVal of providers) {
+            if (providerVal.get('domain') && providerVal.get('domainRedirectEnabled') === true) {
+                providerDomains.push(providerVal.get('domain'));
+            }
+        }
+        return providerDomains;
     }),
     /**
      * For PREPRINTS and REGISTRIES. A mapping of activeFilters to facet names expected by SHARE. Ex. {'providers': 'sources'}

--- a/addon/components/discover-page/template.hbs
+++ b/addon/components/discover-page/template.hbs
@@ -168,7 +168,7 @@
                         {{!RESULTS FOUND}}
                         <div class="results-top">
                             {{#each results as |result|}}
-                                {{search-result themeProvider=themeProvider queryParams=queryParams detailRoute=detailRoute filterReplace=filterReplace addFilter='addFilter' updateFilters=(action 'updateFilters') result=result currentService=currentService filteredProviders=filteredProviders}}
+                                {{search-result themeProvider=themeProvider queryParams=queryParams detailRoute=detailRoute filterReplace=filterReplace addFilter='addFilter' updateFilters=(action 'updateFilters') result=result currentService=currentService domainRedirectProviders=domainRedirectProviders}}
                             {{/each}}
                         </div>
                         <div class="pull-right text-right">

--- a/addon/components/discover-page/template.hbs
+++ b/addon/components/discover-page/template.hbs
@@ -168,7 +168,7 @@
                         {{!RESULTS FOUND}}
                         <div class="results-top">
                             {{#each results as |result|}}
-                                {{search-result themeProvider=themeProvider queryParams=queryParams detailRoute=detailRoute filterReplace=filterReplace addFilter='addFilter' updateFilters=(action 'updateFilters') result=result currentService=currentService}}
+                                {{search-result themeProvider=themeProvider queryParams=queryParams detailRoute=detailRoute filterReplace=filterReplace addFilter='addFilter' updateFilters=(action 'updateFilters') result=result currentService=currentService filteredProviders=filteredProviders}}
                             {{/each}}
                         </div>
                         <div class="pull-right text-right">

--- a/addon/components/search-result/component.js
+++ b/addon/components/search-result/component.js
@@ -140,7 +140,7 @@ export default Ember.Component.extend(Analytics, hostAppName, {
         for (let identifier of identifiers) {
             // If the identifier's url matches a branded url, then use that
             let url = identifier.match(urlRegex);
-            if (url.length && domainRedirectList.includes(url[0])) {
+            if (url && domainRedirectList.includes(url[0])) {
                 returnedUrl = identifier;
             }
         }


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-771

# Purpose

If a preprint uses a branded domain that has a domain redirect enabled it should not use an osf url.  Instead, it should take the user to the branded domain (ex `engrxiv.org/guid` instead of `osf.io/preprints/engrxiv/guid`)

# Summary of changes

- Pass a filtered list of providers that are branded and redirect to the search-result component
- Update hyperlink function to check if any identifiers match a filtered provider's domain

If none of the identifier's match a branded domain, then it will use an osf url like before.
<hr>
<img width="1440" alt="screen shot 2017-08-11 at 12 01 19 pm" src="https://user-images.githubusercontent.com/19379783/29224804-ce9a0c7a-7e99-11e7-908d-194b7c769770.png">
(the preprint does not have an identifier that uses a branded domain, so it just uses the standard osf url)
<hr>
<img width="1440" alt="screen shot 2017-08-11 at 12 01 44 pm" src="https://user-images.githubusercontent.com/19379783/29224880-20b839f0-7e9a-11e7-855a-c95c0d6bd388.png">
(this one has an identifier that uses a branded domain though, so it will have a url that points towards that instead)
<hr>

# Testing notes

To test this, make sure that your local providers have the right settings:
- domain: `http://staging-[provider].cos.io/` (ex `http://staging-engrxiv.cos.io/`)
- domain_redirect_enabled: true

If a preprint is using a branded domain that has redirect enabled, then the url should now be pointing towards that domain instead of an osf one.
