### PR TITLE
Fix dropzone queue error

### DIFF
--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -67,6 +67,7 @@ export default Ember.Component.extend({
         let drop = new CustomDropzone(`#${this.elementId}`, {
             url: file => typeof this.get('buildUrl') === 'function' ? this.get('buildUrl')(file) : this.get('buildUrl'),
             autoProcessQueue: false,
+            autoQueue: false,
             dictDefaultMessage: this.get('defaultMessage') || 'Drop files here to upload',
             sending(file, xhr) {
                 // Monkey patch to send the raw file instead of formData


### PR DESCRIPTION
## Purpose

The dropzone widget is currently trying to process files before queueing them.  This is causing issues when trying to upload files.

## Summary of Changes

Add `autoQueue: false` when uploading a file.

## Ticket

None.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
