### PR TITLE
[IN-70][Ember-OSF] Add whitelist functionality for preprint discover page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `scheduled-banner` component that pulls banners (created in the OSF Admin app) from the API.
+- Whitelist functionality for preprint discover page
 
 ### Changed
 - Format last edited date in search result like "MMM DDD, YYYY UTC" instead of "YYYY-MM-DD (UTC)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Whitelist functionality for preprint discover page
 
 ## [0.17.0] - 2018-05-29
 ### Added
 - `scheduled-banner` component that pulls banners (created in the OSF Admin app) from the API
-- Whitelist functionality for preprint discover page
 
 ### Changed
 - Format last edited date in search result like "MMM DDD, YYYY UTC" instead of "YYYY-MM-DD (UTC)"

--- a/addon/components/discover-page/template.hbs
+++ b/addon/components/discover-page/template.hbs
@@ -145,6 +145,7 @@
                     facets=facets
                     aggregations=aggregations
                     activeFilters=activeFilters
+                    whiteListedProviders=whiteListedProviders
                     updateFilters=(action 'updateFilters')
                     filterReplace=filterReplace
                 }}

--- a/addon/components/faceted-search/template.hbs
+++ b/addon/components/faceted-search/template.hbs
@@ -15,6 +15,7 @@
                 updateFilters=updateFilters
                 activeFilters=activeFilters
                 filterReplace=filterReplace
+                whiteListedProviders=whiteListedProviders
                 onChange=(action 'facetChanged')
                 data=facet.data}}
             </div>


### PR DESCRIPTION
## Purpose
This is the second of two PRs (the first PR is [here](https://github.com/CenterForOpenScience/ember-osf-preprints/pull/492)) for the preprint discover page to get whitelisted SHARE providers from /preprint_providers endpoint of API V2.

## Summary of Changes

New parameters are added to `discover-page` and `faceted-search` components to allow passing of the whitelist down to `search-facet-provider` component.

## Side Effects / Testing Notes

None

## Ticket

https://openscience.atlassian.net/browse/IN-70

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
