### PR TITLE
[EOSF-927] Fix position of 'download as zip' button

### DIFF
--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -55,9 +55,10 @@
                     {{#if (and edit (if-filter 'delete-button' display))}}
                         <button {{action 'openModal' 'deleteMultiple'}} class='btn text-danger'>{{fa-icon "trash"}} Delete multiple</button>
                     {{/if}}
-                    {{#if (if-filter 'download-button' display)}}
-                        <a href='{{downloadUrl}}' class='btn text-primary' onclick={{unless edit (action 'click' 'button' 'Quick Files - Download zip' preventDefault=false)}}>{{fa-icon "download"}} Download as zip</a>
-                    {{/if}}
+                {{/if}}
+            {{else}}
+                {{#if (if-filter 'download-button' display)}}
+                    <a href='{{downloadUrl}}' class='btn text-primary' onclick={{unless edit (action 'click' 'button' 'Quick Files - Download zip' preventDefault=false)}}>{{fa-icon "download"}} Download as zip</a>
                 {{/if}}
             {{/if}}
             <button {{action 'toggleText' 'filtering'}} class='btn text-primary'>{{fa-icon "search"}} Filter</button>


### PR DESCRIPTION
## Purpose

The 'Download as zip' button was mistakenly moved and will now only appear whenever there are items selected.  The button should only display if there isn't anything selected.

## Summary of Changes

Move the 'Download as zip' button to where it's supposed to be.

## Ticket

https://openscience.atlassian.net/browse/EOSF-927

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
