### PR TITLE
[IN-78][Emberosf] Fix focusOut issue

### DIFF
--- a/addon/components/validated-input/component.js
+++ b/addon/components/validated-input/component.js
@@ -29,6 +29,16 @@ export default Ember.Component.extend({
         defineProperty(this, 'value', computed.alias(`model.${valuePath}`));
     },
 
+    // This is a to make sure we parse and set the date value from manual inputs.
+    focusOut: function () {
+        if (this.get('isDateField')) {
+            let date = Date.parse(this.$('input')[0].value);
+            if (!isNaN(date)) {
+                this.set('value', new Date(date));
+            }
+        }
+    },
+
     isTextArea: computed.equal('inputType', 'textarea'),
     isTextField: computed.equal('inputType', 'text'),
     isDateField: computed.equal('inputType', 'date'),

--- a/addon/components/validated-input/component.js
+++ b/addon/components/validated-input/component.js
@@ -29,16 +29,6 @@ export default Ember.Component.extend({
         defineProperty(this, 'value', computed.alias(`model.${valuePath}`));
     },
 
-    // This is a to make sure we parse and set the date value from manual inputs.
-    focusOut: function () {
-        if (this.get('isDateField')) {
-            let date = Date.parse(this.$('input')[0].value);
-            if (!isNaN(date)) {
-                this.set('value', new Date(date));
-            }
-        }
-    },
-
     isTextArea: computed.equal('inputType', 'textarea'),
     isTextField: computed.equal('inputType', 'text'),
     isDateField: computed.equal('inputType', 'date'),
@@ -67,6 +57,10 @@ export default Ember.Component.extend({
     actions: {
         pressSubmit() {
             this.sendAction('pressSubmit');
+        },
+        
+        forceParse(component) {
+            component._forceParse();
         }
     }
 });

--- a/addon/components/validated-input/template.hbs
+++ b/addon/components/validated-input/template.hbs
@@ -3,7 +3,7 @@
         {{textarea value=value type=type placeholder=placeholder class="form-control" name=valuePath}}
 
     {{else if isDateField}}
-        {{bootstrap-datepicker type=type value=value placeholder=placeholder class="form-control" name=valuePath}}
+        {{bootstrap-datepicker type=type value=value placeholder=placeholder class="form-control" name=valuePath focus-out="forceParse"}}
 
     {{else if isTextField}}
         {{input type=type value=value placeholder=placeholder class="form-control" name=valuePath}}


### PR DESCRIPTION
## Purpose

Currently, when the user manually edits the "Original publication date" field on preprint submission/edit page, the value of the property does not change when the element loses focus. This PR fixes the problem.

## Summary of Changes

A `focusOut` event handler is added to parse and set the value from manual input.

## Side Effects / Testing Notes

For an existing preprint, make sure that when you manually change date value in the "Original publication date" field (not using datepicker) and then click "save", the change is reflected in the preprint detail page.

## Ticket

https://openscience.atlassian.net/browse/IN-78

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
