### PR TITLE
[EMB-84] Get upload error message by coalescing all possible response formats

### DIFF
--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -159,9 +159,8 @@ export default Ember.Component.extend(Analytics, {
             this.set('dropping', false);
         },
         error(_, __, file, response) {
-            let message = response.message === undefined ? response : response.message;
             this.get('uploading').removeObject(file);
-            this.get('toast').error(message);
+            this.get('toast').error(response.message_long || response.message || response);
         },
         success(_, __, file, response) {
             this.send('track', 'upload', 'track', 'Quick Files - Upload');


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Handle authentication failure error responses on file upload in file-browser component.

## Summary of Changes

Coalesce all possible response formats to find error message, starting with most specific.

### Before:
![screen shot 2018-01-24 at 2 57 07 pm](https://user-images.githubusercontent.com/348630/35354105-202c1574-0117-11e8-917d-fc535db198d5.png)

### After:
![screen shot 2018-01-24 at 2 57 50 pm](https://user-images.githubusercontent.com/348630/35354137-33e57b1e-0117-11e8-8ab2-03e02996d378.png)

## Side Effects / Testing Notes

Go to quick files, open another window and log out of the OSF, attempt a file upload. You should get a nice informative error message instead of `[object Object]`.

## Ticket

https://openscience.atlassian.net/browse/EMB-84

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
