### PR TITLE
[EOSF-921] fix persistent drop overlay

### DIFF
--- a/addon/components/file-browser/style.scss
+++ b/addon/components/file-browser/style.scss
@@ -106,6 +106,10 @@
         height: 100%;
         z-index: 1;
         position: absolute;
+        pointer-events: none;
+        &.transparent {
+            opacity: 0;
+        }
     }
 
     .flash-message-alert {

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -9,6 +9,7 @@
     dragenter=(action 'dragStart')
     dragover=(action 'dragStart')
     drop=(action 'dragEnd')
+    dragleave=(action 'dragEnd')
     enable=edit
     class='dropzone-area'
 }}
@@ -161,16 +162,12 @@
                 {{/bs-modal}}
             {{/if}}
         {{/if}}
-        {{#if (or modalOpen dropping)}}
-            {{#if dropping}}
-                <div class='shade'>
-                    <div class='upload-drop'>
-                        <div class='upload-text'>{{fa-icon 'upload' size=5}}</div>
-                        <div class='upload-text'>Drop file to upload</div>
-                    </div>
-                </div>
-            {{/if}}
-        {{/if}}
+        <div class='shade {{if (not dropping) "transparent"}}'>
+            <div class='upload-drop'>
+                <div class='upload-text'>{{fa-icon 'upload' size=5}}</div>
+                <div class='upload-text'>Drop file to upload</div>
+            </div>
+        </div>
         {{#if (eq browserState 'loading')}}
             <br><br>
             <div class='ball-scale ball-dark' style='text-align: center'><div></div></div>


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix the case where drop overlay persists when you cancel dropping a file.

## Summary of Changes

* Added a dragleave handler
* Made drop overlay persistent and click-throughable to avoid flashing

## Side Effects / Testing Notes

Drop overlay should no longer persist when canceling a drop

## Ticket

https://openscience.atlassian.net/browse/EOSF-921

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
