### PR TITLE
[EOSF-823] Add 'My Quick Files' link to navbar and fix 'Search' link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - file-browser-item now formatted to fit in with file-widget
 - file-browser-item now supports icons for different file extensions
 - dropzone-widget now has custom dropzone class that extends dropzone functionality to conditionally disallow folders and multiple files from being dropped
-
+- 'Search' button in navbar to link to search page
 
 ## [0.11.0] - 2017-10-11
 ### Changed

--- a/addon/components/new-osf-navbar/template.hbs
+++ b/addon/components/new-osf-navbar/template.hbs
@@ -39,8 +39,7 @@
                     {{#each (build-secondary-nav-links currentService) as |navLink|}}
                         {{#if (and (eq currentService 'HOME') (eq navLink.type "search"))}}
                             <li>
-                                {{!TOGGLE SEARCH BUTTON FOR HOME SERVICE}}
-                                <a role="button" class="btn-link search-toggle" {{action 'toggleSearch'}} {{action 'click' 'button' (concat 'Navbar - ' currentService navLink.name)}}>
+                                <a href="{{navLink.href}}" onclick={{action 'click' 'link' (concat 'Navbar - ' navlink.name)}}>
                                     {{t navLink.name}}
                                 </a>
                             </li>

--- a/addon/const/service-links.js
+++ b/addon/const/service-links.js
@@ -21,6 +21,7 @@ const serviceLinks = {
     exploreActivity: `${osfUrl}explore/activity/`,
     meetingsHome: `${osfUrl}meetings/`,
     myProjects: `${osfUrl}myprojects/`,
+    myQuickFiles: `${osfUrl}quickfiles/`,
     osfHome: osfUrl,
     osfSupport: `${osfUrl}support/`,
     preprintsDiscover: `${osfUrl}preprints/discover/`,
@@ -31,7 +32,8 @@ const serviceLinks = {
     registriesDiscover: `${osfUrl}registries/discover/`,
     registriesHome: `${osfUrl}registries/`,
     registriesSupport: 'http://help.osf.io/m/registrations/',
-    settings: `${osfUrl}settings/`
+    search: `${osfUrl}search/`,
+    settings: `${osfUrl}settings/`,
 };
 
 

--- a/addon/helpers/build-secondary-nav-links.js
+++ b/addon/helpers/build-secondary-nav-links.js
@@ -99,8 +99,7 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                     href: serviceLinks.osfSupport
                 }
             );
-        }
-        if(session.get('isAuthenticated')) {
+        } else {
             links.HOME.unshift(
                 {
                     name: 'eosf.navbar.myQuickFiles',

--- a/addon/helpers/build-secondary-nav-links.js
+++ b/addon/helpers/build-secondary-nav-links.js
@@ -27,7 +27,7 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                 },
                 {
                     name: 'eosf.navbar.search',
-                    href: '#',
+                    href: serviceLinks.search,
                     type: 'search'
                 },
                 {
@@ -97,6 +97,14 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                 {
                     name: 'eosf.navbar.support',
                     href: serviceLinks.osfSupport
+                }
+            );
+        }
+        if(session.get('isAuthenticated')) {
+            links.HOME.unshift(
+                {
+                    name: 'eosf.navbar.myQuickFiles',
+                    href: serviceLinks.myQuickFiles
                 }
             );
         }

--- a/addon/helpers/build-secondary-nav-links.js
+++ b/addon/helpers/build-secondary-nav-links.js
@@ -92,18 +92,18 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
         });
 
         // If unauthenticated, add support link to HOME links. (If authenticated, support link can be found under Auth dropdown)
-        if (!session.get('isAuthenticated')) {
-            links.HOME.push(
-                {
-                    name: 'eosf.navbar.support',
-                    href: serviceLinks.osfSupport
-                }
-            );
-        } else {
+        if(session.get('isAuthenticated')) {
             links.HOME.unshift(
                 {
                     name: 'eosf.navbar.myQuickFiles',
                     href: serviceLinks.myQuickFiles
+                }
+            );
+        } else {
+            links.HOME.push(
+                {
+                    name: 'eosf.navbar.support',
+                    href: serviceLinks.osfSupport
                 }
             );
         }

--- a/addon/locales/en/translations.js
+++ b/addon/locales/en/translations.js
@@ -59,6 +59,7 @@ export default {
             donate: 'Donate',
             goHome: 'Go home',
             myProjects: 'My Projects',
+            myQuickFiles: 'My Quick Files',
             search: 'Search',
             searchHelp: 'Search help',
             searchTheOSF: 'Search the OSF',


### PR DESCRIPTION
# Purpose

To add 'My Quick Files' link to the ember-osf navbar and to fix the 'Search' button to take the user to the search page instead of dropdown the search box.

# Changes

- Add quickfiles to the navbar and translate files
- Change the search button into a link that goes to the search page
