### PR TITLE
[EOSF-929] Fix scrollbar on file-browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Download as zip
   - Upload
 - Support button to the HOME navbar
+- Class for small-display on `file-browser`
 
 ### Changed
 - getContents() function for files to use `redirect = true` and `mode = 'render'`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Moved share button in `file-browser-item` to the `file-browser` toolbar
 - Rename button to have class `primary` instead of `success` on the `file-browser` component
 
+### Fixed
+- Margins for scrollbar on `file-browser`
+
 ## [0.12.3] - 2017-11-29
 ### Added
 - Week 3 banner images and text

--- a/addon/components/file-browser/style.scss
+++ b/addon/components/file-browser/style.scss
@@ -59,12 +59,14 @@
         margin-top: 4px;
     }
     .actions-header {
-
         background: #efefef;
         border: 1px solid #eee;
         margin: 0 0 10px;
         background: #efefef;
         padding: 6px 0;
+        &.small-display {
+            margin-bottom: 3px;
+        }
     }
 
     .column-labels-wrapper {

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -1,4 +1,4 @@
-<div class="actions-header row" style="margin-bottom:10px">
+<div class="row actions-header {{if (not display.length) 'small-display'}}">
     {{#if textFieldOpen}}
         <div class="col-xs-9 filter-input">
             {{input placeholder=(if filtering "Filter" selectedItems.firstObject.itemName) class='form-control' value=textValue type="text" enter=(action "textValueKeypress")}}


### PR DESCRIPTION
## Purpose

On the file-detail page the scrollbar for the file-browser widget goes beyond the limits of the list.  The scrollbar should only be as tall as the parent it's in.

## Summary of Changes

- Added conditional to fix `margin-bottom` on above element

On the file-detail page (small view)
![screen shot 2017-11-29 at 1 33 17 pm](https://user-images.githubusercontent.com/19379783/33392383-e7f59f9c-d509-11e7-9c4f-dfdeed050283.png)


On the main page (large view)
![screen shot 2017-11-29 at 1 19 23 pm](https://user-images.githubusercontent.com/19379783/33391779-1202375c-d508-11e7-9fe2-82f387919a80.png)

## Ticket

https://openscience.atlassian.net/browse/EOSF-929

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
