### PR TITLE
[EOSF-879] Update preprint to show alert when DOI is being minted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Class for small-display on `file-browser`
 - Conditional to check between `files` and `items` in array for file upload between chrome and safari
 - alias in provider model to check if has highlighted subjects
+- Add `preprintDoiCreated` attribute to the `preprint` model
 
 ### Changed
 - getContents() function for files to use `redirect = true` and `mode = 'render'`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Class for small-display on `file-browser`
 - Conditional to check between `files` and `items` in array for file upload between chrome and safari
 - alias in provider model to check if has highlighted subjects
-- Add `preprintDoiCreated` attribute to the `preprint` model
+- `preprintDoiCreated` attribute to the `preprint` model
 
 ### Changed
 - getContents() function for files to use `redirect = true` and `mode = 'render'`

--- a/addon/models/preprint.js
+++ b/addon/models/preprint.js
@@ -30,6 +30,7 @@ export default OsfModel.extend({
     licenseRecord: DS.attr(),
     reviewsState: DS.attr('string'),
     dateLastTransitioned: DS.attr('date'),
+    preprintDoiCreated: DS.attr('date'),
 
     // Relationships
     node: DS.belongsTo('node', { inverse: null, async: true }),


### PR DESCRIPTION
## Purpose

Currently, preprint DOI link on preprint detail page could fail to resolve when the DOI is being minted. This PR shows a prompt message and shows DOI as plain text while the DOI is being minted.

## Summary of Changes

In `model/preprint.js`, a new attribute `preprintDoiCreated` is added to the model to fetch the apiV2 `preprint_doi_created` field.
Also updated the changelog.

## Side Effects / Testing Notes

None

## Ticket

https://openscience.atlassian.net/browse/EOSF-879

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
