### PR TITLE
[EOSF-769] File-version widget

### DIFF
--- a/addon/components/file-version/component.js
+++ b/addon/components/file-version/component.js
@@ -13,7 +13,8 @@ import layout from './template';
  * ```handlebars
  * {{file-version
  * version=version
- * download='download'}}
+ * download='download'
+ * clickable=true}}
  * ```
  * @class file-version
  */
@@ -21,6 +22,7 @@ export default Ember.Component.extend({
     layout,
     classNames: ['file-version'],
     tagName: 'tr',
+    clickable: false,
 
     actions: {
         downloadVersion(version) {

--- a/addon/components/file-version/component.js
+++ b/addon/components/file-version/component.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from './template';
+import moment from 'moment';
 
 /**
  * @module ember-osf
@@ -14,7 +15,8 @@ import layout from './template';
  * {{file-version
  * version=version
  * download='download'
- * clickable=true}}
+ * currentVersion=currentVersion
+ * versionUrl='versionUrl'}}
  * ```
  * @class file-version
  */
@@ -22,11 +24,31 @@ export default Ember.Component.extend({
     layout,
     classNames: ['file-version'],
     tagName: 'tr',
-    clickable: false,
+    
+    clickable: Ember.computed('version', 'currentVersion', function() {
+        return this.get('version.id') == this.get('currentVersion') ? false : true;
+    }),
+
+    dateFormatted: Ember.computed('version', function() {
+        return moment(this.get('version.attributes.modified_utc')).format('YYYY-MM-DD h:mm A');
+    }),
 
     actions: {
         downloadVersion(version) {
             this.sendAction('download', version);
+        },
+        changeVersion(version) {
+            this.sendAction('versionChange', version);
+        },
+        copyMd5() {
+            const id = '#md5-' + this.get('version.id');
+            document.querySelector(id).select();
+            document.execCommand('copy');
+        },
+        copySha256() {
+            const id = '#sha256-' + this.get('version.id');
+            document.querySelector(id).select();
+            document.execCommand('copy');
         }
     }
 });

--- a/addon/components/file-version/component.js
+++ b/addon/components/file-version/component.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from './template';
-import moment from 'moment';
 
 /**
  * @module ember-osf
@@ -24,29 +23,21 @@ export default Ember.Component.extend({
     layout,
     classNames: ['file-version'],
     tagName: 'tr',
-    
-    clickable: Ember.computed('version', 'currentVersion', function() {
-        return this.get('version.id') == this.get('currentVersion') ? false : true;
-    }),
+    currentVersion: null,
+    versionUrl: null,
 
-    dateFormatted: Ember.computed('version', function() {
-        return moment(this.get('version.attributes.modified_utc')).format('YYYY-MM-DD h:mm A');
+    clickable: Ember.computed('version', 'currentVersion', function() {
+        return this.get('version.id') != this.get('currentVersion');
     }),
 
     actions: {
         downloadVersion(version) {
-            this.sendAction('download', version);
+            this.attrs.download(version);
         },
         changeVersion(version) {
-            this.sendAction('versionChange', version);
+            this.attrs.versionChange(version);
         },
-        copyMd5() {
-            const id = '#md5-' + this.get('version.id');
-            document.querySelector(id).select();
-            document.execCommand('copy');
-        },
-        copySha256() {
-            const id = '#sha256-' + this.get('version.id');
+        copyLink(id) {
             document.querySelector(id).select();
             document.execCommand('copy');
         }

--- a/addon/components/file-version/style.scss
+++ b/addon/components/file-version/style.scss
@@ -1,0 +1,3 @@
+.btn.versionButton {
+	padding: 0px;
+}

--- a/addon/components/file-version/template.hbs
+++ b/addon/components/file-version/template.hbs
@@ -1,3 +1,9 @@
-<td>{{version.id}}</td>
+<td>
+	{{#if clickable}}
+		<a href='{{version.url}}'>{{version.id}}</a>
+	{{else}}
+		{{version.id}}
+	{{/if}}
+</td>
 <td>{{version.size}}</td>
 <td><button {{action 'downloadVersion' version.id}}>{{fa-icon 'download'}}</button></td>

--- a/addon/components/file-version/template.hbs
+++ b/addon/components/file-version/template.hbs
@@ -1,9 +1,26 @@
 <td>
 	{{#if clickable}}
-		<a href='{{version.url}}'>{{version.id}}</a>
+		<a {{action 'changeVersion' version.id}}>{{version.id}}</a>
 	{{else}}
 		{{version.id}}
 	{{/if}}
 </td>
-<td>{{version.size}}</td>
-<td><button {{action 'downloadVersion' version.id}}>{{fa-icon 'download'}}</button></td>
+<td>{{dateFormatted}}</td>
+<td><div class='badge'>{{version.attributes.extra.downloads}}</div></td>
+<td><button class='btn btn-primary btn-sm' {{action 'downloadVersion' version.id}}>{{fa-icon 'download'}}</button></td>
+<td>
+	<div class='input-group'>
+		<span class='input-group-btn'>
+			<button type='button' class='btn btn-default btn-sm' {{action 'copyMd5'}}>{{fa-icon 'copy'}}</button>
+		</span>
+		<input type='text' readonly='readonly' value='{{version.attributes.extra.hashes.md5}}' class='hashBox' id='md5-{{version.id}}'>
+	</div>
+</td>
+<td>
+	<div class='input-group'>
+		<span class='input-group-btn'>
+			<button type='button' class='btn btn-default btn-sm' {{action 'copySha256'}}>{{fa-icon 'copy'}}</button>
+		</span>
+		<input type='text' readonly='readonly' value='{{version.attributes.extra.hashes.sha256}}' class='hashBox' id='sha256-{{version.id}}'>
+	</div>
+</td>

--- a/addon/components/file-version/template.hbs
+++ b/addon/components/file-version/template.hbs
@@ -1,26 +1,26 @@
 <td>
-	{{#if clickable}}
-		<a {{action 'changeVersion' version.id}}>{{version.id}}</a>
-	{{else}}
-		{{version.id}}
-	{{/if}}
+    {{#if clickable}}
+        <button type='button' class='btn btn-link' {{action 'changeVersion' version.id}}>{{version.id}}</button>
+    {{else}}
+        {{version.id}}
+    {{/if}}
 </td>
 <td>{{dateFormatted}}</td>
 <td><div class='badge'>{{version.attributes.extra.downloads}}</div></td>
 <td><button class='btn btn-primary btn-sm' {{action 'downloadVersion' version.id}}>{{fa-icon 'download'}}</button></td>
 <td>
-	<div class='input-group'>
-		<span class='input-group-btn'>
-			<button type='button' class='btn btn-default btn-sm' {{action 'copyMd5'}}>{{fa-icon 'copy'}}</button>
-		</span>
-		<input type='text' readonly='readonly' value='{{version.attributes.extra.hashes.md5}}' class='hashBox' id='md5-{{version.id}}'>
-	</div>
+    <div class='input-group'>
+        <span class='input-group-btn'>
+            <button type='button' class='btn btn-default btn-sm' {{action 'copyMd5'}}>{{fa-icon 'copy'}}</button>
+        </span>
+        <input type='text' readonly='readonly' value='{{version.attributes.extra.hashes.md5}}' class='hashBox' id='md5-{{version.id}}'>
+    </div>
 </td>
 <td>
-	<div class='input-group'>
-		<span class='input-group-btn'>
-			<button type='button' class='btn btn-default btn-sm' {{action 'copySha256'}}>{{fa-icon 'copy'}}</button>
-		</span>
-		<input type='text' readonly='readonly' value='{{version.attributes.extra.hashes.sha256}}' class='hashBox' id='sha256-{{version.id}}'>
-	</div>
+    <div class='input-group'>
+        <span class='input-group-btn'>
+            <button type='button' class='btn btn-default btn-sm' {{action 'copySha256'}}>{{fa-icon 'copy'}}</button>
+        </span>
+        <input type='text' readonly='readonly' value='{{version.attributes.extra.hashes.sha256}}' class='hashBox' id='sha256-{{version.id}}'>
+    </div>
 </td>

--- a/addon/components/file-version/template.hbs
+++ b/addon/components/file-version/template.hbs
@@ -1,6 +1,6 @@
 <td>
     {{#if clickable}}
-        <button type='button' class='btn btn-link' {{action 'changeVersion' version.id}}>{{version.id}}</button>
+        <button class='btn btn-link versionButton' {{action 'changeVersion' version.id}}>{{version.id}}</button>
     {{else}}
         {{version.id}}
     {{/if}}

--- a/addon/components/file-version/template.hbs
+++ b/addon/components/file-version/template.hbs
@@ -5,7 +5,7 @@
         {{version.id}}
     {{/if}}
 </td>
-<td>{{moment-format version.attributes.modified_utc 'YYYY-MM-DD h:mm A'}}</td>
+<td>{{moment-format version.attributes.modified_utc}}</td>
 <td><div class='badge'>{{version.attributes.extra.downloads}}</div></td>
 <td><button class='btn btn-primary btn-sm' onclick={{action 'downloadVersion' version.id}}>{{fa-icon 'download'}}</button></td>
 <td>

--- a/addon/components/file-version/template.hbs
+++ b/addon/components/file-version/template.hbs
@@ -1,17 +1,17 @@
 <td>
     {{#if clickable}}
-        <button class='btn btn-link versionButton' {{action 'changeVersion' version.id}}>{{version.id}}</button>
+        <button class='btn btn-link versionButton' onclick={{action 'changeVersion' version.id}}>{{version.id}}</button>
     {{else}}
         {{version.id}}
     {{/if}}
 </td>
-<td>{{dateFormatted}}</td>
+<td>{{moment-format version.attributes.modified_utc 'YYYY-MM-DD h:mm A'}}</td>
 <td><div class='badge'>{{version.attributes.extra.downloads}}</div></td>
-<td><button class='btn btn-primary btn-sm' {{action 'downloadVersion' version.id}}>{{fa-icon 'download'}}</button></td>
+<td><button class='btn btn-primary btn-sm' onclick={{action 'downloadVersion' version.id}}>{{fa-icon 'download'}}</button></td>
 <td>
     <div class='input-group'>
         <span class='input-group-btn'>
-            <button type='button' class='btn btn-default btn-sm' {{action 'copyMd5'}}>{{fa-icon 'copy'}}</button>
+            <button type='button' class='btn btn-default btn-sm' onclick={{action 'copyLink' 'md5-{{version.id}}'}}>{{fa-icon 'copy'}}</button>
         </span>
         <input type='text' readonly='readonly' value='{{version.attributes.extra.hashes.md5}}' class='hashBox' id='md5-{{version.id}}'>
     </div>
@@ -19,7 +19,7 @@
 <td>
     <div class='input-group'>
         <span class='input-group-btn'>
-            <button type='button' class='btn btn-default btn-sm' {{action 'copySha256'}}>{{fa-icon 'copy'}}</button>
+            <button type='button' class='btn btn-default btn-sm' onclick={{action 'copyLink' 'sha256-{{version.id}}'}}>{{fa-icon 'copy'}}</button>
         </span>
         <input type='text' readonly='readonly' value='{{version.attributes.extra.hashes.sha256}}' class='hashBox' id='sha256-{{version.id}}'>
     </div>

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -18,3 +18,4 @@
 @import 'components/search-facet-worktype-hierarchy/style';
 @import 'components/search-facet-worktype-button/style';
 @import 'components/donate-banner/style';
+@import 'components/file-version/style';

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,5 +2,9 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-    return {};
+    return {
+        moment: {
+            includeTimezone: 'all'
+        }
+    };
 };

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "js-yaml": "3.8.4",
     "keen-tracking": "1.1.3",
     "langs": "1.0.2",
-    "toastr": "^2.1.2"
+    "toastr": "^2.1.2",
+    "moment-timezone": "^0.5.13",
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "keen-tracking": "1.1.3",
     "langs": "1.0.2",
     "toastr": "^2.1.2",
-    "moment-timezone": "^0.5.13",
+    "moment-timezone": "^0.5.13"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -3,6 +3,10 @@ import Ember from 'ember';
 export default Ember.Route.extend({
     store: Ember.inject.service(),
     session: Ember.inject.service(),
+    moment: Ember.inject.service(),
+    beforeModal() {
+        this.get('moment').setTimeZone('UTC');
+    },
     model() {
         if (this.get('session.isAuthenticated')) {
             return this.get('store').findRecord('user', 'me');

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -3,10 +3,6 @@ import Ember from 'ember';
 export default Ember.Route.extend({
     store: Ember.inject.service(),
     session: Ember.inject.service(),
-    moment: Ember.inject.service(),
-    beforeModal() {
-        this.get('moment').setTimeZone('UTC');
-    },
     model() {
         if (this.get('session.isAuthenticated')) {
             return this.get('store').findRecord('user', 'me');

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -68,7 +68,7 @@ module.exports = function(environment) {
             componentOptions: {
                 turnAuditOff: false
             }
-        }
+        },
         
         moment: {
             includeTimezone: 'all',

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -69,6 +69,11 @@ module.exports = function(environment) {
                 turnAuditOff: false
             }
         }
+        
+        moment: {
+            includeTimezone: 'all',
+            outputFormat: 'YYYY-MM-DD h:mm A z',
+        },
     };
 
     /*if (environment === 'development') {

--- a/tests/integration/components/file-version/component-test.js
+++ b/tests/integration/components/file-version/component-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
 
 import FactoryGuy, {manualSetup }  from 'ember-data-factory-guy';
 
@@ -16,12 +17,22 @@ test('it renders', function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
     var fileVersion = FactoryGuy.make('file-version');
+    const currentDate = moment().format('YYYY-MM-DD h:mm A');
+
     this.set('fileVersion', fileVersion);
+    this.set('fileVersion', 'modified_utc', currentDate);
+
     this.render(hbs`{{file-version version=fileVersion}}`);
 
     assert.equal(
-        this.$('.file-version').children().eq(1).text(),
-        `${fileVersion.get('size')}`,
-        'Second list element should be a label with file size'
+        this.$('.file-version').children().eq(1).text(), 
+        currentDate, 
+        'Second list element should be a label with the files date'
+    );
+
+    assert.equal(
+        this.$('.file-version').children().eq(2).text(), 
+        0, 
+        'Third list element should be a label with the download count - which is 0'
     );
 });

--- a/tests/integration/components/file-version/component-test.js
+++ b/tests/integration/components/file-version/component-test.js
@@ -7,6 +7,7 @@ moduleForComponent('file-version', 'Integration | Component | file version', {
 
     beforeEach: function() {
         // Set up factory guy, per docs
+        this.service = this.container.lookup('service:moment');
         manualSetup(this.container);
     }
 });
@@ -25,7 +26,9 @@ test('it renders', function(assert) {
     };
 
     this.set('version', version);
-
+    
+    this.service.setTimeZone('UTC');
+    
     this.render(hbs`{{file-version version=version}}`);
 
     assert.equal(
@@ -36,8 +39,8 @@ test('it renders', function(assert) {
 
     assert.equal(
         this.$('.file-version').children().eq(1).text(),
-        '2017-10-06 6:23 PM UTC'
-        'Second list element should be a label with the files date'
+        '2017-10-06 6:23 PM UTC',
+        'Second list element should be a label with the file date'
     );
 
     assert.equal(

--- a/tests/integration/components/file-version/component-test.js
+++ b/tests/integration/components/file-version/component-test.js
@@ -36,7 +36,7 @@ test('it renders', function(assert) {
 
     assert.equal(
         this.$('.file-version').children().eq(1).text(),
-        '2017-10-06 2:23 PM',
+        '2017-10-06 6:23 PM UTC'
         'Second list element should be a label with the files date'
     );
 

--- a/tests/integration/components/file-version/component-test.js
+++ b/tests/integration/components/file-version/component-test.js
@@ -1,8 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import moment from 'moment';
-
-import FactoryGuy, {manualSetup }  from 'ember-data-factory-guy';
+import { manualSetup } from 'ember-data-factory-guy';
 
 moduleForComponent('file-version', 'Integration | Component | file version', {
     integration: true,
@@ -14,25 +12,38 @@ moduleForComponent('file-version', 'Integration | Component | file version', {
 });
 
 test('it renders', function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.on('myAction', function(val) { ... });
-    var fileVersion = FactoryGuy.make('file-version');
-    const currentDate = moment().format('YYYY-MM-DD h:mm A');
+    // Tests that the file-version table renders when given the right data
 
-    this.set('fileVersion', fileVersion);
-    this.set('fileVersion', 'modified_utc', currentDate);
+    const version = {
+        id: 1,
+        attributes: {
+            modified_utc: '2017-10-06T18:23:50+00:00',
+            extra: {
+                downloads: 10,
+            }
+        }
+    };
 
-    this.render(hbs`{{file-version version=fileVersion}}`);
+    this.set('version', version);
+
+    this.render(hbs`{{file-version version=version}}`);
 
     assert.equal(
-        this.$('.file-version').children().eq(1).text(), 
-        currentDate, 
+        this.$('.file-version').children().eq(0).text().trim(),
+        '1',
+        'The first element should be the id, which is 1'
+    );
+
+    assert.equal(
+        this.$('.file-version').children().eq(1).text(),
+        '2017-10-06 2:23 PM',
         'Second list element should be a label with the files date'
     );
 
     assert.equal(
-        this.$('.file-version').children().eq(2).text(), 
-        0, 
-        'Third list element should be a label with the download count - which is 0'
+        this.$('.file-version').children().eq(2).text(),
+        10,
+        'Third list element should be a label with the download count - which is 10'
     );
+
 });

--- a/tests/integration/components/file-version/component-test.js
+++ b/tests/integration/components/file-version/component-test.js
@@ -12,7 +12,7 @@ moduleForComponent('file-version', 'Integration | Component | file version', {
     }
 });
 
-test('it renders', function(assert) {
+test('it renders 88665544', function(assert) {
     // Tests that the file-version table renders when given the right data
 
     const version = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6471,7 +6471,7 @@ moment-timezone@^0.3.0:
   dependencies:
     moment ">= 2.6.0"
 
-moment-timezone@^0.5.13:
+moment-timezone@^0.5.13, moment-timezone@~0.5.11:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.13.tgz#99ce5c7d827262eb0f1f702044177f60745d7b90"
   dependencies:


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-769

# Purpose

To alter the file-version widget to include necessary information for the file-detail page.

# Summary of changes

Changed some of the data being sent through and added fields to the table for `Date`, `Download Count`, `MD5`, and `SHA2`.

![screen shot 2017-09-25 at 11 45 53 am](https://user-images.githubusercontent.com/19379783/30817544-1ef2db82-a1e7-11e7-9cbc-138c33043119.png)

# Testing

Please be sure to check that the right information is being used in cases where there are multiple file versions.
In cases where there are multiple versions, the version currently selected is not clickable.  Please make sure that the versions clickable change based on what's selected.
