### PR TITLE
[EOSF-927] Change rename button to be blue on file-browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Moved `Support` to be between `Search` and `Donate` on the navbar when user is logged out
 - Remove print margin on ember-ace editor on file-detail page
 - Moved share button in `file-browser-item` to the `file-browser` toolbar
+- Rename button to have class `primary` instead of `success` on the `file-browser` component
 
 ## [0.12.3] - 2017-11-29
 ### Added

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -49,7 +49,7 @@
                         <button {{action 'openModal' 'delete'}} class='btn text-danger'>{{fa-icon "trash"}} Delete</button>
                     {{/if}}
                     {{#if (and edit (if-filter 'rename-button' display))}}
-                        <button {{action 'toggleText' 'renaming'}} class='btn text-success'>{{fa-icon "pencil"}} Rename</button>
+                        <button {{action 'toggleText' 'renaming'}} class='btn text-primary'>{{fa-icon "pencil"}} Rename</button>
                     {{/if}}
                 {{else}}
                     {{#if (and edit (if-filter 'delete-button' display))}}


### PR DESCRIPTION
## Purpose

To change the rename button to be blue instead of green on the file-browser component.

## Summary of Changes

Changed the color.

## Ticket

https://openscience.atlassian.net/browse/EOSF-927

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
