### PR TITLE
[IN-31][Ember-OSF] Add facebookAppId to preprint-provider model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Move function for `file` model
 - `ember-collapsable-panel` and `ember-power-select` packages
 - Added "choose your custom citation" section to citation-widget
+- `facebookAppId` field to `preprint-provider` model
 
 ### Changed
 - Node `addChild` model function to create public child elements

--- a/addon/models/preprint-provider.js
+++ b/addon/models/preprint-provider.js
@@ -16,6 +16,7 @@ export default OsfModel.extend({
     additionalProviders: DS.attr(),
     shareSource: DS.attr('string'),
     preprintWord: DS.attr('string'),
+    facebookAppId: DS.attr('number'),
 
     // Reviews settings
     permissions: DS.attr(),


### PR DESCRIPTION
## Purpose

`facebook_app_id` was recently added to the `preprint_provider` model in osf.io.  We should add it to the `preprint-provider` model in ember-osf to use it for sharing on branded preprints.

## Summary of Changes

- Added `facebookAppId` field to `preprint-provider` model

## Side Effects / Testing Notes

This shouldn't affect anything other than adding a field to the model.  

## Ticket

https://openscience.atlassian.net/browse/IN-31

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
