### PR TITLE
[EOSF-884] Alter provider model to check for highlighted subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support button to the HOME navbar
 - Class for small-display on `file-browser`
 - Conditional to check between `files` and `items` in array for file upload between chrome and safari
+- alias in provider model to check if has highlighted subjects
 
 ### Changed
 - getContents() function for files to use `redirect = true` and `mode = 'render'`

--- a/addon/models/preprint-provider.js
+++ b/addon/models/preprint-provider.js
@@ -29,4 +29,6 @@ export default OsfModel.extend({
     highlightedTaxonomies: DS.hasMany('taxonomy'),
     preprints: DS.hasMany('preprint', { inverse: 'provider', async: true }),
     licensesAcceptable: DS.hasMany('license', { inverse: null }),
+
+    hasHighlightedSubjects: Ember.computed.alias('data.links.relationships.highlighted_taxonomies.links.related.meta.has_highlighted_subjects'),
 });


### PR DESCRIPTION
## Purpose

There is soon going to be a flag that will return a boolean value in the case that a provider has highlighted subjects.  In order to make it easier in the future to access, there should be an alias in the provider model that will have the value ready.

## Summary of Changes

- Add an alias in the provider model that returns the value of the `has_highlighted_subjects` flag

## Ticket

https://openscience.atlassian.net/browse/EOSF-884

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
