### PR TITLE
[EOSF-882] fix discover page for Registries

### DIFF
--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -502,7 +502,7 @@ export default Ember.Component.extend(Analytics, hostAppName, {
             }
         });
         // For PREPRINTS and REGISTRIES. If theme.isProvider, add provider(s) to query body
-        if (this.get('themeProvider.name') !== null) {
+        if (this.get('themeProvider')) {
             const themeProvider = this.get('themeProvider');
             // Regular preprint providers will have their search results restricted to the one provider.
             // If the provider has additionalProviders, all of these providers will be added to the "sources" SHARE query


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-882

# Purpose

Allow Registries discover page to return results once again

# Summary of changes

Handle case where themeProvider is not set.

# Testing notes

Make sure this doesn't break Preprints