### PR TITLE
[IN-6][Ember-OSF] Add model for moderator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bump OSF API version from 2.4 to 2.6
 - ember-cli-moment-shim version to `^3.5.3` due to security issues found in `moment` versions before `2.19.3`
 
+### Added
+- Add moderator model, serializer, and adapter
+
+### Removed
+- Ability to create new components when moving files.
+
 ## [0.15.0] - 2018-03-06
 ### Added
 - Added "choose your custom citation" section to citation-widget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add moderator model, serializer, and adapter
 
-### Removed
-- Ability to create new components when moving files.
-
 ## [0.15.0] - 2018-03-06
 ### Added
 - Added "choose your custom citation" section to citation-widget

--- a/addon/adapters/moderator.js
+++ b/addon/adapters/moderator.js
@@ -12,15 +12,15 @@ export default OsfAdapter.extend({
         } else if (requestType === 'createRecord' && snapshot.record.provider) {
             provider = snapshot.record.provider;
             delete snapshot.record.provider;
-            return this._buildURL(modelName) + `/${provider}/moderators/`;
+            return `${this._buildURL(modelName)}/${provider}/moderators/`;
         } else if (snapshot.adapterOptions && snapshot.adapterOptions.provider) {
             provider = snapshot.adapterOptions.provider;
             delete snapshot.adapterOptions.provider;
             if (requestType === 'updateRecord' || requestType === 'deleteRecord' || requestType === 'findRecord') {
-                return this._buildURL(modelName) + `/${provider}/moderators/${id}/`;
+                return `${this._buildURL(modelName)}/${provider}/moderators/${id}/`;
             }
         }
 
-        return this._super(...arguments) + `${provider}/moderators/`;
+        return `${this._super(...arguments)}${provider}/moderators/`;
     }
 });

--- a/addon/adapters/moderator.js
+++ b/addon/adapters/moderator.js
@@ -1,0 +1,25 @@
+import OsfAdapter from './osf-adapter';
+
+export default OsfAdapter.extend({
+    pathForType() {
+        return 'preprint_providers';
+    },
+    buildURL(modelName, id, snapshot, requestType, query) {
+        let provider = '';
+        if (query) {
+            provider = query.provider;
+            delete query.provider;
+        } else if (requestType === 'createRecord' && snapshot.record.provider) {
+            provider = snapshot.record.provider;
+            delete snapshot.record.provider;
+            return this._buildURL(modelName) + `/${provider}/moderators/`;
+        } else if (snapshot.adapterOptions && snapshot.adapterOptions.provider) {
+            provider = snapshot.adapterOptions.provider;
+            if (requestType === 'updateRecord' || requestType === 'deleteRecord' || requestType === 'findRecord') {
+                return this._buildURL(modelName) + `/${provider}/moderators/${id}/`;
+            }
+        }
+
+        return this._super(...arguments) + `${provider}/moderators/`;
+    }
+});

