### PR TITLE
[EOSF-928] Move share button to toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Removed `Browse` from the navbar when user is logged out
 - Moved `Support` to be between `Search` and `Donate` on the navbar when user is logged out
 - Remove print margin on ember-ace editor on file-detail page
+- Moved share button in `file-browser-item` to the `file-browser` toolbar
 
 ## [0.12.1] - 2017-11-21
 ### Added

--- a/addon/components/file-browser-item/component.js
+++ b/addon/components/file-browser-item/component.js
@@ -21,7 +21,6 @@ import Analytics from '../../mixins/analytics';
   *        selectMultiple=(action 'selectMultiple') Action - handling clicking multiple rows, through cmd/ctrl and/or shift
   *        display=display Array[Strings] - Indicating which rows of information to display
   *        nameColumnWidth=nameColumnWidth String of number - How wide is the main collumn (name)
-  *        dismissOtherPops=(action 'dismissOtherPops') Action - handling cleaning up popups created by the Share button
   *     }}
   * ```
   * @class file-browser-icon
@@ -65,17 +64,5 @@ export default Ember.Component.extend(Analytics, {
         open() {
             this.openItem(this.get('item'));
         },
-        copyLink() {
-            this.dismissOtherPops(this.get('item'));
-            this.set('item.visiblePopup', true);
-            if (this.get('link')) {
-                return;
-            }
-            this.get('item').getGuid();
-        },
-        dismissPop() {
-            this.send('click', 'button', 'Quick Files - Share file');
-            this.set('item.visiblePopup', false);
-        }
     }
 });

--- a/addon/components/file-browser-item/template.hbs
+++ b/addon/components/file-browser-item/template.hbs
@@ -24,32 +24,6 @@
                 {{date}}
             </div>
         {{/if}}
-        {{#if (if-filter 'share-link-column' display)}}
-            <div class="col-sm-1 file-row-col hidden-md hidden-sm hidden-xs file-browser-header link-column">
-                <div class='btn-group'>
-                    <button class='btn btn-default popover-toggler' {{action 'copyLink'}}>
-                        {{#bs-popover placement='left' title='Share' visible=item.visiblePopup}}
-                            {{#if link}}
-                                <div class="input-group">
-                                    <span class="input-group-btn">
-                                        {{#copy-button success=(action 'dismissPop') class='btn btn-default copy-btn' clipboardText=link}}
-                                            {{fa-icon 'files-o'}}
-                                        {{/copy-button}}
-                                    </span>
-                                    {{! template-lint-disable }}
-                                    <input readonly="true" type="text" value="{{link}}" class="form-control share-link">
-                                    {{! template-lint-enable }}
-                                </div>
-                            {{else}}
-                                Loading...
-                            {{/if}}
-                        {{/bs-popover}}
-                        Share
-                    </button>
-
-                </div>
-            </div>
-        {{/if}}
     {{else}}
         <div class='col-md-12 flash-message-alert alert-{{item.flash.type}}'>
             <div class='flash-message'>{{item.flash.message}}</div>

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -29,7 +29,7 @@
                 {{#if selectedItems}}
                     {{! TODO: show available actions for selected files }}
                     {{#if (eq selectedItems.length 1)}}
-                        <button id="popoverBtn" class='btn text-primary popover-btn' {{action 'copyLink'}}>
+                        <button id="shareButton" class='btn text-primary popover-toggler' {{action 'copyLink'}}>
                             {{fa-icon 'share-alt'}}
                             Share
                             {{#bs-popover placement='bottom' title='Share' visible=popupOpen}}

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -29,6 +29,26 @@
                 {{#if selectedItems}}
                     {{! TODO: show available actions for selected files }}
                     {{#if (eq selectedItems.length 1)}}
+                        <button id="popoverBtn" class='btn text-primary popover-btn' {{action 'copyLink'}}>
+                            {{fa-icon 'share-alt'}}
+                            Share
+                            {{#bs-popover placement='bottom' title='Share' visible=popupOpen}}
+                                {{#if link}}
+                                    <div class="input-group">
+                                        <span class="input-group-btn">
+                                            {{#copy-button success=(action 'dismissPop') class='btn btn-default copy-btn' clipboardText=link}}
+                                                {{fa-icon 'files-o'}}
+                                            {{/copy-button}}
+                                        </span>
+                                        {{! template-lint-disable }}
+                                        <input readonly="true" type="text" value="{{link}}" class="form-control share-link">
+                                        {{! template-lint-enable }}
+                                    </div>
+                                {{else}}
+                                    Loading...
+                                {{/if}}
+                            {{/bs-popover}}
+                        </button>
                         {{#if (if-filter 'download-button' display)}}
                             <button onclick={{unless edit (action 'click' 'button' 'Quick Files - Download')}} {{action 'downloadItem'}} class='btn text-success'>{{fa-icon "download"}} Download</button>
                         {{/if}}
@@ -87,10 +107,6 @@
                         <span class="sortable-column">Modified</span>
                         {{fa-icon 'chevron-up' class='dateModifiedasc sorting' click=(action 'sort' 'dateModified' 'asc')}}
                         {{fa-icon 'chevron-down' class='dateModifieddes sorting' click=(action 'sort' 'dateModified' 'des')}}
-                    </div>
-                {{/if}}
-                {{#if (if-filter 'share-link-column' display)}}
-                    <div class="col-lg-1 hidden-md hidden-sm hidden-xs file-browser-header header">
                     </div>
                 {{/if}}
             </div>
@@ -227,7 +243,6 @@
                         selectMultiple=(action 'selectMultiple')
                         display=display
                         nameColumnWidth=nameColumnWidth
-                        dismissOtherPops=(action 'dismissOtherPops')
                     }}
                 {{/each}}
             </div>

--- a/addon/utils/outside-click.js
+++ b/addon/utils/outside-click.js
@@ -12,6 +12,9 @@ import Ember from 'ember';
  */
 export default function outsideClick(clickFunction) {
     Ember.$('body').on('click', (e) => {
+        if (e.target.classList.contains('popover-btn')) {
+            return;
+        }
         if (Ember.$(e.target).parents('.popover.in').length === 0 &&
             Ember.$(e.target).attr('class') &&
             Ember.$(e.target).attr('class').indexOf('popover-toggler') === -1) {

--- a/addon/utils/outside-click.js
+++ b/addon/utils/outside-click.js
@@ -12,9 +12,6 @@ import Ember from 'ember';
  */
 export default function outsideClick(clickFunction) {
     Ember.$('body').on('click', (e) => {
-        if (e.target.classList.contains('popover-btn')) {
-            return;
-        }
         if (Ember.$(e.target).parents('.popover.in').length === 0 &&
             Ember.$(e.target).attr('class') &&
             Ember.$(e.target).attr('class').indexOf('popover-toggler') === -1) {

--- a/tests/integration/components/file-browser-item/component-test.js
+++ b/tests/integration/components/file-browser-item/component-test.js
@@ -23,7 +23,6 @@ test('it renders with all default columns', function(assert) {
     this.render(hbs`{{file-browser-item item=item}}`);
 
     assert.ok(this.$().html().indexOf('An item') !== -1, "Name of the item didn't appear, when it should've.");
-    assert.ok(this.$().html().indexOf('Share') !== -1, "Link for the file didn't appear, when it should've.");
     assert.ok(this.$().html().indexOf('kB') !== -1, "Size didn't appear, when it should've.");
     assert.ok(this.$().html().indexOf('version-link') !== -1, "Version of item didn't appear, when it should've.");
     assert.ok(this.$().html().indexOf('192830') !== -1, "Download count didn't appear, when it should've.");
@@ -36,7 +35,6 @@ test('it renders with some of the columns', function(assert) {
     this.render(hbs`{{file-browser-item item=item display=display}}`);
 
     assert.ok(this.$().html().indexOf('An item') !== -1, "Name of the item didn't appear, when it should've.");
-    assert.ok(this.$().html().indexOf('Share') !== -1, "Link for the file didn't appear, when it should've.");
     assert.ok(this.$().html().indexOf('kB') !== -1, "Size didn't appear, when it should've.");
     assert.ok(this.$().html().indexOf('version-link') === -1, "Version of item appeared when it shouldn't have.");
     assert.ok(this.$().html().indexOf('192830') === -1, "Download count appeared when it shouldn't have.");
@@ -48,7 +46,6 @@ test('always displays name', function(assert) {
     this.render(hbs`{{file-browser-item item=item display=display}}`);
 
     assert.ok(this.$().html().indexOf('An item') !== -1, "Name of the item didn't appear, when it should've.");
-    assert.ok(this.$().html().indexOf('Share') === -1, "Link for the file appeared when it shouldn't have.");
     assert.ok(this.$().html().indexOf('kB') === -1, "Size appeared when it shouldn't have.");
     assert.ok(this.$().html().indexOf('version-link') === -1, "Version of item appeared when it shouldn't have.");
     assert.ok(this.$().html().indexOf('192830') === -1, "Download count appeared when it shouldn't have.");
@@ -66,7 +63,6 @@ test('flash appears, replaces everything else', function(assert) {
     this.render(hbs`{{file-browser-item item=item}}`);
 
     assert.ok(this.$().html().indexOf('An item') === -1, "Name of the item appeared when it shouldn't have.");
-    assert.ok(this.$().html().indexOf('Share') === -1, "Link for the file appeared when it shouldn't have.");
     assert.ok(this.$().html().indexOf('kB') === -1, "Size appeared when it shouldn't have.");
     assert.ok(this.$().html().indexOf('version-link') === -1, "Version of item appeared when it shouldn't have.");
     assert.ok(this.$().html().indexOf('192830') === -1, "Download count appeared when it shouldn't have.");


### PR DESCRIPTION
## Purpose

To keep the share button visible and consistent on all screen sizes, it should be moved to the toolbar with the other options.

## Summary of Changes

Moved the share button and functionality from the `file-browser-item` component to the `file-browser`.  

<img width="1438" alt="screen shot 2017-11-22 at 9 39 21 am" src="https://user-images.githubusercontent.com/19379783/33135809-1e07ab80-cf69-11e7-94bc-d8513186dc41.png">
<img width="1440" alt="screen shot 2017-11-22 at 9 39 36 am" src="https://user-images.githubusercontent.com/19379783/33135810-1e1bcc5a-cf69-11e7-9922-7c4abfb1eae9.png">


## Ticket

https://openscience.atlassian.net/browse/EOSF-928

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
