### PR TITLE
[IN-71][Ember-OSF] Add authentication to citation request

### DIFF
--- a/addon/components/citation-widget/component.js
+++ b/addon/components/citation-widget/component.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
-import layout from './template';
+
 import { task, timeout } from 'ember-concurrency';
 import config from 'ember-get-config';
+
+import { authenticatedAJAX } from 'ember-osf/utils/ajax-helpers';
+import layout from './template';
 
 /**
  * @module ember-osf
@@ -90,9 +93,9 @@ export default Ember.Component.extend({
 
     findStyles: task(function* (term) {
         yield timeout(500);
-        const response = yield Ember.$.ajax({
+        const response = yield authenticatedAJAX({
             method: 'GET',
-            url: `${config.OSF.apiUrl}/${config.OSF.apiNamespace}/citations/styles/?filter[title,short_title]=${term}&page[size]=100` ,
+            url: `${config.OSF.apiUrl}/${config.OSF.apiNamespace}/citations/styles/?filter[title,short_title]=${term}&page[size]=100`,
             dataType: 'json',
             contentType: 'application/json'
         });


### PR DESCRIPTION
## Purpose
Allow contributors to generate different citations before their preprint is public.


## Summary of Changes
* Add authentication to the citation request.
* Ordered imports like "standard library imports, third party imports, local application imports"


## Side Effects / Testing Notes
Should not change the behavior for logged out users.
Authors should be able to generate different citations before their preprint is public.


## Ticket

https://openscience.atlassian.net/browse/IN-71

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
