### PR TITLE
[EMB-17][ember-osf] Add button style on select for project selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Translations for `project-selector` component
 - Move function for `file` model
 - `ember-collapsable-panel` and `ember-power-select` packages
+- Styling on `project-selector` buttons that are selected
 
 ### Changed
 - Node `addChild` model function to create public child elements

--- a/addon/components/project-selector/style.scss
+++ b/addon/components/project-selector/style.scss
@@ -7,6 +7,10 @@
 .toggle-button {
     input {
         display: none;
+        &:checked + label {
+            background-color: #67A3BF;
+            color: white;
+        }
     }
     label {
         display: inline-block;


### PR DESCRIPTION
## Purpose

Add styling to show when a button is selected on the project selector.

## Summary of Changes

Change the background-color and color of selected buttons.

![demo](https://user-images.githubusercontent.com/19379783/35696424-6a4b7a16-0755-11e8-9f9d-3a82d9c4f5b1.gif)


## Side Effects / Testing Notes

There is only the main CSS styling change to the sheet, which should change the color of the button and the font on select.

## Ticket

https://openscience.atlassian.net/browse/EMB-17

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
