### PR TITLE
[EOSF] Fix sign-up button size

### DIFF
--- a/addon/components/new-navbar-auth-dropdown/template.hbs
+++ b/addon/components/new-navbar-auth-dropdown/template.hbs
@@ -44,7 +44,7 @@
             </div>
         {{else}}
             <div>
-                <a href="{{signupUrl}}" class="btn btn-success btn-top-signup m-l-sm m-r-xs" onclick={{action 'click' 'link' 'Navbar - SignUp'}}>{{t 'eosf.authDropdown.signUp'}}</a>
+                <a href="{{signupUrl}}" class="btn btn-success btn-top-signup m-l-sm m-r-xs" style="line-height:1.7" onclick={{action 'click' 'link' 'Navbar - SignUp'}}>{{t 'eosf.authDropdown.signUp'}}</a>
                 <a {{action loginAction}} onclick={{action 'click' 'link' 'Navbar - SignIn'}} class="btn btn-info btn-top-login m-r-xs" role="button">{{t 'eosf.authDropdown.signIn'}}</a>
             </div>
         {{/if}}


### PR DESCRIPTION
## Purpose

The sign-up and sign-in buttons are different sizes in the navbar.  They should both be the same.

## Summary of Changes

- Added an inline `line-height` property to the sign-up button to make it the same size as the sign-in button.  This is a temporary fix and will need to be removed when ember-osf and osf are updated to use the newest osf-style.

## Side Effects / Testing Notes

There shouldn't be any side-effects.  The button should now be the same size as the other button on the navbar.

Before:
![screen shot 2018-04-30 at 2 07 02 pm](https://user-images.githubusercontent.com/19379783/39442756-4aec649e-4c80-11e8-9800-d858a6107ecf.png)


After:
![screen shot 2018-04-30 at 2 07 13 pm](https://user-images.githubusercontent.com/19379783/39442762-512cee5a-4c80-11e8-9b8e-6cba55fdcedb.png)


## Ticket

None

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(small change that will be removed later)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
