### PR TITLE
[EMB-259] Waffling + Institutions nav

### DIFF
--- a/addon/components/new-osf-navbar/component.js
+++ b/addon/components/new-osf-navbar/component.js
@@ -25,11 +25,15 @@ import AnalyticsMixin from 'ember-osf/mixins/analytics';
  */
 export default Ember.Component.extend(hostAppName, AnalyticsMixin, {
     layout,
-    osfServices,
     session: Ember.inject.service(),
     i18n: Ember.inject.service(),
+    features: Ember.inject.service(),
     serviceLinks: serviceLinks,
     host: config.OSF.url,
+
+    osfAppNames: Ember.computed(`features.${Ember.String.camelize(config.OSF.institutionsLandingFlag)}`, function() {
+        return osfServices.filter(each => !each.flag || this.get('features').isEnabled(each.flag));
+    }),
     currentService: Ember.computed('hostAppName', function() { // Pulls current service name from consuming service's config file
         let appName = this.get('hostAppName') || 'Home';
         if (appName === 'Dummy App') {

--- a/addon/components/new-osf-navbar/template.hbs
+++ b/addon/components/new-osf-navbar/template.hbs
@@ -21,7 +21,7 @@
                         <span class="fa fa-caret-down fa-2x"></span>
                     </button>
                     <ul class="dropdown-menu service-dropdown" role="menu">
-                        {{#each osfServices as |service|}}
+                        {{#each osfAppNames as |service|}}
                             <li><a href="{{service.url}}" onclick={{action 'click' 'link' (concat 'Navbar - ' service.name)}}>{{t 'eosf.navbar.osf'}}<b>{{service.name}}</b></a></li>
                         {{/each}}
                     </ul>

--- a/addon/const/service-links.js
+++ b/addon/const/service-links.js
@@ -35,6 +35,7 @@ const serviceLinks = {
     search: `${osfUrl}search/`,
     settings: `${osfUrl}settings/`,
     reviewsHome: `${osfUrl}reviews/`,
+    institutionsLanding: `${osfUrl}institutions/`,
 };
 
 
@@ -65,6 +66,11 @@ const osfServices = [
     {
         name: 'MEETINGS',
         url: serviceLinks.meetingsHome
+    },
+    {
+        name: 'INSTITUTIONS',
+        url: serviceLinks.institutionsLanding,
+        flag: config.OSF.institutionsLandingFlag,
     }
 ];
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ module.exports = {
             scope: eitherConfig('OAUTH_SCOPES'),
             apiNamespace: 'v2', // URL suffix (after host)
             backend: BACKEND,
-            redirectUri: eitherConfig('REDIRECT_URI')
+            redirectUri: eitherConfig('REDIRECT_URI'),
+            institutionsLandingFlag: 'institutions_nav_bar',
         };
 
         // Fetch configuration information for the application

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
     "ember-cli-htmlbars": "2.0.1",
     "ember-cli-htmlbars-inline-precompile": "0.4.3",
     "ember-cli-shims": "1.0.2",
+    "ember-concurrency": "^0.8.12",
+    "ember-feature-flags": "^5.0.0",
     "ember-collapsible-panel": "^2.1.1",
     "ember-concurrency": "^0.8.12",
     "ember-cp-validations": "^3.5.0",

--- a/tests/unit/services/current-user-test.js
+++ b/tests/unit/services/current-user-test.js
@@ -1,22 +1,35 @@
-import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+import { moduleFor } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+import { task } from 'ember-concurrency';
+import CurrentUser from 'ember-osf/services/current-user';
+
+const currentUserStub = CurrentUser.extend({
+    setWaffle: task(function* () {
+        // do_nothing
+    }),
+})
 
 moduleFor('service:current-user', 'Unit | Service | current user', {
-  // Specify the other units that are required for this test.
-  //   needs: ['service:session']
+    needs: ['service:session', 'service:features'],
+    beforeEach() {
+        this.register('service:current-user', currentUserStub);
+    }
 });
 
 test('currentUser sessionKey computed property', function(assert) {
-    let service = this.subject();
-    let currentUserId = 'npugv';
+    Ember.run(() => {
+        let service = this.subject();
+        let currentUserId = 'npugv';
 
-    let hash = service.hashCode(currentUserId);
+        let hash = service.hashCode(currentUserId);
+        service.set('currentUserId', currentUserId);
+        assert.ok(service.get('sessionKey'));
+        assert.strictEqual(service.get('sessionKey'), hash.toString());
+        assert.ok(!Number.isNaN(+service.get('sessionKey')));
 
-    service.set('currentUserId', currentUserId);
-    assert.ok(service.get('sessionKey'));
-    assert.strictEqual(service.get('sessionKey'), hash.toString());
-    assert.ok(!Number.isNaN(+service.get('sessionKey')));
-
-    service.set('currentUserId', null);
-    assert.ok(service.get('sessionKey'));
-    assert.ok(Number.isNaN(+service.get('sessionKey')));
+        service.set('currentUserId', null);
+        assert.ok(service.get('sessionKey'));
+        assert.ok(Number.isNaN(+service.get('sessionKey')));
+    });
 });

--- a/tests/unit/services/file-manager-test.js
+++ b/tests/unit/services/file-manager-test.js
@@ -90,7 +90,8 @@ moduleFor('service:file-manager', 'Unit | Service | file manager', {
     unit: true,
     needs: [
         'model:file', 'model:file-version', 'model:comment', 'model:node',
-        'transform:links', 'transform:embed', 'transform:fixstring', 'model:user'
+        'transform:links', 'transform:embed', 'transform:fixstring', 'model:user',
+        'service:features',
     ],
     beforeEach() {
         this.register('service:session', sessionStub);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3689,6 +3689,12 @@ ember-faker@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ember-faker/-/ember-faker-1.1.1.tgz#90ca83edef385d8f43bed3ceaed263b59f68773c"
 
+ember-feature-flags@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ember-feature-flags/-/ember-feature-flags-5.0.0.tgz#630d2876f5341b456db89996f35c0b109a0e27ec"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+
 "ember-fetch@^2.1.0 || ^3.0.0":
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-3.4.4.tgz#926ffa1c4120324b298c44e9558b458e586eb504"


### PR DESCRIPTION
## Purpose
Allow the use of waffle in ember-osf apps, and update the navbar to have a link to the institutions landing page when that flag is turned on.


## Summary of Changes
- Add ember-feature-flags
- Use ember-feature-flags and the current-user service to grab and use waffle flags/switches.


## Ticket
https://openscience.atlassian.net/browse/EMB-259

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
