### PR TITLE
[EOSF-711] Add properties to file-browser to control select behavior

### DIFF
--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -28,6 +28,9 @@ export default Ember.Component.extend({
         preventMultipleFiles: true,
         acceptDirectories: false
     },
+    multiple: true,
+    unselect: true,
+    openOnSelect: false,
     init() {
         this._super(...arguments);
         this.set('_items', Ember.A());
@@ -191,13 +194,16 @@ export default Ember.Component.extend({
             });
         },
         selectItem(item) {
+            if (this.get('openOnSelect')) {
+                this.sendAction('openFile', item);
+            }
             this.set('renaming', false);
             if (this.get('selectedItems.length') > 1) {
                 for (var item_ of this.get('selectedItems')) {
                     item_.set('isSelected', item_ === item);
                 }
             } else if (this.get('selectedItems.length') ===  1) {
-                if (item.get('isSelected')) {
+                if (item.get('isSelected') && this.get('unselect')) {
                     item.set('isSelected', false);
                     return;
                 }
@@ -208,6 +214,9 @@ export default Ember.Component.extend({
             this.set('shiftAnchor', item);
         },
         selectMultiple(item, toggle) {
+            if (!this.get('multiple')) {
+                return;
+            }
             this.set('renaming', false);
             if (toggle) {
                 item.toggleProperty('isSelected');


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Add properties to file-browser to control select behavior.

## Summary of Changes

* Add properties to disable multiple select and unselect.
* Add property to open file on select.

## Side Effects / Testing Notes

Default values retain original behavior. Need to set these when calling the file browser.

## Ticket

https://openscience.atlassian.net/browse/EOSF-711

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
