### PR TITLE
[EOSF-909] Add query params to openFile function

### DIFF
--- a/addon/components/file-browser-item/component.js
+++ b/addon/components/file-browser-item/component.js
@@ -59,10 +59,10 @@ export default Ember.Component.extend(Analytics, {
     },
     actions: {
         openVersion() {
-            this.openItem(this.get('item'), '?revision=' + this.get('item.currentVersion'));
+            this.openItem(this.get('item'), 'revision');
         },
         open() {
-            this.openItem(this.get('item'));
+            this.openItem(this.get('item'), 'view');
         },
     }
 });

--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -209,7 +209,7 @@ export default Ember.Component.extend(Analytics, {
         },
         selectItem(item) {
             if (this.get('openOnSelect')) {
-                this.sendAction('openFile', item, 'view');
+                this.openFile(item, 'view');
             }
             this.set('renaming', false);
             this.set('popupOpen', false);
@@ -256,10 +256,10 @@ export default Ember.Component.extend(Analytics, {
         },
         viewItem() {
             let item = this.get('selectedItems.firstObject');
-            this.sendAction('openFile', item, 'view');
+            this.openFile(item, 'view');
         },
         openItem(item, qparams) {
-            this.sendAction('openFile', item, qparams);
+            this.openFile(item, qparams);
         },
         downloadItem() {
             let downloadLink = this.get('selectedItems.firstObject.links.download');

--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -209,7 +209,7 @@ export default Ember.Component.extend(Analytics, {
         },
         selectItem(item) {
             if (this.get('openOnSelect')) {
-                this.sendAction('openFile', item);
+                this.sendAction('openFile', item, 'view');
             }
             this.set('renaming', false);
             this.set('popupOpen', false);
@@ -256,7 +256,7 @@ export default Ember.Component.extend(Analytics, {
         },
         viewItem() {
             let item = this.get('selectedItems.firstObject');
-            this.sendAction('openFile', item);
+            this.sendAction('openFile', item, 'view');
         },
         openItem(item, qparams) {
             this.sendAction('openFile', item, qparams);


### PR DESCRIPTION
## Purpose

In response to fixes done to https://github.com/CenterForOpenScience/ember-osf-web/pull/36, add query params to the openFile function to determine what view to go to.

## Summary of Changes

Added query params or pass `view/revision` values.

## Ticket

https://openscience.atlassian.net/browse/EOSF-909
https://github.com/CenterForOpenScience/ember-osf-web/pull/36

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
