### PR TITLE
[IN-71][Ember-OSF] private project

### DIFF
--- a/addon/components/citation-widget/component.js
+++ b/addon/components/citation-widget/component.js
@@ -87,13 +87,13 @@ export default Ember.Component.extend({
 
     _selectStyle: task(function* (id) {
         const citationLink = this.get('citationLink');
-        const response = yield Ember.$.ajax(`${citationLink}${id}/`);
+        const response = yield authenticatedAJAX({ url: `${citationLink}${id}/` });
         this.set('citationText', response.data.attributes.citation);
     }).restartable(),
 
     findStyles: task(function* (term) {
         yield timeout(500);
-        const response = yield authenticatedAJAX({
+        const response = yield Ember.$.ajax({
             method: 'GET',
             url: `${config.OSF.apiUrl}/${config.OSF.apiNamespace}/citations/styles/?filter[title,short_title]=${term}&page[size]=100`,
             dataType: 'json',


### PR DESCRIPTION
## Purpose
Selecting a citation for a preprint shouldn't 401.


## Summary of Changes
* Add authentication to the select citation request
* Remove authentication from the search request since it doesn't need authentication


## Side Effects / Testing Notes
Selecting a citation for a preprint shouldn't 401 -- specifically a pending pre-moderation preprint where the related project is private.

## Ticket

https://openscience.atlassian.net/browse/IN-71

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
