### PR TITLE
[EOSF-921] Make file-browser upload button functional again

### DIFF
--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -21,7 +21,8 @@ import layout from './template';
  *   buildUrl=buildUrl
  *   success=attrs.success
  *   defaultMessage=defaultMessage
- *   options=dropzoneOptions}}
+ *   options=dropzoneOptions
+ *   clickable=clickable}}
  * ```
  *
  * @class dropzone-widget
@@ -68,6 +69,7 @@ export default Ember.Component.extend({
             url: file => typeof this.get('buildUrl') === 'function' ? this.get('buildUrl')(file) : this.get('buildUrl'),
             autoProcessQueue: false,
             autoQueue: false,
+            clickable: this.get('clickable'),
             dictDefaultMessage: this.get('defaultMessage') || 'Drop files here to upload',
             sending(file, xhr) {
                 // Monkey patch to send the raw file instead of formData

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -113,6 +113,7 @@
     enable=edit
     class='dropzone-area'
     id=dropZoneId
+    clickable=(if (and edit (if-filter 'upload-button' display)) '.dz-message' undefined)
 }}
     <div class='file-browser-list'>
         {{#if modalOpen}}


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make file browser upload button functional again.

## Summary of Changes

Configure dropzone to make elements with .dz-message class clickable.

## Side Effects / Testing Notes

Make sure upload button works.

## Ticket

https://openscience.atlassian.net/browse/EOSF-921

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
