### PR TITLE
[IN-234][Ember-OSF] Fix navbar to take in new osf-style changes to navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `secondary-nav-dropdown` class to `new-navbar-auth-dropdown` component
+
 ### Changed
 - Moved all static strings to translation files
 - `bare-strings` option in eslint to `true`
 - Bump OSF API version from 2.4 to 2.6
 - ember-cli-moment-shim version to `^3.5.3` due to security issues found in `moment` versions before `2.19.3`
+- classes and element tags to match styles needed for long name truncation on navbar
 
 ## [0.15.0] - 2018-03-06
 ### Added
@@ -34,14 +38,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Move function for `file` model
 - `ember-collapsable-panel` and `ember-power-select` packages
 - Styling on `project-selector` buttons that are selected
-- `secondary-nav-dropdown` class to `new-navbar-auth-dropdown` component
 
 ### Changed
 - Node `addChild` model function to create public child elements
 - Import compiled css for ember-power-select even when consumin app uses SASS
     - This can be overriden by setting ember-power-select.useSass to true in the app's options
 - Node `addChild` model method will only use defaults for undefined parameters (instead of falsey parameters)
-- classes and element tags to match styles needed for long name truncation on navbar
 
 ### Removed
 - ember-data-has-many-query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Move function for `file` model
 - `ember-collapsable-panel` and `ember-power-select` packages
 - Styling on `project-selector` buttons that are selected
+- `secondary-nav-dropdown` class to `new-navbar-auth-dropdown` component
 
 ### Changed
 - Node `addChild` model function to create public child elements
 - Import compiled css for ember-power-select even when consumin app uses SASS
     - This can be overriden by setting ember-power-select.useSass to true in the app's options
 - Node `addChild` model method will only use defaults for undefined parameters (instead of falsey parameters)
+- classes and element tags to match styles needed for long name truncation on navbar
 
 ### Removed
 - ember-data-has-many-query

--- a/addon/components/new-navbar-auth-dropdown/component.js
+++ b/addon/components/new-navbar-auth-dropdown/component.js
@@ -27,7 +27,7 @@ export default Ember.Component.extend(AnalyticsMixin, {
     currentUser: Ember.inject.service(),
     i18n: Ember.inject.service(),
     tagName: 'li',
-    classNames: ['dropdown'],
+    classNames: ['dropdown', 'secondary-nav-dropdown'],
     classNameBindings: ['notAuthenticated:sign-in'],
     notAuthenticated: Ember.computed.not('session.isAuthenticated'),
     redirectUrl: null,

--- a/addon/components/new-navbar-auth-dropdown/template.hbs
+++ b/addon/components/new-navbar-auth-dropdown/template.hbs
@@ -2,9 +2,10 @@
     {{! TODO: Replace display name functionality if possible- for now truncate via CSS at end of label }}
     {{#bs-dropdown as |dd|}}
         {{#dd.toggle tagName="button" classNames="nav-user-dropdown btn-link"}}
-            <span class="osf-gravatar">
+            <div class="osf-profile-image">
                 <img src="{{gravatarUrl}}" alt="User gravatar">
-            </span> {{get-display-name user.fullName}}
+            </div> 
+            <div class="nav-profile-name">{{user.fullName}}</div>
             <span class="caret"></span>
         {{/dd.toggle}}
 

--- a/addon/components/new-osf-navbar/template.hbs
+++ b/addon/components/new-osf-navbar/template.hbs
@@ -2,12 +2,6 @@
     <nav class="navbar navbar-inverse navbar-fixed-top" id="navbarScope" role="navigation">
         <div class="container">
             <div class="navbar-header">
-                {{!TOGGLE NAVIGATION BUTTON - XS SCREEN}}
-                <a type="button" role="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#secondary-navigation" onclick={{action 'closeSearch'}} aria-label={{t 'eosf.navbar.toggleSecondary'}}>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </a>
                 {{!OSF BRAND}}
                 <a class="navbar-brand" href="/" aria-label={{t 'eosf.navbar.goHome'}}>
                     <span class="osf-navbar-logo"></span>
@@ -32,6 +26,12 @@
                         {{/each}}
                     </ul>
                 </div>
+                {{!TOGGLE NAVIGATION BUTTON - XS SCREEN}}
+                <a type="button" role="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#secondary-navigation" onclick={{action 'closeSearch'}} aria-label={{t 'eosf.navbar.toggleSecondary'}}>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </a>
             </div>
             <div class="navbar-collapse collapse navbar-right" id="secondary-navigation">
                 <ul class="nav navbar-nav">


### PR DESCRIPTION
## Purpose

osf-style is now adding `flexbox` to the navbar styles from [this PR](https://github.com/CenterForOpenScience/osf-style/pull/111).  The current ember-osf navbar should change in order to reflect these new styles.

## Summary of Changes

- Move the `navbar-toggle collapsed` button to right of the other elements in its container
- Added `secondary-nav-dropdown` class to the `new-navbar-auth-dropdown` component
- Changed classes and element tags to match styles needed for long name truncation

## Side Effects / Testing Notes

This should be tested with https://github.com/CenterForOpenScience/osf-style/pull/111 which adds the styles to the navbar

- Relates to https://github.com/CenterForOpenScience/osf.io/pull/8163

# Note
- Will need to be updated to use newest version of osf-style after https://github.com/CenterForOpenScience/osf-style/pull/111 is merged

## Ticket

https://openscience.atlassian.net/browse/IN-95

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
