### PR TITLE
[EOSF-769] Update file-renderer to take version

### DIFF
--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -24,10 +24,14 @@ export default Ember.Component.extend({
     width: '100%',
     height: '100%',
     allowfullscreen: true,
-    mfrUrl: Ember.computed('download', function() {
+    version: null,
+    mfrUrl: Ember.computed('download', 'version', function() {
         var base = config.OSF.renderUrl;
-        var download = this.get('download');
-        var renderUrl = base + '?url=' + encodeURIComponent(download + '?direct&mode=render&initialWidth=766');
+        var download = this.get('download') + '?direct&mode=render&initialWidth=766';
+        if (this.get('version')) {
+            download += '&version=' + this.get('version');
+        }
+        var renderUrl = base + '?url=' + encodeURIComponent(download);
         return renderUrl;
     })
 });

--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -26,12 +26,10 @@ export default Ember.Component.extend({
     allowfullscreen: true,
     version: null,
     mfrUrl: Ember.computed('download', 'version', function() {
-        var base = config.OSF.renderUrl;
-        var download = this.get('download') + '?direct&mode=render&initialWidth=766';
+        let download = this.get('download') + '?direct&mode=render&initialWidth=766';
         if (this.get('version')) {
             download += '&version=' + this.get('version');
         }
-        var renderUrl = base + '?url=' + encodeURIComponent(download);
-        return renderUrl;
+        return config.OSF.renderUrl + '?url=' + encodeURIComponent(download);
     })
 });


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-769

# Purpose

Quickfiles will need to have the ability to change versions.  Part of this is to show a different version in the mfr renderer when needed.  The purpose of this PR was to add a new property to the file renderer that handles versions being passed through.

# Summary of changes

Added a new property that watches for if a version is being passed through.  If there is a version, the url will update to append the version query parameter to the end of the mfr url.
