### PR TITLE
[EOSF-836] use branded domains in preprint search results regardless of protocol

### DIFF
--- a/addon/components/search-result/component.js
+++ b/addon/components/search-result/component.js
@@ -133,14 +133,19 @@ export default Ember.Component.extend(Analytics, hostAppName, {
         return false;
     }),
     hyperlink: Ember.computed('result', function() {
-        let urlRegex = /^https?:\/\/[^\/]+\//;
+        const urlRegex = /^https?:\/\/([^\/]+)\/(.+)$/;
         const domainRedirectList = this.get('domainRedirectProviders');
         const identifiers = this.get('result.identifiers').filter(ident => ident.startsWith('http://') || ident.startsWith('https://') );
         for (let identifier of identifiers) {
-            // If the identifier's url matches a branded url, then use that
             let url = identifier.match(urlRegex);
-            if (url && domainRedirectList.includes(url[0])) {
-                return identifier;
+            if (url) {
+                const domainRegex = new RegExp("^https?://" + url[1] + "/");
+                for (let domain of domainRedirectList) {
+                    if (domainRegex.test(domain)) {
+                        // If the domain matches use the path from the identifier concatentated to the domain
+                        return domain + url[2];
+                    }
+                }
             }
         }
         let re = this.providerUrlRegex.OSF;


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-836

# Purpose

In the search results, use an identifier link that contains a matching domain, regardless of the protocol.

# Summary of changes

Match based on domain instead of entire origin.

# Testing notes

Make sure search results use the branded domain when the provider's domain uses https.