### PR TITLE
[EOSF-711] Fix file-browser dialog text

### DIFF
--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -106,11 +106,12 @@
                             </button>
                         </div>
                         <div class="modal-body">
-                            <p><b>Select rows:</b> Click on a row (outside the add-on, file, or folder name) to show further actions in the toolbar. Use Command or Shift keys to select multiple files.</p>
+                            <p><b>Upload:</b> Single file uploads via drag and drop or by clicking the upload button.</p>
+                            <p><b>Select rows:</b> Click on a row to show further actions in the toolbar. Use Command or Shift keys to select multiple files.</p>
+                            <p><b>Folders:</b> Not supported; consider an OSF project for uploading and managing many files.</p>
                             <p><b>Open files:</b> Click a file name to go to view the file in the OSF.</p>
                             <p><b>Open files in new tab:</b> Press Command (Ctrl in Windows) and click a file name to open it in a new tab.</p>
-                            <p><b>Download as zip:</b> Click on the row of an add-on or folder and click the Download as Zip button in the toolbar. <i>Not available for all storage add-ons.</i></p>
-                            <p><b>Copy files:</b> Press Option (Alt in Windows) while dragging a file to a new folder or component. <i>Only for contributors with write access.</i></p>
+                            <p><b>Download as zip:</b> Click the Download as Zip button in the toolbar to download all files as a .zip.</p>
                         </div>
                         <div class="modal-footer">
                             <button {{action 'closeModal'}} class='btn modal-btn btn-secondary'>Close</button>


### PR DESCRIPTION
# Purpose

To fix the wording on the info modal for the file-widget.

# Summary of changes

Updated the wording for the info modal.