--- a/addon/adapters/moderator.js
+++ b/addon/adapters/moderator.js
@@ -15,6 +15,7 @@ export default OsfAdapter.extend({
             return this._buildURL(modelName) + `/${provider}/moderators/`;
         } else if (snapshot.adapterOptions && snapshot.adapterOptions.provider) {
             provider = snapshot.adapterOptions.provider;
+            delete snapshot.adapterOptions.provider;
             if (requestType === 'updateRecord' || requestType === 'deleteRecord' || requestType === 'findRecord') {
                 return this._buildURL(modelName) + `/${provider}/moderators/${id}/`;
             }

--- a/addon/models/moderator.js
+++ b/addon/models/moderator.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+import OsfModel from './osf-model';
+
+export default OsfModel.extend({
+    permissionGroup: DS.attr('string'),
+    fullName: DS.attr('string'),
+});

--- a/addon/models/moderator.js
+++ b/addon/models/moderator.js
@@ -4,4 +4,5 @@ import OsfModel from './osf-model';
 export default OsfModel.extend({
     permissionGroup: DS.attr('string'),
     fullName: DS.attr('string'),
+    email: DS.attr('string'),
 });

--- a/addon/serializers/moderator.js
+++ b/addon/serializers/moderator.js
@@ -1,0 +1,4 @@
+import OsfSerializer from './osf-serializer';
+
+export default OsfSerializer.extend({
+});

--- a/app/adapters/moderator.js
+++ b/app/adapters/moderator.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/adapters/moderator';

--- a/app/models/moderator.js
+++ b/app/models/moderator.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/models/moderator';

--- a/app/serializers/moderator.js
+++ b/app/serializers/moderator.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/serializers/moderator';

--- a/test-support/factories/moderator.js
+++ b/test-support/factories/moderator.js
@@ -1,0 +1,9 @@
+import FactoryGuy from 'ember-data-factory-guy';
+import faker from 'faker';
+
+FactoryGuy.define('moderator', {
+    default: {
+        fullName: () => faker.name.findName(),
+        permissionGroup: () => 'admin',
+    },
+});

--- a/tests/unit/adapters/moderator-test.js
+++ b/tests/unit/adapters/moderator-test.js
@@ -1,0 +1,113 @@
+import {moduleFor} from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+import FactoryGuy, {manualSetup} from 'ember-data-factory-guy';
+
+
+moduleFor('adapter:moderator', 'Unit | Adapter | moderator', {
+    needs: [
+        'model:moderator',
+        'adapter:moderator',
+        'serializer:moderator',
+        'service:session',
+    ],
+    beforeEach() {
+        manualSetup(this.container);
+    }
+});
+
+test('#buildURL appends a trailing slash if missing', function (assert) {
+    const url = 'http://localhost:8000/v2/preprint_providers/osf/moderators';
+    const adapter = this.subject();
+    const moderator = FactoryGuy.make('moderator');
+    const result = adapter.buildURL(
+        'moderator',
+        null,
+        moderator._internalModel.createSnapshot(),
+        'query',
+        { provider: 'osf' }
+    );
+    assert.notEqual(result, url);
+    assert.equal(result.slice(-1), '/');
+});
+
+test('#buildURL query', function (assert) {
+    const url = 'http://localhost:8000/v2/preprint_providers/osf/moderators/';
+    const adapter = this.subject();
+    const moderator = FactoryGuy.make('moderator');
+    const result = adapter.buildURL(
+        'moderator',
+        null,
+        moderator._internalModel.createSnapshot(),
+        'query',
+        { provider: 'osf' }
+    );
+    assert.equal(result, url);
+});
+
+test('#buildURL createRecord', function (assert) {
+    const url = 'http://localhost:8000/v2/preprint_providers/osf/moderators/';
+    const adapter = this.subject();
+    const moderator = FactoryGuy.make('moderator');
+
+    let snapshot = moderator._internalModel.createSnapshot();
+    snapshot.record.provider = 'osf';
+
+    const result = adapter.buildURL(
+        'moderator',
+        null,
+        snapshot,
+        'createRecord'
+    );
+    assert.equal(result, url);
+});
+
+test('#buildURL findRecord', function (assert) {
+    const url = 'http://localhost:8000/v2/preprint_providers/osf/moderators/12345/';
+    const adapter = this.subject();
+    const moderator = FactoryGuy.make('moderator');
+
+    let snapshot = moderator._internalModel.createSnapshot();
+    snapshot.adapterOptions = { provider: 'osf' };
+
+    const result = adapter.buildURL(
+        'moderator',
+        '12345',
+        snapshot,
+        'findRecord'
+    );
+    assert.equal(result, url);
+});
+
+test('#buildURL updateRecord', function (assert) {
+    const url = 'http://localhost:8000/v2/preprint_providers/osf/moderators/12345/';
+    const adapter = this.subject();
+    const moderator = FactoryGuy.make('moderator');
+
+    let snapshot = moderator._internalModel.createSnapshot();
+    snapshot.adapterOptions = { provider: 'osf' };
+
+    const result = adapter.buildURL(
+        'moderator',
+        '12345',
+        snapshot,
+        'updateRecord'
+    );
+    assert.equal(result, url);
+});
+
+test('#buildURL deleteRecord', function (assert) {
+    const url = 'http://localhost:8000/v2/preprint_providers/osf/moderators/12345/';
+    const adapter = this.subject();
+    const moderator = FactoryGuy.make('moderator');
+
+    let snapshot = moderator._internalModel.createSnapshot();
+    snapshot.adapterOptions = { provider: 'osf' };
+
+    const result = adapter.buildURL(
+        'moderator',
+        '12345',
+        snapshot,
+        'deleteRecord'
+    );
+    assert.equal(result, url);
+});


### PR DESCRIPTION
## Purpose
Allow preprint providers to add and remove moderators using the moderation app.


## Summary of Changes
* Add moderator model, serializer, and adapter.


## Side Effects / Testing Notes
Should be covered by testing the Reviews side.


## Ticket

https://openscience.atlassian.net/browse/IN-6

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
