### PR TITLE
[EOSF-913] Remove class from footer

### DIFF
--- a/addon/components/osf-footer/template.hbs
+++ b/addon/components/osf-footer/template.hbs
@@ -1,5 +1,5 @@
 <!-- template-lint triple-curlies=false -->
-<footer class="footer m-t-lg m-b-lg p-lg bg-color-light">
+<footer class="footer m-b-lg p-lg bg-color-light">
     <div class="container">
         <div class="row">
             <div class="col-sm-2 col-md-3 col-md-offset-1">


### PR DESCRIPTION
## Purpose

The footer currently uses an unnecessary class that adds a large top-margin.  We should remove this class from the footer to make the styling better.

## Summary of Changes

Remove class from footer.

## Ticket

https://openscience.atlassian.net/browse/EOSF-913

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
