### PR TITLE
[IN-311][EmberOSF] Remove period from end of translation string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Format last edited date in search result like "MMM DDD, YYYY UTC" instead of "YYYY-MM-DD (UTC)"
 - `navbar-auth-dropdown` to match current changes to the navbar
 
+### Fixed
+- Missing banner translation error
+
 ## [0.16.2] - 2018-05-01
 ### Added
 - temporary inline style to sign-up button

--- a/addon/components/maintenance-banner/template.hbs
+++ b/addon/components/maintenance-banner/template.hbs
@@ -6,7 +6,7 @@
     {{#if maintenance.message}}
         {{maintenance.message}}
     {{else}}
-        {{t 'eosf.components.maintenanceBanner.willUndergoMaintenance.'}}
+        {{t 'eosf.components.maintenanceBanner.willUndergoMaintenance'}}
         <strong>
             <time>{{moment-format maintenance.start 'lll'}}</time>
             {{t 'eosf.components.maintenanceBanner.and'}}


### PR DESCRIPTION
## Purpose
Fix missing translation in banner on Reviews and Registries.
<img width="1429" alt="screen shot 2018-05-22 at 1 21 06 pm" src="https://user-images.githubusercontent.com/7131985/40379629-a418b464-5dc4-11e8-8d02-f8f1d481643b.png">

## Summary of Changes
* Remove period from end of translation string

## Side Effects / Testing Notes
Must have maintenance banner up to test.

## Ticket
Will be created shortly
https://openscience.atlassian.net/browse/IN-311

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
