### PR TITLE
[IN-159][EmberOSF] Center banner img; add max height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - `metaschema` model into `registration-metaschema`
+- `scheduled-banner` component to display the banner image centered and adapt to different image heights.
 
 ## [0.17.0] - 2018-05-29
 ### Added

--- a/addon/components/scheduled-banner/component.js
+++ b/addon/components/scheduled-banner/component.js
@@ -46,18 +46,6 @@ export default Ember.Component.extend(Analytics, {
         return { 'background-color': `${bgColor}` };
     }),
 
-    defaultStyle: computedStyle('bgProperty'),
-    bgProperty: Ember.computed('defaultPhoto', function() {
-        const defaultPhotoUrl = this.get('defaultPhoto');
-        return { 'background': `url(${defaultPhotoUrl}) no-repeat center top` };
-    }),
-
-    mobileStyle: computedStyle('mobileBgProperty'),
-    mobileBgProperty: Ember.computed('mobilePhoto', function() {
-        const mobilePhotoUrl = this.get('mobilePhoto');
-        return { 'background': `url(${mobilePhotoUrl}) no-repeat center top`};
-    }),
-
     init() {
         this._super(...arguments);
 

--- a/addon/components/scheduled-banner/style.scss
+++ b/addon/components/scheduled-banner/style.scss
@@ -1,17 +1,4 @@
-.banner {
-    width: 100%;
-}
-
-.banner-lg {
-    background-size: contain;
-    width: 100%;
-    height: 0;
-    padding-top: 12.5%;
-}
-
-.banner-sm {
-    background-size: contain;
-    width: 100%;
-    height: 0;
-    padding-top: 22.5%;
+.banner-img {
+    max-height: 300px;
+    margin: auto;
 }

--- a/addon/components/scheduled-banner/template.hbs
+++ b/addon/components/scheduled-banner/template.hbs
@@ -5,10 +5,10 @@
             <div class="col-md-10 col-md-offset-1 col-lg-8 col-lg-offset-2">
                 <div class="row">
                     <div class="col-sm-md-lg-12 hidden-xs">
-                        <div class="banner-lg" style={{defaultStyle}} alt={{defaultAltText}}></div>
+                        <img src={{defaultPhoto}} alt={{defaultAltText}} class="img-responsive banner-img">
                     </div>
                     <div class="col-xs-12 hidden-sm hidden-md hidden-lg hidden-xl">
-                        <div class="banner-sm" style={{mobileStyle}} alt={{mobileAltText}}></div>
+                        <img src={{mobilePhoto}} alt={{mobileAltText}} class="img-responsive banner-img">
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Purpose

Fix inconsistent banner look on ember apps.

h/t @baylee-d for helping me understand and fix the CSS issues

## Summary of Changes

- Fix banner styles
- Center the banner image

## Side Effects / Testing Notes

Make sure the banner is centered.
Please try different sizes heights to make sure larger banners display right.

## Ticket

[IN-159](https://openscience.atlassian.net/browse/IN-159)

## After

<img width="1678" alt="screen shot 2018-06-14 at 1 37 56 pm" src="https://user-images.githubusercontent.com/4511563/41430428-fa677492-6fdd-11e8-88e4-fd0ab33dcc79.png">


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
