### PR TITLE
[IN-90][EmberOSF] Clear types filter on registries provider change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 # [Unreleased]
+### Added
+- `activeFilters.types` reset when registration provider changes
 
 ## [0.16.0] - 2018-04-24
 ### Added

--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -745,6 +745,7 @@ export default Ember.Component.extend(Analytics, hostAppName, {
                     this.set('type', this.get('activeFilters.types').join('OR'));
                 } else {
                     this.set('type', '');
+                    this.set('activeFilters.types', []);
                 }
             }
         },


### PR DESCRIPTION
## Purpose

As part of the fix to remove observers from ember@2.18 registries.  

The `activeFilters.type` property should be reset from the ember-osf app to resolve glimmer errors showing up on registries.

## Summary of Changes

- Reset `activeFilters.types` when the provider is changed to something other than `OSF`

## Side Effects / Testing Notes

This will work with the Registries PR (https://github.com/CenterForOpenScience/ember-osf-registries/pull/58).  It should help to make the type facets on Registries work like expected again.

## Ticket

https://openscience.atlassian.net/browse/IN-90

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
