### PR TITLE
[EOSF-873] Add analytics to file items for Quick Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - enable open on select
 - ability to specify a pre-selected file in file-browser
 - Stylesheet for the footer to match OSF styles
+- Analytics to `file-browser` and `file-browser-item` for Quick Files:
+  - Share
+  - Download
+  - Download as zip
+  - Upload
 
 ### Changed
 - getContents() function for files to use `redirect = true` and `mode = 'render'`

--- a/addon/components/file-browser-item/component.js
+++ b/addon/components/file-browser-item/component.js
@@ -3,6 +3,8 @@ import moment from 'moment'
 import layout from './template';
 import pathJoin from 'ember-osf/utils/path-join';
 import humanFileSize from 'ember-osf/utils/human-file-size';
+import Analytics from '../../mixins/analytics';
+
 /**
  * @module ember-osf
  * @submodule components
@@ -25,7 +27,7 @@ import humanFileSize from 'ember-osf/utils/human-file-size';
   * @class file-browser-icon
   */
 
-export default Ember.Component.extend({
+export default Ember.Component.extend(Analytics, {
     layout,
     store: Ember.inject.service(),
     classNames: ['file-browser-item'],
@@ -72,6 +74,7 @@ export default Ember.Component.extend({
             this.get('item').getGuid();
         },
         dismissPop() {
+            this.send('click', 'button', 'Quick Files - Share file');
             this.set('item.visiblePopup', false);
         }
     }

--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -2,11 +2,8 @@ import Ember from 'ember';
 import layout from './template';
 
 import loadAll from 'ember-osf/utils/load-relationship';
-<<<<<<< HEAD
 import outsideClick from 'ember-osf/utils/outside-click';
-=======
 import Analytics from '../../mixins/analytics';
->>>>>>> Add analytics to file items for quickfiles
 
 /**
  * File browser widget

--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -2,7 +2,11 @@ import Ember from 'ember';
 import layout from './template';
 
 import loadAll from 'ember-osf/utils/load-relationship';
+<<<<<<< HEAD
 import outsideClick from 'ember-osf/utils/outside-click';
+=======
+import Analytics from '../../mixins/analytics';
+>>>>>>> Add analytics to file items for quickfiles
 
 /**
  * File browser widget
@@ -13,7 +17,7 @@ import outsideClick from 'ember-osf/utils/outside-click';
  * ```
  * @class file-browser
  */
-export default Ember.Component.extend({
+export default Ember.Component.extend(Analytics, {
     // TODO: Improve documentation in the future
     layout,
     //Can be overwritten to have a trimmed down display, these are all the options available to be displayed
@@ -148,6 +152,7 @@ export default Ember.Component.extend({
             this.get('toast').error(response);
         },
         success(_, __, file, response) {
+            this.send('track', 'upload', 'track', 'Quick Files - Upload');
             this.get('uploading').removeObject(file);
             let data = response.data.attributes;
             //OPTIONS (some not researched)

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -30,7 +30,7 @@
                     {{! TODO: show available actions for selected files }}
                     {{#if (eq selectedItems.length 1)}}
                         {{#if (if-filter 'download-button' display)}}
-                            <button {{action 'downloadItem'}} class='btn text-success'>{{fa-icon "download"}} Download</button>
+                            <button onclick={{action 'click' 'button' 'Quick Files - Download'}} {{action 'downloadItem'}} class='btn text-success'>{{fa-icon "download"}} Download</button>
                         {{/if}}
                         {{#if (and edit (if-filter 'rename-button' display))}}
                             <button {{action 'toggleText' 'renaming'}} class='btn text-success'>{{fa-icon "pencil"}} Rename</button>
@@ -48,7 +48,7 @@
                     {{/if}}
                 {{else}}
                     {{#if (if-filter 'download-button' display)}}
-                        <a href='{{downloadUrl}}' class='btn text-success'>{{fa-icon "download"}} Download as zip</a>
+                        <a href='{{downloadUrl}}' class='btn text-success' onclick={{action 'click' 'button' 'Quick Files - Download zip' preventDefault=false}}>{{fa-icon "download"}} Download as zip</a>
                     {{/if}}
                 {{/if}}
                 {{#if (and edit (if-filter 'upload-button' display))}}

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -30,7 +30,7 @@
                     {{! TODO: show available actions for selected files }}
                     {{#if (eq selectedItems.length 1)}}
                         {{#if (if-filter 'download-button' display)}}
-                            <button onclick={{action 'click' 'button' 'Quick Files - Download'}} {{action 'downloadItem'}} class='btn text-success'>{{fa-icon "download"}} Download</button>
+                            <button onclick={{unless edit (action 'click' 'button' 'Quick Files - Download')}} {{action 'downloadItem'}} class='btn text-success'>{{fa-icon "download"}} Download</button>
                         {{/if}}
                         {{#if (and edit (if-filter 'rename-button' display))}}
                             <button {{action 'toggleText' 'renaming'}} class='btn text-success'>{{fa-icon "pencil"}} Rename</button>
@@ -48,7 +48,7 @@
                     {{/if}}
                 {{else}}
                     {{#if (if-filter 'download-button' display)}}
-                        <a href='{{downloadUrl}}' class='btn text-success' onclick={{action 'click' 'button' 'Quick Files - Download zip' preventDefault=false}}>{{fa-icon "download"}} Download as zip</a>
+                        <a href='{{downloadUrl}}' class='btn text-success' onclick={{unless edit (action 'click' 'button' 'Quick Files - Download zip' preventDefault=false)}}>{{fa-icon "download"}} Download as zip</a>
                     {{/if}}
                 {{/if}}
                 {{#if (and edit (if-filter 'upload-button' display))}}


### PR DESCRIPTION
## Purpose

To add analytics to the file-browser items for Quick Files.

## Summary of Changes

Add analytics to: 
- Share link click
- Download from user who doesn't own
- Download as zip from user who doesn't own 
- Upload success

## Ticket

https://openscience.atlassian.net/browse/EOSF-873

Related to ember-osf-web https://github.com/CenterForOpenScience/ember-osf-web/pull/31

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
