### PR TITLE
Changes to styling and functionality for Quick Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Util function that handles popover dismissal when clicking off of popover
+
 ### Changed
 - getContents() function for files to use `redirect = true` and `mode = 'render'`
+- Styling for the file-browser, file-browser-item, and file-version widgets used by Quick Files
 
 ## [0.12.0] - 2017-10-27
 ### Added

--- a/addon/components/file-browser-item/component.js
+++ b/addon/components/file-browser-item/component.js
@@ -41,7 +41,7 @@ export default Ember.Component.extend({
     }),
     date: Ember.computed('item.dateModified', function() {
         let date = this.get('item.dateModified');
-        return moment(date).utc().format('YYYY-MM-DD h:mm a')
+        return moment(date).utc().format('YYYY-MM-DD h:mm A')
     }),
     link: Ember.computed('item.guid', function() {
         let guid = this.get('item.guid');

--- a/addon/components/file-browser-item/style.scss
+++ b/addon/components/file-browser-item/style.scss
@@ -1,0 +1,11 @@
+.popover {
+    min-width: 276px;
+    .share-link {
+        height: 33px;
+    }
+}
+.file-browser-header.link-column {
+    .popover-toggler {
+        margin-top: 2px;
+    }
+}

--- a/addon/components/file-browser-item/template.hbs
+++ b/addon/components/file-browser-item/template.hbs
@@ -1,31 +1,31 @@
 <div class="row file-row-item" style='padding-top: 0px'>
     {{#unless item.flash.message}}
-        <div class="col-sm-{{nameColumnWidth}} file-row-col col-xs-12 file-browser-header">
+        <div class="col-lg-{{nameColumnWidth}} file-row-col col-md-12 file-browser-header">
             {{file-browser-icon item=item}}
             <a {{action 'open' preventDefault='true'}} role="link">{{item.itemName}}</a>
         </div>
         {{#if (if-filter 'size-column' display)}}
-            <div class="col-sm-1 file-row-col hidden-xs file-browser-header">
+            <div class="col-sm-1 file-row-col hidden-md hidden-sm hidden-xs file-browser-header">
                 {{size}}
             </div>
         {{/if}}
         {{#if (if-filter 'version-column' display)}}
-            <div class="col-sm-1 file-row-col hidden-xs file-browser-header">
+            <div class="col-sm-1 file-row-col hidden-md hidden-sm hidden-xs file-browser-header">
                 <a class='version-link' {{action 'openVersion'}} role="link">{{item.currentVersion}}</a>
             </div>
         {{/if}}
         {{#if (if-filter 'downloads-column' display)}}
-            <div class="col-sm-1 file-row-col hidden-xs file-browser-header">
+            <div class="col-sm-1 file-row-col hidden-md hidden-sm hidden-xs file-browser-header">
                 {{item.extra.downloads}}
             </div>
         {{/if}}
         {{#if (if-filter 'modified-column' display)}}
-            <div class="col-sm-2 file-row-col hidden-xs file-browser-header">
+            <div class="col-sm-2 file-row-col hidden-md hidden-sm hidden-xs file-browser-header">
                 {{date}}
             </div>
         {{/if}}
         {{#if (if-filter 'share-link-column' display)}}
-            <div class="col-sm-1 file-row-col hidden-xs file-browser-header link-column">
+            <div class="col-sm-1 file-row-col hidden-md hidden-sm hidden-xs file-browser-header link-column">
                 <div class='btn-group'>
                     <button class='btn btn-default popover-toggler' {{action 'copyLink'}}>
                         {{#bs-popover placement='left' title='Share' visible=item.visiblePopup}}
@@ -37,7 +37,7 @@
                                         {{/copy-button}}
                                     </span>
                                     {{! template-lint-disable }}
-                                    <input readonly="true" type="text" value="{{link}}" class="form-control">
+                                    <input readonly="true" type="text" value="{{link}}" class="form-control share-link">
                                     {{! template-lint-enable }}
                                 </div>
                             {{else}}
@@ -51,7 +51,7 @@
             </div>
         {{/if}}
     {{else}}
-        <div class='col-xs-12 flash-message-alert alert-{{item.flash.type}}'>
+        <div class='col-md-12 flash-message-alert alert-{{item.flash.type}}'>
             <div class='flash-message'>{{item.flash.message}}</div>
         </div>
     {{/unless}}

--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import layout from './template';
 
 import loadAll from 'ember-osf/utils/load-relationship';
+import outsideClick from 'ember-osf/utils/outside-click';
 
 /**
  * File browser widget
@@ -30,11 +31,12 @@ export default Ember.Component.extend({
     init() {
         this._super(...arguments);
         this.set('_items', Ember.A());
-        Ember.$('body').on('click', (e) => {
-            if (Ember.$(e.target).parents('.popover.in').length === 0 && Ember.$(e.target).attr('class') && Ember.$(e.target).attr('class').indexOf('popover-toggler') === -1) {
-                this.send('dismissOtherPops');
-            }
-        });
+        outsideClick(function() {
+            this.send('dismissOtherPops');
+        }.bind(this));
+        Ember.$(window).resize(function() {
+            this.send('dismissOtherPops');
+        }.bind(this));
     },
     currentUser: Ember.inject.service(),
     edit: Ember.computed('user', function() {

--- a/addon/components/file-browser/style.scss
+++ b/addon/components/file-browser/style.scss
@@ -67,12 +67,25 @@
         padding: 6px 0;
     }
 
+    .column-labels-wrapper {
+        position: relative;
+        .column-labels-header::after {
+            position: absolute;
+            background-color: #f5f5f5;
+            width: 20px;
+            height: 33px;
+            top: 1px;
+            right: 1px;
+        }
+    }
+
     .column-labels-header {
         margin: 0px;
         display: block;
         height: 35px;
         background: #f5f5f5;
         border: 1px solid #eee;
+        overflow-y: scroll;
     }
 
     .file-browser-list {
@@ -83,7 +96,8 @@
     .items {
         z-index: 0;
         height: 100%;
-        overflow: scroll;
+        overflow-y: scroll;
+        overflow-x: hidden;
     }
 
     .shade {
@@ -105,13 +119,21 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        height: 100%;
     }
 
     .file-browser-header.header {
         line-height: 23px;
         padding: 3px 0 7px 5px;
         font-size: 14px;
-        border-left: 1px solid #DDD;
+        font-weight: 600;
+        &:not(:first-child) {
+            border-left: 1px solid #DDD;
+        }
+    }
+
+    .sortable-column {
+        padding-right: 10px;
     }
 
     .file-browser-item {
@@ -127,6 +149,7 @@
         }
         a.version-link {
             color: #337ab7;
+            font-weight: 600;
         }
         border-bottom: 1px solid #f5f5f5;
         line-height: 27px;
@@ -184,27 +207,15 @@
         height: 34px;
     }
 
-    #modal {
-        width: 75%;
-        height: 80%;
-        z-index: 2;
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        margin: auto;
-        overflow: scroll;
-    }
-
     .file-row-item {
-        margin-left: -10px;
+        margin-left: 0px;
         margin-right: 0px;
     }
 
     .file-row-col {
         padding-top: 2px;
-        margin-left: -1px;
+        padding-left: 6px;
+        margin-left: 0px;
     }
 
     .sorting {
@@ -213,5 +224,12 @@
     }
     .sorting.active {
         color: black;
+    }
+    .upload-file-header {
+        color: black;
+    }
+    .progress {
+        margin-bottom: 0;
+        margin-top: 7px
     }
 }

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -59,124 +59,117 @@
         {{/if}}
     </div>
     {{#if (if-filter 'header' display)}}
-        <div class="row column-labels-header">
-            <div class="col-xs-{{nameColumnWidth}} file-browser-header header">
-                Name
-                {{fa-icon 'chevron-up' class='itemNameasc sorting' click=(action 'sort' 'itemName' 'asc')}}
-                {{fa-icon 'chevron-down' class='itemNamedes sorting' click=(action 'sort' 'itemName' 'des')}}
+        <div class="column-labels-wrapper">
+            <div class="row column-labels-header">
+                <div class="col-lg-{{nameColumnWidth}} col-md-12 file-browser-header header">
+                    <span class="sortable-column">Name</span>
+                    {{fa-icon 'chevron-up' class='itemNameasc sorting' click=(action 'sort' 'itemName' 'asc')}}
+                    {{fa-icon 'chevron-down' class='itemNamedes sorting' click=(action 'sort' 'itemName' 'des')}}
+                </div>
+                {{#if (if-filter 'size-column' display)}}
+                    <div class="col-lg-1 hidden-md hidden-sm hidden-xs file-browser-header header">
+                        <span class="sortable-column">Size</span>
+                    </div>
+                {{/if}}
+                {{#if (if-filter 'version-column' display)}}
+                    <div class="col-lg-1 hidden-md hidden-sm hidden-xs file-browser-header header">
+                        <span class="sortable-column">Version</span>
+                    </div>
+                {{/if}}
+                {{#if (if-filter 'downloads-column' display)}}
+                    <div class="col-lg-1 hidden-md hidden-sm hidden-xs file-browser-header header">
+                        <span class="sortable-column">Downloads</span>
+                    </div>
+                {{/if}}
+                {{#if (if-filter 'modified-column'  display)}}
+                    <div class="col-lg-2 hidden-md hidden-sm hidden-xs file-browser-header header">
+                        <span class="sortable-column">Modified</span>
+                        {{fa-icon 'chevron-up' class='dateModifiedasc sorting' click=(action 'sort' 'dateModified' 'asc')}}
+                        {{fa-icon 'chevron-down' class='dateModifieddes sorting' click=(action 'sort' 'dateModified' 'des')}}
+                    </div>
+                {{/if}}
+                {{#if (if-filter 'share-link-column' display)}}
+                    <div class="col-lg-1 hidden-md hidden-sm hidden-xs file-browser-header header">
+                    </div>
+                {{/if}}
             </div>
-            {{#if (if-filter 'size-column' display)}}
-                <div class="col-sm-1 hidden-xs file-browser-header header">
-                    Size
-                </div>
-            {{/if}}
-            {{#if (if-filter 'version-column' display)}}
-                <div class="col-sm-1 hidden-xs file-browser-header header">
-                    Version
-                </div>
-            {{/if}}
-            {{#if (if-filter 'downloads-column' display)}}
-                <div class="col-sm-1 hidden-xs file-browser-header header">
-                    Downloads
-                </div>
-            {{/if}}
-            {{#if (if-filter 'modified-column'  display)}}
-                <div class="col-sm-2 hidden-xs file-browser-header header">
-                    Modified
-                    {{fa-icon 'chevron-up' class='dateModifiedasc sorting' click=(action 'sort' 'dateModified' 'asc')}}
-                    {{fa-icon 'chevron-down' class='dateModifieddes sorting' click=(action 'sort' 'dateModified' 'des')}}
-                </div>
-            {{/if}}
-            {{#if (if-filter 'share-link-column' display)}}
-                <div class="col-sm-1 hidden-xs file-browser-header header">
-                </div>
-            {{/if}}
         </div>
     {{/if}}
     <div class='file-browser-list'>
         {{#if modalOpen}}
-            <div id="modal">
-                <div class="modal-content">
-                    {{! modalId }}
-                    {{#if (eq modalOpen 'info')}}
-                        <div class="modal-header">
-                            <h3 class="modal-title break-word">How to Use the File Browser</h3>
-                            <button {{action 'closeModal'}} class="close">
-                                {{fa-icon "times"}}
-                            </button>
-                        </div>
-                        <div class="modal-body">
-                            <p><b>Upload:</b> Single file uploads via drag and drop or by clicking the upload button.</p>
-                            <p><b>Select rows:</b> Click on a row to show further actions in the toolbar. Use Command or Shift keys to select multiple files.</p>
-                            <p><b>Folders:</b> Not supported; consider an OSF project for uploading and managing many files.</p>
-                            <p><b>Open files:</b> Click a file name to go to view the file in the OSF.</p>
-                            <p><b>Open files in new tab:</b> Press Command (Ctrl in Windows) and click a file name to open it in a new tab.</p>
-                            <p><b>Download as zip:</b> Click the Download as Zip button in the toolbar to download all files as a .zip.</p>
-                        </div>
-                        <div class="modal-footer">
-                            <button {{action 'closeModal'}} class='btn modal-btn btn-secondary'>Close</button>
-                        </div>
-                    {{else if (eq modalOpen 'delete')}}
-                        <div class="modal-header">
-                            <h3 class="modal-title break-word">Delete "{{selectedItems.firstObject.itemName}}"?</h3>
-                            <button {{action 'closeModal'}} class="close">
-                                {{fa-icon "times"}}
-                            </button>
-                        </div>
-                        <div class="modal-body">
-                            <p>This action is irreversible.</p>
-                        </div>
-                        <div class="modal-footer">
-                            <button {{action 'closeModal'}} class='btn modal-btn btn-default'>Cancel</button>
-                            <button {{action 'deleteItem'}} class='btn modal-btn btn-danger'>Delete</button>
-                        </div>
-                    {{else if (eq modalOpen 'deleteMultiple')}}
-                        <div class="modal-header">
-                            <h3 class="modal-title break-word">Delete multiple?</h3>
-                            <button {{action 'closeModal'}} class="close">
-                                {{fa-icon "times"}}
-                            </button>
-                        </div>
-                        <div class="modal-body">
-                            <p>This action is irreversible.</p>
-                            {{#each selectedItems as | item |}}
-                                <b>{{item.itemName}}</b>
-                                <hr style='margin-top: 5px'>
-                            {{/each}}
-                        </div>
-                        <div class="modal-footer">
-                            <button {{action 'closeModal'}} class='btn modal-btn btn-default'>Cancel</button>
-                            <button {{action 'deleteItems'}} class='btn modal-btn btn-danger'>Delete</button>
-                        </div>
-                    {{else if (eq modalOpen 'renameConflict')}}
-                        <div class="modal-header">
-                            <h3 class="modal-title break-word">An item named {{textValue}} already exists in this location.</h3>
-                            <button {{action 'closeModal'}} class="close">
-                                {{fa-icon "times"}}
-                            </button>
-                        </div>
-                        <div class="modal-body">
-                            <p>"Keep Both" will retain both files (and their version histories) in this location.</p>
-                            <p>"Replace" will overwrite the existing file in this location. You will lose previous versions of the overwritten file. You will keep previous versions of the moved file.</p>
-                        </div>
-                        <div class="modal-footer">
-                            <button {{action 'cancelRename'}} class='btn modal-btn btn-default'>Cancel</button>
-                            <button {{action '_rename' 'keep'}} class='btn modal-btn btn-primary'>Keep both</button>
-                            <button {{action '_rename' 'replace'}} class='btn modal-btn btn-primary'>Replace</button>
-                        </div>
-                    {{/if}}
-                </div>
-            </div>
+            {{#if (eq modalOpen 'info')}}
+                {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
+                    {{#modal.header onClose=(action 'closeModal')}}
+                        <h3 class="modal-title">How to use the file browser</h3>
+                    {{/modal.header}}
+                    {{#modal.body}}
+                        <p><b>Upload:</b> Single file uploads via drag and drop or by clicking the upload button.</p>
+                        <p><b>Select rows:</b> Click on a row to show further actions in the toolbar. Use Command or Shift keys to select multiple files.</p>
+                        <p><b>Folders:</b> Not supported; consider an OSF project for uploading and managing many files.</p>
+                        <p><b>Open files:</b> Click a file name to go to view the file in the OSF.</p>
+                        <p><b>Open files in new tab:</b> Press Command (Ctrl in Windows) and click a file name to open it in a new tab.</p>
+                        <p><b>Download as zip:</b> Click the Download as Zip button in the toolbar to download all files as a .zip.</p>
+                    {{/modal.body}}
+                    {{#modal.footer}}
+                        {{#bs-button onClick=(action 'closeModal') type='default'}}Close{{/bs-button}}
+                    {{/modal.footer}}
+                {{/bs-modal}}
+            {{else if (eq modalOpen 'delete')}}
+                {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
+                    {{#modal.header onClose=(action 'closeModal')}}
+                        <h3 class="modal-title break-word">Delete "{{selectedItems.firstObject.itemName}}"?</h3>
+                    {{/modal.header}}
+                    {{#modal.body}}
+                        <p>This action is irreversible.</p>
+                    {{/modal.body}}
+                    {{#modal.footer}}
+                        {{#bs-button onClick=(action 'closeModal') type='default'}}Cancel{{/bs-button}}
+                        {{#bs-button onClick=(action 'deleteItem') type='danger'}}Delete{{/bs-button}}
+                    {{/modal.footer}}
+                {{/bs-modal}}
+            {{else if (eq modalOpen 'deleteMultiple')}}
+                {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
+                    {{#modal.header onClose=(action 'closeModal')}}
+                        <h3 class="modal-title break-word">Delete multiple?</h3>
+                    {{/modal.header}}
+                    {{#modal.body}}
+                        <p>This action is irreversible.</p>
+                        {{#each selectedItems as | item |}}
+                            <b>{{item.itemName}}</b>
+                            <hr style='margin-top: 5px'>
+                        {{/each}}
+                    {{/modal.body}}
+                    {{#modal.footer}}
+                        {{#bs-button onClick=(action 'closeModal') type='default'}}Cancel{{/bs-button}}
+                        {{#bs-button onClick=(action 'deleteItems') type='danger'}}Delete{{/bs-button}}
+                    {{/modal.footer}}
+                {{/bs-modal}}
+            {{else if (eq modalOpen 'renameConflict')}}
+                {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
+                    {{#modal.header onClose=(action 'closeModal')}}
+                        <h3 class="modal-title break-word">An item named {{textValue}} already exists in this location.</h3>
+                    {{/modal.header}}
+                    {{#modal.body}}
+                        <p>"Keep Both" will retain both files (and their version histories) in this location.</p>
+                        <p>"Replace" will overwrite the existing file in this location. You will lose previous versions of the overwritten file. You will keep previous versions of the moved file.</p>
+                    {{/modal.body}}
+                    {{#modal.footer}}
+                        {{#bs-button onClick=(action 'closeModal') type='default'}}Cancel{{/bs-button}}
+                        {{#bs-button onClick=(action '_rename' 'keep') type='primary'}}Keep both{{/bs-button}}
+                        {{#bs-button onClick=(action '_rename' 'replace') type='primary'}}Replace{{/bs-button}}
+                    {{/modal.footer}}
+                {{/bs-modal}}
+            {{/if}}
         {{/if}}
         {{#if (or modalOpen dropping)}}
-            <div class='shade'>
-                {{#if dropping}}
+            {{#if dropping}}
+                <div class='shade'>
                     <div class='upload-drop'>
                         <div class='upload-text'>{{fa-icon 'upload' size=5}}</div>
                         <div class='upload-text'>Drop file to upload</div>
                     </div>
-                {{/if}}
-            </div>
+                </div>
+            {{/if}}
         {{/if}}
         {{#if (eq browserState 'loading')}}
             <br><br>
@@ -214,10 +207,10 @@
         {{else}}
             <div class='items'>
                 {{#each uploading as |file|}}
-                    <div class="row">
-                        <div class="col-xs-5 file-browser-header">
+                    <div class="file-browser-item">
+                        <div class="col-xs-5 file-browser-header file-row-col">
                             {{file-browser-icon item=file}}
-                            {{file.name}}
+                            <span class="upload-file-header">{{file.name}}</span>
                         </div>
                         <div class="col-xs-5">
                             <div class="progress">

--- a/addon/components/file-version/template.hbs
+++ b/addon/components/file-version/template.hbs
@@ -1,14 +1,14 @@
-<td>
+<td class='col-md-4'>
     {{#if clickable}}
         <button class='btn btn-link versionButton' onclick={{action 'changeVersion' version.id}}>{{version.id}}</button>
     {{else}}
         {{version.id}}
     {{/if}}
 </td>
-<td>{{moment-format version.attributes.modified_utc}}</td>
-<td><div class='badge'>{{version.attributes.extra.downloads}}</div></td>
-<td><button class='btn btn-primary btn-sm' onclick={{action 'downloadVersion' version.id}}>{{fa-icon 'download'}}</button></td>
-<td>
+<td class='col-md-6'>{{moment-format version.attributes.modified_utc}}</td>
+<td class='col-xs-1'><div class='badge'>{{version.attributes.extra.downloads}}</div></td>
+<td class='col-xs-1'><button class='btn btn-primary btn-sm' onclick={{action 'downloadVersion' version.id}}>{{fa-icon 'download'}}</button></td>
+<td class='hidden-md hidden-sm hidden-xs'>
     <div class='input-group'>
         <span class='input-group-btn'>
             <button type='button' class='btn btn-default btn-sm' onclick={{action 'copyLink' 'md5-{{version.id}}'}}>{{fa-icon 'copy'}}</button>
@@ -16,7 +16,7 @@
         <input type='text' readonly='readonly' value='{{version.attributes.extra.hashes.md5}}' class='hashBox' id='md5-{{version.id}}'>
     </div>
 </td>
-<td>
+<td class='hidden-md hidden-sm hidden-xs'>
     <div class='input-group'>
         <span class='input-group-btn'>
             <button type='button' class='btn btn-default btn-sm' onclick={{action 'copyLink' 'sha256-{{version.id}}'}}>{{fa-icon 'copy'}}</button>

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,5 +1,6 @@
 @import 'components/eosf-project-nav/style';
 @import 'components/file-browser/style';
+@import 'components/file-browser-item/style';
 @import 'components/file-editor/style';
 @import 'components/file-widget/style';
 @import 'components/navbar-auth-dropdown/style';

--- a/addon/utils/outside-click.js
+++ b/addon/utils/outside-click.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+
+/**
+ * Dismisses popovers on outside click
+ * @class outside-click
+ */
+
+/**
+ *
+ * @method outsideClick
+ * @param {Function} clickFunction
+ */
+export default function outsideClick(clickFunction) {
+    Ember.$('body').on('click', (e) => {
+        if (Ember.$(e.target).parents('.popover.in').length === 0 &&
+            Ember.$(e.target).attr('class') &&
+            Ember.$(e.target).attr('class').indexOf('popover-toggler') === -1) {
+            clickFunction();
+        }
+    });
+}


### PR DESCRIPTION
## Purpose

There are some basic styling and functionality errors on Quick Files.  This PR does a lot of small changes through the `file-browser`, file-browser-item` and `file-version` files, as well as adds a util function.

## Summary of Changes

Added styling for some basic issues: 

- Height of the border on the `share link` column on the file-browser widget (to fix border not spanning the whole height of the header)
- Add CSS hack to position header elements over their represented columns
- Fix the width of the share popover to have a min-width.  This will prevent the popover from rendering small and expanding when guids load.
- Change position of the share button to have a margin off of the bottom of the row
- Change the formatted time to have `AM/PM` values instead of `am/pm`
- Fix the classes for the progress bar rows
- Add font-weight to the headers to be semi-bold and match other instances on the site
- Wrap header text in a span to add more space between text and sortable arrows
- Remove border on the first header to fix the double border situation going on

Added:

- Util function that handles popover dismissal when clicking off of the popover
- Functionality to completely remove popover when the size of the page changes (to add more responsiveness to the site)

## Ticket

None

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
