### PR TITLE
[IN-338][Ember-OSF] GA anonymize sender ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.17.1] -
+### Added
+- `anonymizeIp: true` in GA config to anonymize sender IP.
+
 ## [0.17.0] - 2018-05-29
 ### Added
 - `scheduled-banner` component that pulls banners (created in the OSF Admin app) from the API

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "ember-diff-attrs": "^0.2.0",
     "ember-get-config": "0.2.1",
     "ember-i18n": "5.0.1",
-    "ember-metrics": "^0.12.1",
+    "ember-metrics": "https://github.com/cos-forks/ember-metrics#v0.12.1+cos0",
     "ember-moment": "^7.4.1",
     "ember-power-select": "^1.10.4",
     "ember-radio-buttons": "4.0.3",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -19,7 +19,11 @@ module.exports = function(environment) {
                 name: 'GoogleAnalytics',
                 environments: ['all'],
                 config: {
-                    id: process.env.GOOGLE_ANALYTICS_ID
+                    id: process.env.GOOGLE_ANALYTICS_ID,
+                    setFields: {
+                        // Ensure the IP address of the sender will be anonymized.
+                        anonymizeIp: true,
+                    }
                 }
             },
             {
@@ -69,7 +73,7 @@ module.exports = function(environment) {
                 turnAuditOff: false
             }
         },
-        
+
         moment: {
             includeTimezone: 'all',
             outputFormat: 'YYYY-MM-DD h:mm A z',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3823,9 +3823,9 @@ ember-maybe-in-element@^0.1.3:
   dependencies:
     ember-cli-babel "^6.11.0"
 
-ember-metrics@^0.12.1:
+"ember-metrics@https://github.com/cos-forks/ember-metrics#v0.12.1+cos0":
   version "0.12.1"
-  resolved "https://registry.yarnpkg.com/ember-metrics/-/ember-metrics-0.12.1.tgz#8659343bf7b8bda403e70d482ff59cc9714d89f6"
+  resolved "https://github.com/cos-forks/ember-metrics#32fcc6eec0c4bc1974c854435401f94f660c6e74"
   dependencies:
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^6.1.0"


### PR DESCRIPTION
## Purpose

as part of GDPR compliance efforts, `anonymizeIp: true` allows
the sender IPs to be anonymized.

## Summary of Changes

- Update config to set `anonymizeIp: true`
- Point to fork to allow setting GA configs.

## Side Effects / Testing Notes
In case GA is enabled on staging environments, you can verify this flag is set by looking at the GA requests in the console (filter by `collect`)

## Ticket

[IN-338](https://openscience.atlassian.net/browse/IN-338)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`
