### PR TITLE
[WIP][IN-170] Allow toggling hypothesis

### DIFF
--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -14,7 +14,8 @@ import config from 'ember-get-config';
  * ```handlebars
  * {{file-renderer
  *   download=model.links.download
- *     width="800" height="1000" allowfullscreen=true}}
+ *.  allowCommenting=provider.allowCommenting
+ *   width="800" height="1000" allowfullscreen=true}}
  * ```
  * @class file-renderer
  */
@@ -31,5 +32,15 @@ export default Ember.Component.extend({
             download += '&version=' + this.get('version');
         }
         return config.OSF.renderUrl + '?url=' + encodeURIComponent(download);
-    })
+    }),
+
+    didRender() {
+        this._super(...arguments);
+
+        if (this.get('allowCommenting')) {
+            Ember.$('iframe').on('load', function() {
+                Ember.$('iframe')[0].contentWindow.postMessage('startHypothesis', config.OSF.mfrUrl);
+            });
+        }
+    },
 });

--- a/addon/models/preprint-provider.js
+++ b/addon/models/preprint-provider.js
@@ -13,6 +13,7 @@ export default OsfModel.extend({
     subjectsAcceptable: DS.attr(),
     footerLinks: DS.attr('string'),
     allowSubmissions: DS.attr('boolean'),
+    allowCommenting: DS.attr('boolean'),
     additionalProviders: DS.attr(),
     shareSource: DS.attr('string'),
     preprintWord: DS.attr('string'),

--- a/config/backends.json
+++ b/config/backends.json
@@ -2,6 +2,7 @@
     "local": {
         "url": "http://localhost:5000/",
         "apiUrl": "http://localhost:8000",
+        "mfrUrl": "http://localhost:7778/",
         "renderUrl": "http://localhost:7778/render",
         "waterbutlerUrl": "http://localhost:7777/",
         "helpUrl": "http://localhost:4200/help",
@@ -14,6 +15,7 @@
     "stage": {
         "url": "https://staging.osf.io/",
         "apiUrl": "https://staging-api.osf.io",
+        "mfrUrl": "https://staging-mfr.osf.io/",
         "renderUrl": "https://staging-mfr.osf.io/render",
         "waterbutlerUrl": "https://staging-files.osf.io/",
         "helpUrl": "http://help.osf.io",
@@ -26,6 +28,7 @@
     "stage2": {
         "url": "https://staging2.osf.io/",
         "apiUrl": "https://staging2-api.osf.io",
+        "mfrUrl": "https://staging2-mfr.osf.io/",
         "renderUrl": "https://staging2-mfr.osf.io/render",
         "waterbutlerUrl": "https://staging2-files.osf.io/",
         "helpUrl": "http://help.osf.io",
@@ -38,6 +41,7 @@
     "stage3": {
         "url": "https://staging3.osf.io/",
         "apiUrl": "https://staging3-api.osf.io",
+        "mfrUrl": "https://staging3-mfr.osf.io/",
         "renderUrl": "https://staging3-mfr.osf.io/render",
         "waterbutlerUrl": "https://staging3-files.osf.io/",
         "helpUrl": "http://help.osf.io",
@@ -50,6 +54,7 @@
     "prod": {
         "url": "https://osf.io/",
         "apiUrl": "https://api.osf.io",
+        "mfrUrl": "https://mfr.osf.io/",
         "renderUrl": "https://mfr.osf.io/render",
         "waterbutlerUrl": "https://files.osf.io/",
         "helpUrl": "http://help.osf.io",
@@ -62,6 +67,7 @@
     "test": {
         "url": "https://test.osf.io/",
         "apiUrl": "https://test-api.osf.io",
+        "mfrUrl": "https://test-mfr.osf.io/",
         "renderUrl": "https://test-mfr.osf.io/render",
         "waterbutlerUrl": "https://test-files.osf.io/",
         "helpUrl": "http://help.osf.io",
@@ -74,6 +80,7 @@
     "env": {
         "url": "OSF_URL",
         "apiUrl": "OSF_API_URL",
+        "mfrUrl": "OSF_MFR_URL",
         "renderUrl": "OSF_RENDER_URL",
         "waterbutlerUrl": "OSF_FILE_URL",
         "helpUrl": "OSF_HELP_URL",


### PR DESCRIPTION
## Purpose
Allow toggling hypothesis based on preprint provider setting.

## Summary of Changes
* Start hypothesis in file renderer if allowCommenting is true for the current preprint provider
* Add allowCommenting to preprint provider model

## Side Effects / Testing Notes
Will be tested via https://github.com/CenterForOpenScience/ember-osf-preprints/pull/559


## Ticket

https://openscience.atlassian.net/browse/IN-170

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
