### PR TITLE
[EOSF-919] Change navbar to match OSF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - getContents() function for files to use `redirect = true` and `mode = 'render'`
 - Styling for the file-browser, file-browser-item, and file-version widgets used by Quick Files
+- Removed `Browse` from the navbar when user is logged out
+- Moved `Support` to be between `Search` and `Donate` on the navbar when user is logged out
 
 ## [0.12.0] - 2017-10-27
 ### Added

--- a/addon/helpers/build-secondary-nav-links.js
+++ b/addon/helpers/build-secondary-nav-links.js
@@ -24,10 +24,6 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
         let links = Ember.Object.create({
             HOME: [
                 {
-                    name: session.get('isAuthenticated') ? 'eosf.navbar.myProjects' : 'eosf.navbar.browse',
-                    href: session.get('isAuthenticated') ? serviceLinks.myProjects : serviceLinks.exploreActivity,
-                },
-                {
                     name: 'eosf.navbar.search',
                     href: serviceLinks.search,
                     type: 'search'
@@ -99,6 +95,10 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                 {
                     name: 'eosf.navbar.myQuickFiles',
                     href: serviceLinks.myQuickFiles
+                },
+                {
+                    name: 'eosf.navbar.myProjects',
+                    href: serviceLinks.myProjects,
                 }
             );
             this.get('currentUser.user').then((user) => {
@@ -110,7 +110,7 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                 }
             })
         } else {
-            links.HOME.push(
+            links.HOME.splice(1, 0, 
                 {
                     name: 'eosf.navbar.support',
                     href: serviceLinks.osfSupport

--- a/tests/unit/helpers/build-secondary-nav-links-test.js
+++ b/tests/unit/helpers/build-secondary-nav-links-test.js
@@ -88,7 +88,7 @@ test('returns home service links, unauthenticated', function(assert) {
             {{/each}}
         `);
 
-    assert.equal(this.$()[0].innerText, 'Browse Search Support');
+    assert.equal(this.$()[0].innerText, 'Search Support');
 });
 
 test('returns Registries service links', function(assert) {


### PR DESCRIPTION
## Purpose

When users are logged out, the Quickfiles navbar is different from the OSF style navbar.  

## Summary of Changes

- Remove `Browse` from navbar
- Switch position of `Support` and `Donate` on navbar

## Ticket

https://openscience.atlassian.net/browse/EOSF-919

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
