### PR TITLE
[EOSF-711] Feature/allow specifying a preselected file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - disable multiple select
   - disable unselect
   - enable open on select
+- ability to specify a pre-selected file in file-browser
 
 ### Changed
 - getContents() function for files to use `redirect = true` and `mode = 'render'`

--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -31,6 +31,7 @@ export default Ember.Component.extend({
     multiple: true,
     unselect: true,
     openOnSelect: false,
+    selectedFile: null,
     init() {
         this._super(...arguments);
         this.set('_items', Ember.A());
@@ -50,6 +51,11 @@ export default Ember.Component.extend({
         loadAll(user, 'quickfiles', this.get('_items')).then(() => {
             this.set('loaded', true);
             this.set('_items', this.get('_items').sortBy('itemName'));
+            this.get('_items').forEach(item => {
+                if (this.get('selectedFile.id') && this.get('selectedFile.id') === item.id) {
+                    item.isSelected = true;
+                }
+            });
         });
     },
     _loadUser:  Ember.on('init', Ember.observer('user', function() {


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allow specification of pre-selected file in file-browser.

## Summary of Changes

Added property to specify selected file.

## Side Effects / Testing Notes

Should not select any file/behave normally when this property is not set (e.g. on user-quickfiles).

## Ticket

https://openscience.atlassian.net/browse/EOSF-711

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
