### PR TITLE
[EOSF-917] Fix error when uploading file twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Giving Tuesday donate banner end date and mobile image class
 - Styling and order of buttons on the file-browser to match OSF
+- Growl message to show actual error message on file uploads
+
+### Removed
+- `?kind=file` from end of file path if there is a conflicting file when uploading
 
 ## [0.12.1] - 2017-11-21
 ### Added

--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -152,7 +152,7 @@ export default Ember.Component.extend(Analytics, {
         },
         error(_, __, file, response) {
             this.get('uploading').removeObject(file);
-            this.get('toast').error(response);
+            this.get('toast').error(response.message);
         },
         success(_, __, file, response) {
             this.send('track', 'upload', 'track', 'Quick Files - Upload');
@@ -175,7 +175,7 @@ export default Ember.Component.extend(Analytics, {
                     size: data.size,
                     currentVersion: data.extra.version,
                     dateModified: data.modified_utc
-                })
+                });
                 return;
             }
             response.data.type = 'file'; //
@@ -201,7 +201,7 @@ export default Ember.Component.extend(Analytics, {
                 }
             }
             if (conflictingItem) {
-                return conflictingItem.get('links.upload') + '?kind=file';
+                return conflictingItem.get('links.upload');
             }
             return this.get('uploadUrl') + '?' + Ember.$.param({
                 name: files[0].name


### PR DESCRIPTION
## Purpose

Quick Files will currently display an unreadable error message when trying to upload the same file twice.  We should fix the error message to actually be readable as well as copy behavior on the OSF (show upload progress bar without any messages or changes to the original file)

## Summary of Changes

- Changed the error message to show `response.message`, which will display a proper error message instead of `[Object object]`
- Removed `?kind=file` from the file path if there is a conflicting file upon upload

<i>Upload warning messages will be discussed for a later release.</i>

## Ticket

https://openscience.atlassian.net/browse/EOSF-917

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
