### PR TITLE
[EMB-60] Prevent user from selecting multiple files when clicking upload button.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Margins for scrollbar on `file-browser`
 - Clickability on dropzone widget
 - Handle Dropzone enable/disable properly
+- Prevent users from selecting multiple files by clicking 'Upload' button in Quickfiles
 
 ## [0.12.4] - 2017-12-04
 ### Added

--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -80,6 +80,14 @@ export default Ember.Component.extend({
             }
         });
 
+        // Dropzone.js does not have an option for disabling selecting multiple files when clicking the "upload" button.
+        // Therefore, we remove the "multiple" attribute for the hidden file input element, so that users cannot select
+        // multiple files for upload in the first place.
+        let clickableElement = this.get('clickable');
+        if (this.options.preventMultipleFiles && clickableElement){
+            Ember.$('.dz-hidden-input').removeAttr('multiple');
+        }
+
         this.set('dropzoneElement', drop);
 
         // Set osf session header

--- a/addon/components/dropzone-widget/component.js
+++ b/addon/components/dropzone-widget/component.js
@@ -83,8 +83,7 @@ export default Ember.Component.extend({
         // Dropzone.js does not have an option for disabling selecting multiple files when clicking the "upload" button.
         // Therefore, we remove the "multiple" attribute for the hidden file input element, so that users cannot select
         // multiple files for upload in the first place.
-        let clickableElement = this.get('clickable');
-        if (this.options.preventMultipleFiles && clickableElement){
+        if (this.get('options.preventMultipleFiles') && this.get('clickable')){
             Ember.$('.dz-hidden-input').removeAttr('multiple');
         }
 


### PR DESCRIPTION
## Purpose

Currently for quickfiles, uploading multiple files by drag'n'drop is not allowed and would show "Cannot upload multiple files". However, this is not the case when user clicks the "upload" button and select multiple files to upload. This PR fix this problem by not allowing users to select multiple files for upload.

## Summary of Changes

Dropzone.js handles drag'n'drop upload differently than clicking the "upload" button for upload. Therefore, there is not an event handler that we can override to prevent multiple uploads through clicking the "upload" button. However, we could remove the "multiple" attribute from the hidden `<input>` element Dropzone uses, thus preventing users from selecting multiple files. And that is what is done in this PR.

## Side Effects / Testing Notes

None.

## Ticket

https://openscience.atlassian.net/browse/EMB-60

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
