### PR TITLE
[EOSF-777] Make sure results always match latest (and initial) filters selected

### DIFF
--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -572,6 +572,7 @@ export default Ember.Component.extend(Analytics, hostAppName, {
             data: queryBody
         }).then((json) => {
             if (this.isDestroyed || this.isDestroying) return;
+            if (queryBody !== JSON.stringify(this.getQueryBody())) return; //Safeguard: if query has changed since request was sent, dont update results
             let results = json.hits.hits.map(hit => {
                 // HACK: Make share data look like apiv2 preprints data
                 let result = Ember.merge(hit._source, {


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-777

# Purpose
Preprints had a small problem where initial query params would not be respected, and instead default query would take place when the page is first loaded. After investigating, it seems that the first query (before queryParams are 'noticed') takes longer to resolve than the subsequent computed queries, so its results are the last to be returned and are the ones displayed to the user.

This change makes it so, regardless of order of resolution, only requests with queries that match the query composed by the currently selected (or passed) filters will updated the results. 

# Summary of changes
Added safeguard that escapes update of results on query mismatch (between the one sent and the one currently selected). Should also help reduce flashing of results when selecting a bunch of filters in a specific interval if debouncing fails.

