### PR TITLE
[EOSF-884] Change path of alias for highlighted_subjects for provider models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Added model tests for `review-action`
   - Customize model adapter
 - `meta.total` to `meta.total_pages` in osf-serializer
+- `hasHighlightedSubjects` path in preprint-providers model
 
 ### Fixed
 - Margins for scrollbar on `file-browser`

--- a/addon/models/preprint-provider.js
+++ b/addon/models/preprint-provider.js
@@ -30,5 +30,5 @@ export default OsfModel.extend({
     preprints: DS.hasMany('preprint', { inverse: 'provider', async: true }),
     licensesAcceptable: DS.hasMany('license', { inverse: null }),
 
-    hasHighlightedSubjects: Ember.computed.alias('data.links.relationships.highlighted_taxonomies.links.related.meta.has_highlighted_subjects'),
+    hasHighlightedSubjects: Ember.computed.alias('links.relationships.highlighted_taxonomies.links.related.meta.has_highlighted_subjects'),
 });


### PR DESCRIPTION
## Purpose

To change the preprint-provider model's `hasHighlightedSubjects` alias to point to the right place.

## Summary of Changes

Remove `data` from beginning of path for `hasHighlightedSubjects`.

## Ticket

https://openscience.atlassian.net/browse/EOSF-884

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
