### PR TITLE
Only reload Dropzone when clickable attribute changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Margins for scrollbar on `file-browser`
 - Clickability on dropzone widget
+- Handle Dropzone enable/disable properly
 
 ## [0.12.4] - 2017-12-04
 ### Added

--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -2,6 +2,7 @@
 
 import Ember from 'ember';
 import config from 'ember-get-config';
+import diffAttrs from 'ember-diff-attrs';
 
 import layout from './template';
 
@@ -110,14 +111,27 @@ export default Ember.Component.extend({
             }
         });
     },
-    didUpdateAttrs() {
-        if (this.get('enable')) {
-            if (this.get('dropzoneElement')) {
-                this.get('dropzoneElement').destroy();
-            }
-            this.loadDropzone();
+    destroyDropzone() {
+        if (this.get('dropzoneElement')) {
+            this.get('dropzoneElement').destroy();
         }
     },
+    didReceiveAttrs: diffAttrs('enable', 'clickable', function(changedAttrs, ...args) {
+        this._super(...args);
+        if (changedAttrs) {
+            if (changedAttrs.enable) {
+                if (this.get('enable')) {
+                    this.loadDropzone();
+                } else {
+                    this.destroyDropzone();
+                }
+            } else if (changedAttrs.clickable && this.get('enable')) {
+                // Dropzone must be reloaded for clickable changes to take effect.
+                this.destroyDropzone();
+                this.loadDropzone();
+            }
+        }
+    }),
     didInsertElement() {
         if (this.get('enable')) {
             this.loadDropzone();

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "ember-cli-shims": "1.0.2",
     "ember-cp-validations": "^3.5.0",
     "ember-data-has-many-query": "^0.2.0",
+    "ember-diff-attrs": "^0.2.0",
     "ember-get-config": "0.2.1",
     "ember-i18n": "5.0.1",
     "ember-metrics": "0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1826,6 +1826,13 @@ browserslist@^2.1.2:
     caniuse-lite "^1.0.30000744"
     electron-to-chromium "^1.3.24"
 
+browserslist@^2.2.2:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.10.0.tgz#bac5ee1cc69ca9d96403ffb8a3abdc5b6aed6346"
+  dependencies:
+    caniuse-lite "^1.0.30000780"
+    electron-to-chromium "^1.3.28"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -1918,6 +1925,10 @@ can-symlink@^1.0.0:
 caniuse-lite@^1.0.30000744:
   version "1.0.30000746"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000746.tgz#c64f95a3925cfd30207a308ed76c1ae96ea09ea0"
+
+caniuse-lite@^1.0.30000780:
+  version "1.0.30000783"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000783.tgz#9b5499fb1b503d2345d12aa6b8612852f4276ffd"
 
 capture-exit@^1.0.7:
   version "1.2.0"
@@ -2508,6 +2519,12 @@ debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.
   dependencies:
     ms "2.0.0"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -2705,6 +2722,10 @@ ee-first@1.1.1:
 electron-to-chromium@^1.3.24:
   version "1.3.26"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.26.tgz#996427294861a74d9c7c82b9260ea301e8c02d66"
+
+electron-to-chromium@^1.3.28:
+  version "1.3.28"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz#8dd4e6458086644e9f9f0a1cf32e2a1f9dffd9ee"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -3401,6 +3422,13 @@ ember-data@2.11.3:
     semver "^5.1.0"
     silent-error "^1.0.0"
 
+ember-diff-attrs@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-diff-attrs/-/ember-diff-attrs-0.2.0.tgz#376bc09349e2a601d74fa0b21fdb43540d3b8e7c"
+  dependencies:
+    ember-cli-babel "^5.1.7"
+    ember-weakmap "^3.0.0"
+
 ember-disable-prototype-extensions@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.2.tgz#261cccaf6bf8fbb1836be7bdfe4278f9ab92b873"
@@ -3737,6 +3765,14 @@ ember-weakmap@^2.0.0:
   resolved "https://registry.yarnpkg.com/ember-weakmap/-/ember-weakmap-2.0.0.tgz#71c6819a8bfd0b077ae17ca1d9053fc5db06e4ac"
   dependencies:
     ember-cli-babel "^5.1.6"
+
+ember-weakmap@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/ember-weakmap/-/ember-weakmap-3.1.1.tgz#2ae6e0080b5b80cf0d108f7752dc69ea9603dbd7"
+  dependencies:
+    browserslist "^2.2.2"
+    debug "^3.1.0"
+    ember-cli-babel "^6.3.0"
 
 ember-wormhole@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Only reload Dropzone when clickable attribute changes

## Summary of Changes

* Refactor to only reload Dropzone when clickable attribute changes (already noted in CHANGELOG.md)
* Also, properly handle Dropzone enable and disable

Refactor based on recommendation from https://www.emberjs.com/deprecations/v2.x/#toc_code-didreceiveattrs-code-and-code-didupdateattrs-code-arguments

## Side Effects / Testing Notes

Dropzone in Preprints lets you upload again

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
