### PR TITLE
[MOD-176][Feature] Replace has-many-query with queryHasMany

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- ember-data-has-many-query
+    - Code that uses `model.query()` should update to `model.queryHasMany()`
+
+### Added
+- `osf-model.queryHasMany`, for reliable querying of hasMany relations
 
 ## [0.13.1] - 2018-01-11
 ### Changed

--- a/addon/adapters/osf-adapter.js
+++ b/addon/adapters/osf-adapter.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-import HasManyQuery from 'ember-data-has-many-query';
 import config from 'ember-get-config';
 import GenericDataAdapterMixin from 'ember-osf/mixins/generic-data-adapter';
 
@@ -19,10 +18,9 @@ import {
  *
  * @class OsfAdapter
  * @extends DS.JSONAPIAdapter
- * @uses HasManyQuery.RESTAdapterMixin
  * @uses GenericDataAdapterMixin
  */
-export default DS.JSONAPIAdapter.extend(HasManyQuery.RESTAdapterMixin, GenericDataAdapterMixin, {
+export default DS.JSONAPIAdapter.extend(GenericDataAdapterMixin, {
     headers: {
         ACCEPT: 'application/vnd.api+json; version=2.4'
     },

--- a/addon/models/osf-model.js
+++ b/addon/models/osf-model.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import { OSFAdapter } from 'ember-osf/adapters/osf-adapter';
-import { authenticatedAJAX } from 'ember-osf/utils/ajax-helpers';
+import OSFAdapter from '../adapters/osf-adapter';
+import { authenticatedAJAX } from '../utils/ajax-helpers';
 
 /**
  * @module ember-osf
@@ -65,7 +65,7 @@ export default DS.Model.extend({
                     remove: relation.canonicalMembers.list.filter(m => currentIds.indexOf(m.getRecord().get('id')) === -1)
                 };
 
-                var other = this.get('_dirtyRelationships.${rel}') || {};
+                var other = this.get(`_dirtyRelationships.${rel}`) || {};
                 Ember.merge(other, changes);
                 this.set(`_dirtyRelationships.${rel}`, other);
             }
@@ -95,11 +95,13 @@ export default DS.Model.extend({
             const options = Ember.merge({
                 url,
                 data: queryParams,
-                headers: OSFAdapter.get('headers'),
+                headers: Ember.get(OSFAdapter, 'headers'),
             }, ajaxOptions);
 
-            authenticatedAJAX(options).catch(reject)
-                .then(Ember.bind(this, this.__queryHasManyDone, resolve));
+            authenticatedAJAX(options).then(
+                Ember.run.bind(this, this.__queryHasManyDone, resolve),
+                reject
+            );
         });
 
         const ArrayPromiseProxy = Ember.ArrayProxy.extend(Ember.PromiseProxyMixin);

--- a/addon/models/osf-model.js
+++ b/addon/models/osf-model.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import OSFAdapter from '../adapters/osf-adapter';
-import { authenticatedAJAX } from '../utils/ajax-helpers';
+import OSFAdapter from 'ember-osf/adapters/osf-adapter';
+import { authenticatedAJAX } from 'ember-osf/utils/ajax-helpers';
 
 /**
  * @module ember-osf

--- a/addon/models/osf-model.js
+++ b/addon/models/osf-model.js
@@ -1,10 +1,5 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import ArrayProxy from '@ember/array/proxy';
-import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
-import { bind } from '@ember/runloop';
-import { Promise as EmberPromise } from 'rsvp';
-
 import { OSFAdapter } from 'ember-osf/adapters/osf-adapter';
 import { authenticatedAJAX } from 'ember-osf/utils/ajax-helpers';
 
@@ -89,7 +84,7 @@ export default DS.Model.extend({
      */
     queryHasMany(propertyName, queryParams, ajaxOptions) {
         const reference = this.hasMany(propertyName);
-        const promise = new EmberPromise((resolve, reject) => {
+        const promise = new Ember.RSVP.Promise((resolve, reject) => {
             // HACK: ember-data discards/ignores the link if an object on the belongsTo side
             // came first. In that case, grab the link where we expect it from OSF's API
             const url = reference.link() || this.get(`links.relationships.${propertyName}.links.related.href`);
@@ -104,10 +99,10 @@ export default DS.Model.extend({
             }, ajaxOptions);
 
             authenticatedAJAX(options).catch(reject)
-                .then(bind(this, this.__queryHasManyDone, resolve));
+                .then(Ember.bind(this, this.__queryHasManyDone, resolve));
         });
 
-        const ArrayPromiseProxy = ArrayProxy.extend(PromiseProxyMixin);
+        const ArrayPromiseProxy = Ember.ArrayProxy.extend(Ember.PromiseProxyMixin);
         return ArrayPromiseProxy.create({ promise });
     },
 

--- a/addon/services/file-manager.js
+++ b/addon/services/file-manager.js
@@ -417,7 +417,7 @@ export default Ember.Service.extend({
      * rejects with an error message.
      */
     _getNewFileInfo(parentFolder, name) {
-        let p = parentFolder.query('files', {
+        let p = parentFolder.queryHasMany('files', {
             'filter[name]': name
         });
         return p.then((files) => {

--- a/addon/utils/load-relationship.js
+++ b/addon/utils/load-relationship.js
@@ -25,7 +25,7 @@ export default function loadAll(model, relationship, dest, options = {}) {
     query = Ember.merge(query, options || {});
     Ember.set(model, 'query-params', query);
 
-    return model.query(relationship, query).then(results => {
+    return model.queryHasMany(relationship, query).then(results => {
         dest.pushObjects(results.toArray());
         if (results.meta) {
             var total = results.meta.pagination.total;

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "ember-cli-node-assets": "0.1.6",
     "ember-cli-shims": "1.0.2",
     "ember-cp-validations": "^3.5.0",
-    "ember-data-has-many-query": "^0.2.0",
     "ember-diff-attrs": "^0.2.0",
     "ember-get-config": "0.2.1",
     "ember-i18n": "5.0.1",

--- a/tests/unit/models/osf-model-test.js
+++ b/tests/unit/models/osf-model-test.js
@@ -1,12 +1,91 @@
+import Ember from 'ember';
 import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('osf-model', 'Unit | Model | osf model', {
   // Specify the other units that are required for this test.
-  needs: []
+  needs: ['model:user', 'model:node']
 });
 
 test('it exists', function(assert) {
   let model = this.subject();
   // let store = this.store();
   assert.ok(!!model);
+});
+
+test('queryHasMany works', function(assert) {
+    const store = this.store();
+    const userId = 'guid1';
+    const userNodesUrl = `https://api.osf.io/v2/users/${userId}/nodes/`;
+    const userPayload = `{
+	"data": {
+	    "relationships": {
+		"nodes": {
+		    "links": {
+			"related": {
+			    "href": "${userNodesUrl}",
+			    "meta": {}
+			}
+		    }
+		},
+	    },
+	    "links": {
+		"self": "https://api.osf.io/v2/users/${userId}/",
+		"html": "https://osf.io/${userId}/",
+	    },
+	    "attributes": {
+		"family_name": "Guid",
+		"given_name": "A",
+		"full_name": "A Guid",
+	    },
+	    "type": "users",
+	    "id": "${userId}"
+	},
+    }`;
+    store.pushPayload(userPayload);
+
+    const nodeIds = ['guid2', 'guid3', 'guid4']
+    const nodeJson = [];
+    for (const id in nodeIds) {
+        nodeJson.pushObject(`{
+            "links": {
+                "self": "https://api.osf.io/v2/nodes/${id}/",
+                "html": "https://osf.io/${id}/"
+            },
+            "attributes": {
+                "category": "project",
+                "title": "Project with guid ${id}",
+            },
+            "type": "nodes",
+            "id": "${id}"
+        }`);
+    }
+
+    const queryParams = {'param': 7};
+
+    Ember.$.mockjax({
+        url: userNodesUrl,
+        responseText: `{
+            "data": [
+                ${nodeJson.join()}
+            ],
+            "meta": {
+                "total": ${nodeIds.length},
+            },
+            "links": {
+                "self": "https://api.osf.io/v2/users/${userId}/nodes/",
+            }
+        }`
+    });
+
+    assert.expect(3 + nodeIds.length);
+
+    const user = store.peekRecord('user', userId);
+    assert.ok(!!user);
+    assert.equal(user.get('id'), userId);
+    return user.queryHasMany('nodes', queryParams).then(function(nodes) {
+        assert.equal(nodes.length, nodeIds.length);
+        for (let i = 0; i < nodes.length; i++) {
+            assert.equal(nodes[i].get('id'), nodeIds[i]);
+        }
+    });
 });

--- a/tests/unit/models/osf-model-test.js
+++ b/tests/unit/models/osf-model-test.js
@@ -16,76 +16,76 @@ test('queryHasMany works', function(assert) {
     const store = this.store();
     const userId = 'guid1';
     const userNodesUrl = `https://api.osf.io/v2/users/${userId}/nodes/`;
-    const userPayload = `{
-	"data": {
-	    "relationships": {
-		"nodes": {
-		    "links": {
-			"related": {
-			    "href": "${userNodesUrl}",
-			    "meta": {}
-			}
-		    }
-		},
-	    },
-	    "links": {
-		"self": "https://api.osf.io/v2/users/${userId}/",
-		"html": "https://osf.io/${userId}/",
-	    },
-	    "attributes": {
-		"family_name": "Guid",
-		"given_name": "A",
-		"full_name": "A Guid",
-	    },
-	    "type": "users",
-	    "id": "${userId}"
-	},
-    }`;
-    store.pushPayload(userPayload);
+    const userPayload = {
+        'data': {
+            'relationships': {
+                'nodes': {
+                    'links': {
+                        'related': {
+                            'href': userNodesUrl,
+                            'meta': {}
+                        }
+                    }
+                },
+            },
+            'links': {
+                'self': `https://api.osf.io/v2/users/${userId}/`,
+                'html': `https://osf.io/${userId}/`,
+            },
+            'attributes': {
+                'family_name': 'Guid',
+                'given_name': 'A',
+                'full_name': 'A Guid',
+            },
+            'type': 'users',
+            'id': userId
+        },
+    };
 
     const nodeIds = ['guid2', 'guid3', 'guid4']
-    const nodeJson = [];
-    for (const id in nodeIds) {
-        nodeJson.pushObject(`{
-            "links": {
-                "self": "https://api.osf.io/v2/nodes/${id}/",
-                "html": "https://osf.io/${id}/"
+    const nodePayloads = [];
+    for (const id of nodeIds) {
+        nodePayloads.push({
+            'links': {
+                'self': `https://api.osf.io/v2/nodes/${id}/`,
+                'html': `https://osf.io/${id}/`
             },
-            "attributes": {
-                "category": "project",
-                "title": "Project with guid ${id}",
+            'attributes': {
             },
-            "type": "nodes",
-            "id": "${id}"
-        }`);
+            'type': 'nodes',
+            'id': id
+        });
     }
 
     const queryParams = {'param': 7};
 
     Ember.$.mockjax({
         url: userNodesUrl,
-        responseText: `{
-            "data": [
-                ${nodeJson.join()}
-            ],
-            "meta": {
-                "total": ${nodeIds.length},
+        responseText: {
+            'data': nodePayloads,
+            'meta': {
+                'total': nodePayloads.length,
             },
-            "links": {
-                "self": "https://api.osf.io/v2/users/${userId}/nodes/",
+            'links': {
+                'self': `https://api.osf.io/v2/users/${userId}/nodes/`,
             }
-        }`
+        }
     });
 
     assert.expect(3 + nodeIds.length);
 
-    const user = store.peekRecord('user', userId);
-    assert.ok(!!user);
-    assert.equal(user.get('id'), userId);
-    return user.queryHasMany('nodes', queryParams).then(function(nodes) {
-        assert.equal(nodes.length, nodeIds.length);
-        for (let i = 0; i < nodes.length; i++) {
-            assert.equal(nodes[i].get('id'), nodeIds[i]);
-        }
+    const done = assert.async();
+    Ember.run(function() {
+        store.pushPayload(userPayload);
+        const user = store.peekRecord('user', userId);
+        assert.ok(!!user);
+        assert.equal(user.get('id'), userId);
+        user.queryHasMany('nodes', queryParams).then(function(nodes) {
+            assert.equal(nodes.length, nodeIds.length);
+            for (let i = 0; i < nodes.length; i++) {
+                assert.equal(nodes[i].get('id'), nodeIds[i]);
+            }
+            done();
+        });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,12 +3412,6 @@ ember-data-factory-guy@2.11.7:
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"
 
-ember-data-has-many-query@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-data-has-many-query/-/ember-data-has-many-query-0.2.0.tgz#97ae2c29d6d7f77d3837cca9f165c26bf6e6fb0a"
-  dependencies:
-    ember-cli-babel "^5.1.6"
-
 ember-data@2.11.3:
   version "2.11.3"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-2.11.3.tgz#46ba0e8411dce6dbb52cc02a29194f265b747ef9"


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Move the [`queryHasMany` helper from ember-osf-reviews](https://github.com/CenterForOpenScience/ember-osf-reviews/blob/develop/app/services/store.js#L21) to ember-osf. Provides a way to query relationships without going through ember-data, which sometimes decides it has all the data it needs and doesn't make the request.


## Summary of Changes
- Add `queryHasMany` method to `osf-model`
  - Allows querying relationships with custom query params and ajax options
    e.g. `user.queryHasMany('nodes', { filter: { title: "My title!", public: true } })`
- Remove ember-data-has-many-query


## Side Effects / Testing Notes
Code that uses `model.query()` has to be updated to use `model.queryHasMany()`. In most cases, it's a drop-in replacement, but I didn't want to replace it silently in case someone tries to query a `belongsTo` or somehow depends on `ember-data-has-many-query`-specific behavior. 


## Ticket

https://openscience.atlassian.net/browse/MOD-176

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [x] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
