### PR TITLE
[EOSF-711] Add cmd/ctrl+click to open file in new tab

### DIFF
--- a/addon/components/file-browser-item/component.js
+++ b/addon/components/file-browser-item/component.js
@@ -48,8 +48,10 @@ export default Ember.Component.extend({
         return guid ? pathJoin(window.location.origin, guid) : undefined;
     }),
     click(e) {
-        if (e.shiftKey || e.metaKey) {
-            this.selectMultiple(this.get('item'), e.metaKey);
+        if((e.metaKey || e.ctrlKey) && e.target.nodeName == 'A') {
+            window.open(this.get('link'));
+        } else if (e.shiftKey || e.metaKey) {
+            this.sendAction('selectMultiple', this.get('item'), e.metaKey);
         } else {
             this.selectItem(this.get('item'));
         }

--- a/addon/components/file-browser-item/template.hbs
+++ b/addon/components/file-browser-item/template.hbs
@@ -2,7 +2,7 @@
     {{#unless item.flash.message}}
         <div class="col-sm-{{nameColumnWidth}} file-row-col col-xs-12 file-browser-header">
             {{file-browser-icon item=item}}
-            <a {{action 'open'}} role="link">{{item.itemName}}</a>
+            <a {{action 'open' preventDefault='true'}} role="link">{{item.itemName}}</a>
         </div>
         {{#if (if-filter 'size-column' display)}}
             <div class="col-sm-1 file-row-col hidden-xs file-browser-header">


### PR DESCRIPTION
# Purpose

Make it possible to `ctrl+click` and `cmd+click` on file links to open a new tab.

# Summary of changes

- Added conditional to the ember click function to determine if `ctrl` or `cmd` keys were clicked on a link
- Added `preventDefault='true'` on the file links to prevent it from loading the file on the current and new tab on `cmd/ctrl+click`.
