### PR TITLE
[EOSF-770] Update getContents() function for files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- getContents() function for files to use `redirect = true` and `mode = 'render'`
 
 ## [0.12.0] - 2017-10-27
 ### Added

--- a/addon/models/file.js
+++ b/addon/models/file.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import DS from 'ember-data';
 
 import OsfModel from './osf-model';
@@ -85,9 +84,13 @@ export default OsfModel.extend(FileItemMixin, {
         );
     },
     getContents() {
-        return Ember.$.ajax({
+        return authenticatedAJAX({
             url: this.get('links.download'),
             type: 'GET',
+            data: {
+                direct: true,
+                mode: 'render',
+            },
         });
     },
     updateContents(data) {


### PR DESCRIPTION
## Purpose

Currently when a user clicks on their own editable file and uses the editor, the Ajax call uses the basic download link associated with the file to get the contents.  Because of this, the Ajax call is acting as a theoretical download and is adding to the download count unnecessarily.  The purpose of this PR is to add more parameters to the Ajax call so that this doesn't happen.

## Summary of Changes

Update the Ajax call to getContents of the file to use `redirect = true` and `mode='render'`.

## Side Effects / Testing Notes

None

## Ticket

https://openscience.atlassian.net/browse/EOSF-770

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
