### PR TITLE
[EOSF-951] Fix clickability on dropzone widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Margins for scrollbar on `file-browser`
+- Clickability on dropzone widget
 
 ## [0.12.4] - 2017-12-04
 ### Added

--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -34,6 +34,7 @@ export default Ember.Component.extend({
     dropzone: true,
     enable: true,
     clickable: true,
+    dropzoneElement: '',
     loadDropzone() {
         let preUpload = this.get('preUpload');
         let dropzoneOptions = this.get('options') || {};
@@ -78,6 +79,8 @@ export default Ember.Component.extend({
             }
         });
 
+        this.set('dropzoneElement', drop);
+
         // Set osf session header
         let headers = {};
 
@@ -109,7 +112,7 @@ export default Ember.Component.extend({
     },
     didUpdateAttrs() {
         if (this.get('enable')) {
-            Dropzone.forElement(`#${this.elementId}`).destroy();
+            this.get('dropzoneElement').destroy();
             this.loadDropzone();
         }
     },

--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -33,6 +33,7 @@ export default Ember.Component.extend({
     classNameBindings: ['dropzone'],
     dropzone: true,
     enable: true,
+    clickable: true,
     loadDropzone() {
         let preUpload = this.get('preUpload');
         let dropzoneOptions = this.get('options') || {};
@@ -108,7 +109,7 @@ export default Ember.Component.extend({
     },
     didUpdateAttrs() {
         if (this.get('enable') && !this.get('attached')) {
-            this.set('attached', true);
+            Dropzone.forElement(`#${this.elementId}`).destroy();
             this.loadDropzone();
         }
     },

--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -108,7 +108,7 @@ export default Ember.Component.extend({
         });
     },
     didUpdateAttrs() {
-        if (this.get('enable') && !this.get('attached')) {
+        if (this.get('enable')) {
             Dropzone.forElement(`#${this.elementId}`).destroy();
             this.loadDropzone();
         }

--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -34,7 +34,7 @@ export default Ember.Component.extend({
     dropzone: true,
     enable: true,
     clickable: true,
-    dropzoneElement: '',
+    dropzoneElement: null,
     loadDropzone() {
         let preUpload = this.get('preUpload');
         let dropzoneOptions = this.get('options') || {};
@@ -112,7 +112,9 @@ export default Ember.Component.extend({
     },
     didUpdateAttrs() {
         if (this.get('enable')) {
-            this.get('dropzoneElement').destroy();
+            if (this.get('dropzoneElement')) {
+                this.get('dropzoneElement').destroy();
+            }
             this.loadDropzone();
         }
     },

--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -45,6 +45,7 @@ export default Ember.Component.extend(Analytics, {
         }.bind(this));
     },
     currentUser: Ember.inject.service(),
+    dropzone: Ember.computed.alias('edit'),
     edit: Ember.computed('user', function() {
         return this.get('user.id') === this.get('currentUser.currentUserId');
     }),

--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -138,9 +138,9 @@ export default Ember.Component.extend(Analytics, {
         return this.get('loaded') ? (this.get('_items').length ? (this.get('items').length ? 'show' : 'filtered') : 'empty') : 'loading';
     }),
     clickable: Ember.computed('browserState', function() {
-        let clickable = [".dz-message"];
+        let clickable = ['.dz-message'];
         if (this.get('edit') && this.get('display').contains('upload-button') && this.get('browserState') == 'empty') {
-            clickable.push(".file-browser-list");
+            clickable.push('.file-browser-list');
         }
         return clickable;
     }),
@@ -159,8 +159,9 @@ export default Ember.Component.extend(Analytics, {
             this.set('dropping', false);
         },
         error(_, __, file, response) {
+            let message = response.message === undefined ? response : response.message;
             this.get('uploading').removeObject(file);
-            this.get('toast').error(response.message);
+            this.get('toast').error(message);
         },
         success(_, __, file, response) {
             this.send('track', 'upload', 'track', 'Quick Files - Upload');

--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -138,8 +138,8 @@ export default Ember.Component.extend(Analytics, {
         return this.get('loaded') ? (this.get('_items').length ? (this.get('items').length ? 'show' : 'filtered') : 'empty') : 'loading';
     }),
     clickable: Ember.computed('browserState', function() {
-        let clickable = ['.dz-message'];
-        if (this.get('edit') && this.get('display').contains('upload-button') && this.get('browserState') == 'empty') {
+        let clickable = ['.dz-upload-button'];
+        if (this.get('browserState') == 'empty') {
             clickable.push('.file-browser-list');
         }
         return clickable;

--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -136,6 +136,13 @@ export default Ember.Component.extend(Analytics, {
     browserState: Ember.computed('loaded', '_items', function() {
         return this.get('loaded') ? (this.get('_items').length ? (this.get('items').length ? 'show' : 'filtered') : 'empty') : 'loading';
     }),
+    clickable: Ember.computed('browserState', function() {
+        let clickable = [".dz-message"];
+        if (this.get('edit') && this.get('display').contains('upload-button') && this.get('browserState') == 'empty') {
+            clickable.push(".file-browser-list");
+        }
+        return clickable;
+    }),
     actions: {
         //dropzone listeners
         addedFile(_, __, file) {

--- a/addon/components/file-browser/style.scss
+++ b/addon/components/file-browser/style.scss
@@ -12,6 +12,10 @@
         display: none;
     }
 
+    .dz-clickable {
+        cursor: pointer;
+    }
+
     .upload-drop {
         padding: 50px;
         margin: 50px;

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -12,7 +12,7 @@
     {{else}}
         <div class='pull-right'>
             {{#if (and edit (if-filter 'upload-button' display))}}
-                <button class='btn text-success dz-message'>{{fa-icon "upload"}} Upload</button>
+                <button class='btn text-success dz-upload-button'>{{fa-icon "upload"}} Upload</button>
             {{/if}}
             {{#if selectedItems}}
                 {{! TODO: show available actions for selected files }}
@@ -212,7 +212,7 @@
                     <div class='file-placeholder'>
                         <div class='file-placeholder-content'>
                             <div>{{fa-icon 'upload' size=5}}</div>
-                            <div class='file-placeholder-text dz-message'>Drop files here to upload</div>
+                            <div class='file-placeholder-text'>Drop files here to upload</div>
                         </div>
                     </div>
                 {{else}}

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -57,7 +57,7 @@
                     {{/if}}
                 {{/if}}
             {{else}}
-                {{#if (if-filter 'download-button' display)}}
+                {{#if (and (eq browserState 'show') (if-filter 'download-button' display))}}
                     <a href='{{downloadUrl}}' class='btn text-primary' onclick={{unless edit (action 'click' 'button' 'Quick Files - Download zip' preventDefault=false)}}>{{fa-icon "download"}} Download as zip</a>
                 {{/if}}
             {{/if}}
@@ -98,6 +98,71 @@
             {{/if}}
         </div>
     </div>
+{{/if}}
+{{#if modalOpen}}
+    {{#if (eq modalOpen 'info')}}
+        {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
+            {{#modal.header onClose=(action 'closeModal')}}
+                <h3 class="modal-title">How to use the file browser</h3>
+            {{/modal.header}}
+            {{#modal.body}}
+                <p><b>Upload:</b> Single file uploads via drag and drop or by clicking the upload button.</p>
+                <p><b>Select rows:</b> Click on a row to show further actions in the toolbar. Use Command or Shift keys to select multiple files.</p>
+                <p><b>Folders:</b> Not supported; consider an OSF project for uploading and managing many files.</p>
+                <p><b>Open files:</b> Click a file name to go to view the file in the OSF.</p>
+                <p><b>Open files in new tab:</b> Press Command (Ctrl in Windows) and click a file name to open it in a new tab.</p>
+                <p><b>Download as zip:</b> Click the Download as Zip button in the toolbar to download all files as a .zip.</p>
+            {{/modal.body}}
+            {{#modal.footer}}
+                {{#bs-button onClick=(action 'closeModal') type='default'}}Close{{/bs-button}}
+            {{/modal.footer}}
+        {{/bs-modal}}
+    {{else if (eq modalOpen 'delete')}}
+        {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
+            {{#modal.header onClose=(action 'closeModal')}}
+                <h3 class="modal-title break-word">Delete "{{selectedItems.firstObject.itemName}}"?</h3>
+            {{/modal.header}}
+            {{#modal.body}}
+                <p>This action is irreversible.</p>
+            {{/modal.body}}
+            {{#modal.footer}}
+                {{#bs-button onClick=(action 'closeModal') type='default'}}Cancel{{/bs-button}}
+                {{#bs-button onClick=(action 'deleteItem') type='danger'}}Delete{{/bs-button}}
+            {{/modal.footer}}
+        {{/bs-modal}}
+    {{else if (eq modalOpen 'deleteMultiple')}}
+        {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
+            {{#modal.header onClose=(action 'closeModal')}}
+                <h3 class="modal-title break-word">Delete multiple?</h3>
+            {{/modal.header}}
+            {{#modal.body}}
+                <p>This action is irreversible.</p>
+                {{#each selectedItems as | item |}}
+                    <b>{{item.itemName}}</b>
+                    <hr style='margin-top: 5px'>
+                {{/each}}
+            {{/modal.body}}
+            {{#modal.footer}}
+                {{#bs-button onClick=(action 'closeModal') type='default'}}Cancel{{/bs-button}}
+                {{#bs-button onClick=(action 'deleteItems') type='danger'}}Delete{{/bs-button}}
+            {{/modal.footer}}
+        {{/bs-modal}}
+    {{else if (eq modalOpen 'renameConflict')}}
+        {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
+            {{#modal.header onClose=(action 'closeModal')}}
+                <h3 class="modal-title break-word">An item named {{textValue}} already exists in this location.</h3>
+            {{/modal.header}}
+            {{#modal.body}}
+                <p>"Keep Both" will retain both files (and their version histories) in this location.</p>
+                <p>"Replace" will overwrite the existing file in this location. You will lose previous versions of the overwritten file. You will keep previous versions of the moved file.</p>
+            {{/modal.body}}
+            {{#modal.footer}}
+                {{#bs-button onClick=(action 'closeModal') type='default'}}Cancel{{/bs-button}}
+                {{#bs-button onClick=(action '_rename' 'keep') type='primary'}}Keep both{{/bs-button}}
+                {{#bs-button onClick=(action '_rename' 'replace') type='primary'}}Replace{{/bs-button}}
+            {{/modal.footer}}
+        {{/bs-modal}}
+    {{/if}}
 {{/if}}
 {{#dropzone-widget
     buildUrl=(action 'buildUrl')
@@ -157,71 +222,6 @@
                 {{/if}}
             {{/if}}
         {{else}}
-        {{#if modalOpen}}
-            {{#if (eq modalOpen 'info')}}
-                {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
-                    {{#modal.header onClose=(action 'closeModal')}}
-                        <h3 class="modal-title">How to use the file browser</h3>
-                    {{/modal.header}}
-                    {{#modal.body}}
-                        <p><b>Upload:</b> Single file uploads via drag and drop or by clicking the upload button.</p>
-                        <p><b>Select rows:</b> Click on a row to show further actions in the toolbar. Use Command or Shift keys to select multiple files.</p>
-                        <p><b>Folders:</b> Not supported; consider an OSF project for uploading and managing many files.</p>
-                        <p><b>Open files:</b> Click a file name to go to view the file in the OSF.</p>
-                        <p><b>Open files in new tab:</b> Press Command (Ctrl in Windows) and click a file name to open it in a new tab.</p>
-                        <p><b>Download as zip:</b> Click the Download as Zip button in the toolbar to download all files as a .zip.</p>
-                    {{/modal.body}}
-                    {{#modal.footer}}
-                        {{#bs-button onClick=(action 'closeModal') type='default'}}Close{{/bs-button}}
-                    {{/modal.footer}}
-                {{/bs-modal}}
-            {{else if (eq modalOpen 'delete')}}
-                {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
-                    {{#modal.header onClose=(action 'closeModal')}}
-                        <h3 class="modal-title break-word">Delete "{{selectedItems.firstObject.itemName}}"?</h3>
-                    {{/modal.header}}
-                    {{#modal.body}}
-                        <p>This action is irreversible.</p>
-                    {{/modal.body}}
-                    {{#modal.footer}}
-                        {{#bs-button onClick=(action 'closeModal') type='default'}}Cancel{{/bs-button}}
-                        {{#bs-button onClick=(action 'deleteItem') type='danger'}}Delete{{/bs-button}}
-                    {{/modal.footer}}
-                {{/bs-modal}}
-            {{else if (eq modalOpen 'deleteMultiple')}}
-                {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
-                    {{#modal.header onClose=(action 'closeModal')}}
-                        <h3 class="modal-title break-word">Delete multiple?</h3>
-                    {{/modal.header}}
-                    {{#modal.body}}
-                        <p>This action is irreversible.</p>
-                        {{#each selectedItems as | item |}}
-                            <b>{{item.itemName}}</b>
-                            <hr style='margin-top: 5px'>
-                        {{/each}}
-                    {{/modal.body}}
-                    {{#modal.footer}}
-                        {{#bs-button onClick=(action 'closeModal') type='default'}}Cancel{{/bs-button}}
-                        {{#bs-button onClick=(action 'deleteItems') type='danger'}}Delete{{/bs-button}}
-                    {{/modal.footer}}
-                {{/bs-modal}}
-            {{else if (eq modalOpen 'renameConflict')}}
-                {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
-                    {{#modal.header onClose=(action 'closeModal')}}
-                        <h3 class="modal-title break-word">An item named {{textValue}} already exists in this location.</h3>
-                    {{/modal.header}}
-                    {{#modal.body}}
-                        <p>"Keep Both" will retain both files (and their version histories) in this location.</p>
-                        <p>"Replace" will overwrite the existing file in this location. You will lose previous versions of the overwritten file. You will keep previous versions of the moved file.</p>
-                    {{/modal.body}}
-                    {{#modal.footer}}
-                        {{#bs-button onClick=(action 'closeModal') type='default'}}Cancel{{/bs-button}}
-                        {{#bs-button onClick=(action '_rename' 'keep') type='primary'}}Keep both{{/bs-button}}
-                        {{#bs-button onClick=(action '_rename' 'replace') type='primary'}}Replace{{/bs-button}}
-                    {{/modal.footer}}
-                {{/bs-modal}}
-            {{/if}}
-        {{/if}}
             <div class='items'>
                 {{#each uploading as |file|}}
                     <div class="file-browser-item">

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -176,7 +176,7 @@
     dragover=(action 'dragStart')
     drop=(action 'dragEnd')
     dragleave=(action 'dragEnd')
-    enable=edit
+    enable=dropzone
     class='dropzone-area'
     id=dropZoneId
     clickable=clickable

--- a/addon/components/file-browser/template.hbs
+++ b/addon/components/file-browser/template.hbs
@@ -12,7 +12,7 @@
     {{else}}
         <div class='pull-right'>
             {{#if (and edit (if-filter 'upload-button' display))}}
-                <button class='dz-message btn text-success'>{{fa-icon "upload"}} Upload</button>
+                <button class='btn text-success dz-message'>{{fa-icon "upload"}} Upload</button>
             {{/if}}
             {{#if selectedItems}}
                 {{! TODO: show available actions for selected files }}
@@ -114,9 +114,49 @@
     enable=edit
     class='dropzone-area'
     id=dropZoneId
-    clickable=(if (and edit (if-filter 'upload-button' display)) '.dz-message' undefined)
+    clickable=clickable
 }}
     <div class='file-browser-list'>
+        <div class='shade {{if (not dropping) "transparent"}}'>
+            <div class='upload-drop'>
+                <div class='upload-text'>{{fa-icon 'upload' size=5}}</div>
+                <div class='upload-text'>Drop file to upload</div>
+            </div>
+        </div>
+        {{#if (eq browserState 'loading')}}
+            <br><br>
+            <div class='ball-scale ball-dark' style='text-align: center'><div></div></div>
+        {{else if (eq browserState 'empty')}}
+            {{#if uploading.length}}
+                {{#each uploading as |file|}}
+                    <div class="row">
+                        <div class="col-xs-5 file-browser-header">
+                            {{file-browser-icon item=file}}
+                            {{file.name}}
+                        </div>
+                        <div class="col-xs-5">
+                            <div class="progress">
+                                <div id="uploading-{{file.size}}" class="progress-bar" role="progressbar"></div>
+                            </div>
+                        </div>
+                        <div class="col-xs-2 file-browser-header"></div>
+                    </div>
+                {{/each}}
+            {{else}}
+                {{#if edit}}
+                    <div class='file-placeholder'>
+                        <div class='file-placeholder-content'>
+                            <div>{{fa-icon 'upload' size=5}}</div>
+                            <div class='file-placeholder-text dz-message'>Drop files here to upload</div>
+                        </div>
+                    </div>
+                {{else}}
+                    <div class='file-placeholder'>
+                        <div class='file-placeholder-text file-placeholder-content'>This user has not uploaded any quickfiles</div>
+                    </div>
+                {{/if}}
+            {{/if}}
+        {{else}}
         {{#if modalOpen}}
             {{#if (eq modalOpen 'info')}}
                 {{#bs-modal onHidden=(action 'closeModal') as |modal|}}
@@ -182,46 +222,6 @@
                 {{/bs-modal}}
             {{/if}}
         {{/if}}
-        <div class='shade {{if (not dropping) "transparent"}}'>
-            <div class='upload-drop'>
-                <div class='upload-text'>{{fa-icon 'upload' size=5}}</div>
-                <div class='upload-text'>Drop file to upload</div>
-            </div>
-        </div>
-        {{#if (eq browserState 'loading')}}
-            <br><br>
-            <div class='ball-scale ball-dark' style='text-align: center'><div></div></div>
-        {{else if (eq browserState 'empty')}}
-            {{#if uploading.length}}
-                {{#each uploading as |file|}}
-                    <div class="row">
-                        <div class="col-xs-5 file-browser-header">
-                            {{file-browser-icon item=file}}
-                            {{file.name}}
-                        </div>
-                        <div class="col-xs-5">
-                            <div class="progress">
-                                <div id="uploading-{{file.size}}" class="progress-bar" role="progressbar"></div>
-                            </div>
-                        </div>
-                        <div class="col-xs-2 file-browser-header"></div>
-                    </div>
-                {{/each}}
-            {{else}}
-                {{#if edit}}
-                    <div class='file-placeholder'>
-                        <div class='file-placeholder-content'>
-                            <div>{{fa-icon 'upload' size=5}}</div>
-                            <div class='file-placeholder-text'>Drop files here to upload</div>
-                        </div>
-                    </div>
-                {{else}}
-                    <div class='file-placeholder'>
-                        <div class='file-placeholder-text file-placeholder-content'>This user has not uploaded any quickfiles</div>
-                    </div>
-                {{/if}}
-            {{/if}}
-        {{else}}
             <div class='items'>
                 {{#each uploading as |file|}}
                     <div class="file-browser-item">


### PR DESCRIPTION
## Purpose

The dropzone widget is currently not clickable on staging preprints and quickfiles.

## Summary of Changes

Make the things clickable (and add a bit of styling)

## Ticket

https://openscience.atlassian.net/browse/EOSF-951

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
