### PR TITLE
[IN-234][Ember-OSF] Updated fix for long names in navbar

### DIFF
--- a/addon/components/new-navbar-auth-dropdown/component.js
+++ b/addon/components/new-navbar-auth-dropdown/component.js
@@ -23,12 +23,10 @@ import AnalyticsMixin from 'ember-osf/mixins/analytics';
  */
 export default Ember.Component.extend(AnalyticsMixin, {
     layout,
+    tagName: '',
     session: Ember.inject.service(),
     currentUser: Ember.inject.service(),
     i18n: Ember.inject.service(),
-    tagName: 'li',
-    classNames: ['dropdown', 'secondary-nav-dropdown'],
-    classNameBindings: ['notAuthenticated:sign-in'],
     notAuthenticated: Ember.computed.not('session.isAuthenticated'),
     redirectUrl: null,
 

--- a/addon/components/new-navbar-auth-dropdown/template.hbs
+++ b/addon/components/new-navbar-auth-dropdown/template.hbs
@@ -1,7 +1,7 @@
 {{# if session.isAuthenticated }}
     {{! TODO: Replace display name functionality if possible- for now truncate via CSS at end of label }}
-    {{#bs-dropdown as |dd|}}
-        {{#dd.toggle tagName="button" classNames="nav-user-dropdown btn-link"}}
+    {{#bs-dropdown tagName='li' classNames="secondary-nav-dropdown" as |dd|}}
+        {{#dd.toggle tagName="a" classNames="btn-link"}}
             <div class="osf-profile-image">
                 <img src="{{gravatarUrl}}" alt="User gravatar">
             </div> 
@@ -34,17 +34,19 @@
         {{/dd.menu}}
     {{/bs-dropdown}}
 {{else if allowLogin}}
-    {{#if institution}}
-        {{! TODO: How does the page know whether this is an institution view? Implement in the future }}
-        <div class="btn-group">
-            <a href="${domain}login/?campaign=institution&redirect_url=${redirect_url}" class="btn btn-info btn-top-login">
-                {{t 'eosf.authDropdown.signIn'}} <span class="hidden-xs"><i class="fa fa-arrow-right"></i></span>
-            </a>
-        </div>
-    {{else}}
-        <div>
-            <a href="{{signupUrl}}" class="btn btn-success btn-top-signup m-l-sm m-r-xs" onclick={{action 'click' 'link' 'Navbar - SignUp'}}>{{t 'eosf.authDropdown.signUp'}}</a>
-            <a {{action loginAction}} onclick={{action 'click' 'link' 'Navbar - SignIn'}} class="btn btn-info btn-top-login m-r-xs" role="button">{{t 'eosf.authDropdown.signIn'}}</a>
-        </div>
-    {{/if}}
+    <li class="dropdown sign-in">
+        {{#if institution}}
+            {{! TODO: How does the page know whether this is an institution view? Implement in the future }}
+            <div class="btn-group">
+                <a href="${domain}login/?campaign=institution&redirect_url=${redirect_url}" class="btn btn-info btn-top-login">
+                    {{t 'eosf.authDropdown.signIn'}} <span class="hidden-xs"><i class="fa fa-arrow-right"></i></span>
+                </a>
+            </div>
+        {{else}}
+            <div>
+                <a href="{{signupUrl}}" class="btn btn-success btn-top-signup m-l-sm m-r-xs" onclick={{action 'click' 'link' 'Navbar - SignUp'}}>{{t 'eosf.authDropdown.signUp'}}</a>
+                <a {{action loginAction}} onclick={{action 'click' 'link' 'Navbar - SignIn'}} class="btn btn-info btn-top-login m-r-xs" role="button">{{t 'eosf.authDropdown.signIn'}}</a>
+            </div>
+        {{/if}}
+    </li>
 {{/if}}


### PR DESCRIPTION
## Purpose

Long names in the navbar are still not flexing properly.  This PR should fix that.

## Summary of Changes

- Removed wrapper from component
- Added `li` tagName to the dropdown being generated with all of the necessary classes
- Changed button to `a` tag
- Added `<li>` to sign-in/sign-up button section (needed since the component no longer has an `li` wrapper)

## Side Effects / Testing Notes

This should fix the issues with flexing on reviews/registries.  When there's a name longer than the space given it should break off with `...` ellipses at the end.  It shouldn't run off the page or break onto a new line.

This should also fix the issue of positioning in the navbar.  Before, the name would float just a bit higher than the rest of the navbar text.  This should keep the text inline with everything else.

## Ticket

https://openscience.atlassian.net/browse/IN-234

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(changes already in CHANGELOG.md from previous PR)

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
