### PR TITLE
[EOSF-936] Fix functionality for copy buttons on revision table

### DIFF
--- a/addon/components/file-version/component.js
+++ b/addon/components/file-version/component.js
@@ -38,7 +38,7 @@ export default Ember.Component.extend({
             this.attrs.versionChange(version);
         },
         copyLink(id) {
-            document.querySelector(id).select();
+            $('#'+id).select();
             document.execCommand('copy');
         }
     }

--- a/addon/components/file-version/component.js
+++ b/addon/components/file-version/component.js
@@ -38,7 +38,7 @@ export default Ember.Component.extend({
             this.attrs.versionChange(version);
         },
         copyLink(id) {
-            $('#'+id).select();
+            Ember.$('#'+id).select();
             document.execCommand('copy');
         }
     }

--- a/addon/components/file-version/template.hbs
+++ b/addon/components/file-version/template.hbs
@@ -11,7 +11,7 @@
 <td class='hidden-md hidden-sm hidden-xs'>
     <div class='input-group'>
         <span class='input-group-btn'>
-            <button type='button' class='btn btn-default btn-sm' onclick={{action 'copyLink' 'md5-{{version.id}}'}}>{{fa-icon 'copy'}}</button>
+            <button type='button' class='btn btn-default btn-sm' onclick={{action 'copyLink' (concat 'md5-' version.id)}}>{{fa-icon 'copy'}}</button>
         </span>
         <input type='text' readonly='readonly' value='{{version.attributes.extra.hashes.md5}}' class='hashBox' id='md5-{{version.id}}'>
     </div>
@@ -19,7 +19,7 @@
 <td class='hidden-md hidden-sm hidden-xs'>
     <div class='input-group'>
         <span class='input-group-btn'>
-            <button type='button' class='btn btn-default btn-sm' onclick={{action 'copyLink' 'sha256-{{version.id}}'}}>{{fa-icon 'copy'}}</button>
+            <button type='button' class='btn btn-default btn-sm' onclick={{action 'copyLink' (concat 'sha256-' version.id)}}>{{fa-icon 'copy'}}</button>
         </span>
         <input type='text' readonly='readonly' value='{{version.attributes.extra.hashes.sha256}}' class='hashBox' id='sha256-{{version.id}}'>
     </div>


### PR DESCRIPTION
## Purpose

The copy buttons for SHA2 and MD5 currently aren't working on the revisions table.  This is because it is not getting a proper id when calling the copy function.  

## Summary of Changes

Pass the copy function a properly concatenated string for the id.

## Ticket

https://openscience.atlassian.net/browse/EOSF-936

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
