### PR TITLE
[EOSF-939] Fix drop error on safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Upload
 - Support button to the HOME navbar
 - Class for small-display on `file-browser`
+- Conditional to check between `files` and `items` in array for file upload between chrome and safari
 
 ### Changed
 - getContents() function for files to use `redirect = true` and `mode = 'render'`

--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -42,7 +42,7 @@ export default Ember.Component.extend({
         CustomDropzone.prototype = Object.create(Dropzone.prototype);
         CustomDropzone.prototype.drop = function(e) {
             if (this.options.preventMultipleFiles && e.dataTransfer) {
-                if (e.dataTransfer.items.length > 1) {
+                if (e.dataTransfer.items && e.dataTransfer.items.length > 1 || e.dataTransfer.files.length > 1) {
                     this.emit("drop", e);
                     this.emit('error', 'None', 'Cannot upload multiple files');
                     return;


### PR DESCRIPTION
## Purpose

Users currently are getting an error when trying to upload a file in Safari.

## Summary of Changes

Added a conditional to check between `items` (for chrome) and `files` (for safari).

## Ticket

https://openscience.atlassian.net/browse/EOSF-939

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
