### PR TITLE
[IN-103][Ember-OSF] Use currentUserId for ElasticSearch preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added "choose your custom citation" section to citation-widget
 - `facebookAppId` field to `preprint-provider` model
+- Add ElasticSearch preference (ES) key to preprints ES search requests for reproducible results ordering.
 
 ## [0.14.0] - 2018-02-07
 ### Added
@@ -24,7 +25,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Move function for `file` model
 - `ember-collapsable-panel` and `ember-power-select` packages
 - Styling on `project-selector` buttons that are selected
-- Add ElasticSearch preference (ES) key to preprints ES search requests for reproducible results ordering.
 
 ### Changed
 - Node `addChild` model function to create public child elements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Move function for `file` model
 - `ember-collapsable-panel` and `ember-power-select` packages
 - Styling on `project-selector` buttons that are selected
+- Add ElasticSearch preference (ES) key to preprints ES search requests for reproducible results ordering.
 
 ### Changed
 - Node `addChild` model function to create public child elements

--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -365,7 +365,7 @@ export default Ember.Component.extend(Analytics, hostAppName, {
     }),
     searchUrl: Ember.computed(function() {
         // Pulls SHARE search url from config file.
-        const preference = this.get('currentUser.esPreferenceKey');
+        const preference = this.get('currentUser.sessionKey');
         return `${config.OSF.shareSearchUrl}?preference=${preference}`;
     }),
     subjectChanged: Ember.on('init', Ember.observer('subject', function() {

--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -59,6 +59,7 @@ let filterQueryParams = ['subject', 'provider', 'tags', 'sources', 'publishers',
 
 export default Ember.Component.extend(Analytics, hostAppName, {
     layout,
+    currentUser: Ember.inject.service('current-user'),
     theme: Ember.inject.service(),
     i18n: Ember.inject.service(),
     classNames: ['discover-page'],
@@ -364,7 +365,8 @@ export default Ember.Component.extend(Analytics, hostAppName, {
     }),
     searchUrl: Ember.computed(function() {
         // Pulls SHARE search url from config file.
-        return config.OSF.shareSearchUrl;
+        const preference = this.get('currentUser.esPreferenceKey');
+        return `${config.OSF.shareSearchUrl}?preference=${preference}`;
     }),
     subjectChanged: Ember.on('init', Ember.observer('subject', function() {
         // For PREPRINTS - watches subject query param for changes and modifies activeFilters

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -65,17 +65,38 @@ export default Ember.Service.extend({
     }),
 
     /**
-     * Custom string appended as URL param to ElasticSearch requests for reproducible search results ordering.
-     * If user is logged in, use their userID, otherwise return generated string.
+     * Return a simple hash of the currentUser ID if user is logged in, otherwise return a generated random string.
+     * sessionKey can be used to identify the current session or any general purposes.
+     * For Elasticsearch requests, sessionKey is used as the "preference" URL parameter to ensure reproducible search results ordering.
      *
-     * @property esPreferenceKey
+     * @property sessionKey
      * @return {String}
      */
-    esPreferenceKey: Ember.computed('currentUserId', function() {
+    sessionKey: Ember.computed('currentUserId', function() {
         let currentUserId = this.get('currentUserId');
         if (currentUserId) {
-            return encodeURIComponent(`$^${currentUserId}#@`);
+            return this.hashCode(currentUserId).toString();
         }
         return Math.random().toString(36).substr(2,10);
     }),
+
+    /**
+     * Generate a simple hash (numerical code) from a string.
+     * https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript-jquery
+     *
+     * @param  {string}
+     * @return {string}
+     */
+
+    hashCode(str) {
+        let hash = 0, i, chr;
+        if (str.length === 0) return hash;
+        for (i = 0; i < str.length; i++) {
+            chr   = str.charCodeAt(i);
+            hash  = ((hash << 5) - hash) + chr;
+            hash |= 0;
+        }
+        return hash;
+    },
+
 });

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -63,4 +63,16 @@ export default Ember.Service.extend({
             promise: this.load().catch(() => null),
         });
     }),
+
+    /**
+     * @property esPreferenceKey
+     * @return {String}
+     */
+    esPreferenceKey: Ember.computed('currentUserId', function() {
+        let currentUserId = this.get('currentUserId');
+        if (currentUserId) {
+            return encodeURIComponent(`$^${currentUserId}#@`);
+        }
+        return Math.random().toString(36).substr(2,10);
+    }),
 });

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -65,6 +65,9 @@ export default Ember.Service.extend({
     }),
 
     /**
+     * Custom string appended as URL param to ElasticSearch requests for reproducible search results ordering.
+     * If user is logged in, use their userID, otherwise return generated string.
+     *
      * @property esPreferenceKey
      * @return {String}
      */

--- a/addon/services/current-user.js
+++ b/addon/services/current-user.js
@@ -84,8 +84,9 @@ export default Ember.Service.extend({
      * Generate a simple hash (numerical code) from a string.
      * https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript-jquery
      *
-     * @param  {string}
-     * @return {string}
+     * @method hashCode
+     * @param  str {String}
+     * @return {String}
      */
 
     hashCode(str) {

--- a/tests/unit/services/current-user-test.js
+++ b/tests/unit/services/current-user-test.js
@@ -5,16 +5,18 @@ moduleFor('service:current-user', 'Unit | Service | current user', {
   // needs: ['service:foo']
 });
 
-test('currentUser preferenceKey computed property', function(assert) {
+test('currentUser sessionKey computed property', function(assert) {
     let service = this.subject();
     let currentUserId = 'npugv';
 
+    let hash = service.hashCode(currentUserId);
+
     service.set('currentUserId', currentUserId);
-    assert.strictEqual(service.get('esPreferenceKey'),
-        encodeURIComponent(`$^${currentUserId}#@`));
+    assert.ok(service.get('sessionKey'));
+    assert.strictEqual(service.get('sessionKey'), hash.toString());
+    assert.ok(!Number.isNaN(+service.get('sessionKey')));
 
     service.set('currentUserId', null);
-
-    assert.ok(service.get('esPreferenceKey'));
-    assert.strictEqual(service.get('esPreferenceKey').length, 10);
+    assert.ok(service.get('sessionKey'));
+    assert.ok(Number.isNaN(+service.get('sessionKey')));
 });

--- a/tests/unit/services/current-user-test.js
+++ b/tests/unit/services/current-user-test.js
@@ -5,8 +5,16 @@ moduleFor('service:current-user', 'Unit | Service | current user', {
   // needs: ['service:foo']
 });
 
-// Replace this with your real tests.
-test('it exists', function(assert) {
-  let service = this.subject();
-  assert.ok(service);
+test('currentUser preferenceKey computed property', function(assert) {
+    let service = this.subject();
+    let currentUserId = 'npugv';
+
+    service.set('currentUserId', currentUserId);
+    assert.strictEqual(service.get('esPreferenceKey'),
+        encodeURIComponent(`$^${currentUserId}#@`));
+
+    service.set('currentUserId', null);
+
+    assert.ok(service.get('esPreferenceKey'));
+    assert.strictEqual(service.get('esPreferenceKey').length, 10);
 });


### PR DESCRIPTION
## Purpose

Fix current issue where share elasticSearch returns inconsistent
result ordering.

See here for more details
https://www.elastic.co/guide/en/elasticsearch/reference/current/consistent-scoring.html#_scores_are_not_reproducible

## Summary of Changes
See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-preference.html for suggested solution.

Modify searchUrl to use currentUserId as preference custom string in case user
is logged in. Otherwise, use a random string.

## Side Effects / Testing Notes
This ticket affects the preprints discover/search page.
Test this within the developer console, networks tab:
- Clear the network tab
- Upon searching a term, check the elasticSearch requests to see if the preference
URL parameter was added and looks something like this (in chrome console)
i) logged-in user:
`_search?preference=%24%5Eezcos%23%40`, `ezcos` being the current user id.
ii) Not logged-in user:
_search?preference="some random string"

- In each case, try the same search several times (hitting enter in search bar) in a row and make sure the same preference string is sent.

While the goal is to get the same ordering of search results for the same search query, it might be very hard to compare before and after so we can just leave it up to elasticSearch to do what its thing.

## Ticket

[IN-103](https://openscience.atlassian.net/browse/IN-103)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
