### PR TITLE
[IN-137][Ember-OSF] Use version 2.6 of osf API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 - Ability to create new components when moving files.
 
+### Changed
+- Bump OSF API version from 2.4 to 2.6
+
 ## [0.14.0] - 2018-02-07
 ### Added
 - `osf-model.queryHasMany`, for reliable querying of hasMany relations

--- a/addon/adapters/osf-adapter.js
+++ b/addon/adapters/osf-adapter.js
@@ -22,7 +22,7 @@ import {
  */
 export default DS.JSONAPIAdapter.extend(GenericDataAdapterMixin, {
     headers: {
-        ACCEPT: 'application/vnd.api+json; version=2.4'
+        ACCEPT: 'application/vnd.api+json; version=2.6'
     },
     authorizer: config['ember-simple-auth'].authorizer,
     host: config.OSF.apiUrl,


### PR DESCRIPTION
## Purpose

Bump osf API version from `2.4` to `2.6`

OSF API version `2.5` deprecated `subjects_acceptable` field on the preprint_provider endpoint.
OSF API version `2.6` deprecated the `/v2/taxonomies/`.

## Summary of Changes

Update the osf adapter to use version 2.6 of the api.

## Side Effects / Testing Notes


## Ticket

https://openscience.atlassian.net/browse/IN-137

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
