### PR TITLE
[EOSF-922] Remove print margin on ember-ace editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Styling for the file-browser, file-browser-item, and file-version widgets used by Quick Files
 - Removed `Browse` from the navbar when user is logged out
 - Moved `Support` to be between `Search` and `Donate` on the navbar when user is logged out
+- Remove print margin on ember-ace editor on file-detail page
 
 ## [0.12.0] - 2017-10-27
 ### Added

--- a/addon/components/file-editor/template.hbs
+++ b/addon/components/file-editor/template.hbs
@@ -12,6 +12,7 @@
                 useWrapMode=true
                 showLineNumbers=false 
                 value=newText
+                showPrintMargin=false
                 update=(action 'valueUpdated')}}
         </div>
         <div>


### PR DESCRIPTION
## Purpose

The editor on the file-detail page currently shows a print margin when using the editor in full width.  There should not be a margin shown in any case.

## Summary of Changes

- Add `showPrintMargin:false` on the ember-ace editor to remove the margin
![screen shot 2017-11-15 at 11 02 15 am](https://user-images.githubusercontent.com/19379783/32846152-7e33804e-c9f4-11e7-841b-30e5625bb3b3.png)


## Ticket

https://openscience.atlassian.net/browse/EOSF-922

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
