### PR TITLE
Fix donate banner's end date

### DIFF
--- a/addon/components/donate-banner/component.js
+++ b/addon/components/donate-banner/component.js
@@ -68,12 +68,12 @@ export default Ember.Component.extend(AnalyticsMixin, {
         {
             'date': new Date(2017, 10, 28),
             'largeClass': 'wk-2-lg',
-            'smallClass': 'wk-2-lg',
+            'smallClass': 'wk-2-sm',
             'altLg': 'Happy Giving Tuesday! Please make a gift to support the OSF tools you use and love.',
             'altSm': 'Happy Giving Tuesday! Please make a gift to support the OSF tools you use and love.',
         },
         {
-            'date': new Date(2018, 10, 29)
+            'date': new Date(2017, 10, 29)
         }
     ]),
 });


### PR DESCRIPTION
## Purpose

The donate banner currently has an end date of `2018`.  This should be changed.

## Ticket

None

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
