### PR TITLE
Add fallbacks for when no provider is available or preprintWord never resolves

### DIFF
--- a/addon/instance-initializers/ember-osf.js
+++ b/addon/instance-initializers/ember-osf.js
@@ -14,12 +14,12 @@ export function initialize(appInstance) {
             let translations = this.get('i18n._locale.translations');
             let preprintWord = this.get('theme.provider.preprintWord');
             let getTerms = () => ({
-                preprint: translations[`preprintWords.${preprintWord}.preprint`],
-                preprints: translations[`preprintWords.${preprintWord}.preprints`],
-                Preprint: translations[`preprintWords.${preprintWord}.Preprint`],
-                Preprints: translations[`preprintWords.${preprintWord}.Preprints`]
+                preprint: translations[`preprintWords.${preprintWord || 'preprint'}.preprint`],
+                preprints: translations[`preprintWords.${preprintWord || 'preprint'}.preprints`],
+                Preprint: translations[`preprintWords.${preprintWord || 'preprint'}.Preprint`],
+                Preprints: translations[`preprintWords.${preprintWord || 'preprint'}.Preprints`]
             });
-            if (!preprintWord) {
+            if (!preprintWord && this.get('theme.provider')) {
                 this.get('theme.provider').then(provider => {
                     preprintWord = provider.get('preprintWord') || 'preprint';
                     data.preprintWords = getTerms();


### PR DESCRIPTION
# Purpose
Multiple people consuming the ember-osf app eventually get an error when using the built-in translating engine because it currently assumes the existence of theme providers.
