### PR TITLE
[EOSF-667] Change filter to accept 'thesis'

### DIFF
--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -380,7 +380,7 @@ export default Ember.Component.extend(Analytics, hostAppName, {
     buildLockedQueryBody(lockedParams) {
         /**
          *  For PREPRINTS, REGISTRIES, RETRACTION WATCH - services where portion of query is restricted.
-         *  Builds the locked portion of the query.  For example, in preprints, type=preprint
+         *  Builds the locked portion of the query.  For example, in preprints, types=['preprint', 'thesis']
          *  is something that cannot be modified by the user.
          *
          *  @method buildLockedQueryBody
@@ -396,10 +396,9 @@ export default Ember.Component.extend(Analytics, hostAppName, {
             } else if (key === 'contributors') {
                 queryKey = 'lists.contributors.name';
             }
-
             query[queryKey] = lockedParams[key];
             queryBody.push({
-                term: query
+                terms: query
             });
         });
         return queryBody;
@@ -488,7 +487,6 @@ export default Ember.Component.extend(Analytics, hostAppName, {
                 });
             }
         });
-
         // For PREPRINTS and REGISTRIES. If theme.isProvider, add provider(s) to query body
         if (this.get('theme.isProvider') && this.get('themeProvider.name') !== null) {
             const themeProvider = this.get('themeProvider');
@@ -501,7 +499,6 @@ export default Ember.Component.extend(Analytics, hostAppName, {
                 }
             });
         }
-
         let query = {
             query_string: {
                 query: this.get('q') || '*'
@@ -515,7 +512,6 @@ export default Ember.Component.extend(Analytics, hostAppName, {
                 }
             };
         }
-
         let page = this.get('page');
         let queryBody = {
             query,


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-667

# Purpose

To change the filter to accept multiple types of publications.

# Summary of changes

Change the query to use `terms` instead of `term` in preparation for accepting a list of publication types.

# Testing notes

Since this is changing a part of the filter, please be sure to check that preprints, thesis, and registries still show up as expected.