### PR TITLE
[EMB-111] Always attempt to create a file's guid on upload

### DIFF
--- a/addon/components/file-browser/component.js
+++ b/addon/components/file-browser/component.js
@@ -218,6 +218,7 @@ export default Ember.Component.extend(Analytics, {
             item.set('links', response.data.links); //Push doesnt pass it links
             this.get('_items').unshiftObject(item);
             this.notifyPropertyChange('_items');
+            item.getGuid();
             Ember.run.next(() => {
                 this.flash(item, 'This file has been added.');
                 this.get('toast').success('A file has been added');


### PR DESCRIPTION
## Purpose
Have every item created in quickfiles have a guid.

## Summary of Changes
Attempt to generate guid as a asynchronous side effect to having a successful file upload.

## Ticket

https://openscience.atlassian.net/browse/EMB-111

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
