### PR TITLE
[IN-235][Ember-OSF] Fix styling and format of branded navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Format last edited date in search result like "MMM DDD, YYYY UTC" instead of "YYYY-MM-DD (UTC)"
+- `navbar-auth-dropdown` to match current changes to the navbar
 
 ## [0.16.2] - 2018-05-01
 ### Added

--- a/addon/components/navbar-auth-dropdown/component.js
+++ b/addon/components/navbar-auth-dropdown/component.js
@@ -26,7 +26,7 @@ export default Ember.Component.extend({
     currentUser: Ember.inject.service(),
 
     tagName: 'li',
-    classNames: ['dropdown'],
+    classNames: ['dropdown', 'secondary-nav-dropdown'],
     classNameBindings: ['notAuthenticated:sign-in'],
     notAuthenticated: Ember.computed.not('session.isAuthenticated'),
     redirectUrl: null,

--- a/addon/components/navbar-auth-dropdown/style.scss
+++ b/addon/components/navbar-auth-dropdown/style.scss
@@ -1,5 +1,4 @@
-.osf-gravatar > img {
-    border: 1px solid #CDCDCD;
-    border-radius: 13px;
-    margin-right: 5px;
+.btn-link:hover,
+.btn-link:focus {
+    color: inherit;
 }

--- a/addon/components/navbar-auth-dropdown/template.hbs
+++ b/addon/components/navbar-auth-dropdown/template.hbs
@@ -1,10 +1,13 @@
 {{# if session.isAuthenticated }}
     {{! TODO: Replace display name functionality if possible- for now truncate via CSS at end of label }}
-    <a href="#" class="dropdown-toggle nav-user-dropdown" data-toggle="dropdown" role="button" aria-expanded="false">
-        <span class="osf-gravatar">
+    <a href="#" class="dropdown-toggle btn-link" data-toggle="dropdown" role="button" aria-expanded="false">
+        <div class="osf-profile-image">
             <img src="{{gravatarUrl}}" alt={{t 'eosf.authDropdown.altUserGravatar'}}>
-        </span> {{user.fullName}}
-        <span class="caret"></span>
+        </div> 
+        <div class="nav-profile-name">
+            {{user.fullName}}
+        </div>
+        <div class="caret"></div>
     </a>
     <ul class="dropdown-menu" role="menu">
         {{#if headline}}


### PR DESCRIPTION
## Purpose

The branded navbar's styling doesn't match what is seen in ember-osf and osf.io

## Summary of Changes

- Add some styling to `btn-link` to remove color changes that shouldn't be seen on branded domains
- Change classes and id's in branded navbar to match what's needed in osf-style
- Add 'secondary-nav-dropdown' class to `navbar-auth-dropdown`

## Side Effects / Testing Notes

This should make the branded navbar act the same way as the navbar on ember-osf apps and osf.io.  
- It should cut off long user names and prevent breaking to a new line
- It should also keep cutting the name as the screen gets smaller
- Because this is branded, it should also keep using the old styles that are provider specific


** Note**
This should be used with the change to ember-osf-preprints: 
https://github.com/CenterForOpenScience/ember-osf-preprints/pull/567
![navbar](https://user-images.githubusercontent.com/19379783/40247371-281d868c-5a9a-11e8-9a70-a29f2be1d43f.gif)


## Ticket

https://openscience.atlassian.net/browse/IN-235

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
