### PR TITLE
[EOSF-913] Add footer styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - disable unselect
   - enable open on select
 - ability to specify a pre-selected file in file-browser
+- Stylesheet for the footer to match OSF styles
 
 ### Changed
 - getContents() function for files to use `redirect = true` and `mode = 'render'`

--- a/addon/components/osf-footer/style.scss
+++ b/addon/components/osf-footer/style.scss
@@ -1,0 +1,14 @@
+.footer {
+    margin-top: 0;
+    text-shadow: 0 1px 0 #fff;
+    border-top: 1px solid #e5e5e5;
+    border-bottom: 1px solid #e5e5e5;
+    width: 100%;
+    color: #555;
+}
+
+.footer ul, .footer li {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -6,6 +6,7 @@
 @import 'components/navbar-auth-dropdown/style';
 @import 'components/osf-navbar/style';
 @import 'components/osf-mode-footer/style';
+@import 'components/osf-footer/style';
 @import 'components/query-syntax/style';
 @import 'components/search-dropdown/style';
 @import 'components/sign-up/style';


### PR DESCRIPTION
## Purpose

Currently, footer styles are being defined in individual projects.  This should be avoided if we can centralize the styles with the actual footer itself in ember-osf.

## Summary of Changes

Add style.scss file that has footer styles to match the regular OSF.

## Ticket

https://openscience.atlassian.net/browse/EOSF-913

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
