### PR TITLE
[EOSF-924] Change when table columns are displayed in file-browser table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove print margin on ember-ace editor on file-detail page
 - Moved share button in `file-browser-item` to the `file-browser` toolbar
 - Rename button to have class `primary` instead of `success` on the `file-browser` component
+- What screen sizes columns are displayed in `file-browser` table
 
 ### Fixed
 - Margins for scrollbar on `file-browser`

--- a/addon/components/file-browser-item/template.hbs
+++ b/addon/components/file-browser-item/template.hbs
@@ -1,26 +1,26 @@
 <div class="row file-row-item" style='padding-top: 0px'>
     {{#unless item.flash.message}}
-        <div class="col-lg-{{nameColumnWidth}} file-row-col col-md-12 file-browser-header">
+        <div class="col-lg-{{nameColumnWidth}} file-row-col col-md-9 col-sm-9 col-xs-12 file-browser-header">
             {{file-browser-icon item=item}}
             <a {{action 'open' preventDefault='true'}} role="link">{{item.itemName}}</a>
         </div>
         {{#if (if-filter 'size-column' display)}}
-            <div class="col-sm-1 file-row-col hidden-md hidden-sm hidden-xs file-browser-header">
+            <div class="col-sm-1 col-md-1 file-row-col hidden-sm hidden-xs file-browser-header">
                 {{size}}
             </div>
         {{/if}}
         {{#if (if-filter 'version-column' display)}}
-            <div class="col-sm-1 file-row-col hidden-md hidden-sm hidden-xs file-browser-header">
+            <div class="col-lg-1 file-row-col hidden-md hidden-sm hidden-xs file-browser-header">
                 <a class='version-link' {{action 'openVersion'}} role="link">{{item.currentVersion}}</a>
             </div>
         {{/if}}
         {{#if (if-filter 'downloads-column' display)}}
-            <div class="col-sm-1 file-row-col hidden-md hidden-sm hidden-xs file-browser-header">
+            <div class="col-lg-1 file-row-col hidden-md hidden-sm hidden-xs file-browser-header">
                 {{item.extra.downloads}}
             </div>
         {{/if}}
         {{#if (if-filter 'modified-column' display)}}
-            <div class="col-sm-2 file-row-col hidden-md hidden-sm hidden-xs file-browser-header">
+            <div class="col-sm-3 col-md-2 col-lg-2 file-row-col hidden-xs file-browser-header">
                 {{date}}
             </div>
         {{/if}}

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -69,13 +69,13 @@
 {{#if (if-filter 'header' display)}}
     <div class="column-labels-wrapper">
         <div class="row column-labels-header">
-            <div class="col-lg-{{nameColumnWidth}} col-md-12 file-browser-header header">
+            <div class="col-lg-{{nameColumnWidth}} col-md-9 col-sm-9 col-xs-12 file-browser-header header">
                 <span class="sortable-column">Name</span>
                 {{fa-icon 'chevron-up' class='itemNameasc sorting' click=(action 'sort' 'itemName' 'asc')}}
                 {{fa-icon 'chevron-down' class='itemNamedes sorting' click=(action 'sort' 'itemName' 'des')}}
             </div>
             {{#if (if-filter 'size-column' display)}}
-                <div class="col-lg-1 hidden-md hidden-sm hidden-xs file-browser-header header">
+                <div class="col-lg-1 col-md-1 hidden-sm hidden-xs file-browser-header header">
                     <span class="sortable-column">Size</span>
                 </div>
             {{/if}}
@@ -90,7 +90,7 @@
                 </div>
             {{/if}}
             {{#if (if-filter 'modified-column'  display)}}
-                <div class="col-lg-2 hidden-md hidden-sm hidden-xs file-browser-header header">
+                <div class="col-lg-2 col-md-2 col-sm-3 hidden-xs file-browser-header header">
                     <span class="sortable-column">Modified</span>
                     {{fa-icon 'chevron-up' class='dateModifiedasc sorting' click=(action 'sort' 'dateModified' 'asc')}}
                     {{fa-icon 'chevron-down' class='dateModifieddes sorting' click=(action 'sort' 'dateModified' 'des')}}


### PR DESCRIPTION
## Purpose

To hide and show specific columns in the `file-browser` table at certain screen sizes.

## Summary of Changes

Changed which columns are displayed at certain sizes.
- Show all columns at large/xl sizes
- Only show name/size/modified at md
- Only show name/modified at sm
- Remove all except name at xs

![screen shot 2017-12-05 at 1 46 37 pm](https://user-images.githubusercontent.com/19379783/33624589-dcdf9c44-d9c2-11e7-9e2e-8e9dcadfcec2.png)

![screen shot 2017-12-05 at 1 46 56 pm](https://user-images.githubusercontent.com/19379783/33624599-e53fcc06-d9c2-11e7-8858-9afef0b68d7a.png)

![screen shot 2017-12-05 at 1 47 04 pm](https://user-images.githubusercontent.com/19379783/33624602-e70d4478-d9c2-11e7-95cf-2be94c54c0b9.png)

![screen shot 2017-12-05 at 1 47 11 pm](https://user-images.githubusercontent.com/19379783/33624603-e894f070-d9c2-11e7-85f8-a7716ff08296.png)


## Ticket

https://openscience.atlassian.net/browse/EOSF-924

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
