### PR TITLE
[IN-32][EmberOSF] Add parent ancestry to discover page components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `metaschema` model into `registration-metaschema`
 - `scheduled-banner` component to display the banner image centered and adapt to different image heights.
+- Discover page components to include parent lineage if available
 
 ## [0.17.0] - 2018-05-29
 ### Added

--- a/addon/components/search-result/component.js
+++ b/addon/components/search-result/component.js
@@ -51,6 +51,9 @@ export default Ember.Component.extend(Analytics, hostAppName, {
     */
     themeProvider: null,
     domainRedirectProviders: [],
+    lineage: Ember.computed('result', function() {
+        return this.get('result.lists.lineage');
+    }),
     footerIcon: Ember.computed('showBody', function() {
         return this.get('showBody') ? 'caret-up' : 'caret-down';
     }),

--- a/addon/components/search-result/style.scss
+++ b/addon/components/search-result/style.scss
@@ -52,4 +52,14 @@
     .toggleShowResult.btn:focus {
         outline: none;
     }
+    .ancestor {
+        font-size: .8em;
+        a {
+            display: inline-block;
+            max-width: 300px;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+        }
+    }
 }

--- a/addon/components/search-result/template.hbs
+++ b/addon/components/search-result/template.hbs
@@ -4,6 +4,15 @@
         <div class="col-xs-12">
             {{!Title}}
             <h4>
+                {{#each lineage as |ancestor|}}
+                    <span class="ancestor">
+                        {{#each ancestor.identifiers as |link|}}
+                            {{#if (eq link ancestor.identifiers.lastObject)}}
+                                <a href="{{link}}">{{ancestor.title}}</a> / 
+                            {{/if}}
+                        {{/each}}
+                    </span>
+                {{/each}}
                 {{#if (and detailRoute osfID)}}
                     {{#link-to detailRoute osfID invokeAction=(action 'click' 'link' 'Discover - Result Title' osfID)}}{{fix-special-char result.title}}{{/link-to}}
                 {{else if (and detailRoute (eq hostAppName 'Retraction Watch'))}}


### PR DESCRIPTION
## Purpose

Registrations on the discover page are currently shown without any indication of what parent projects/components they belong to.  This should be changed to match what's on the OSF.
![screen shot 2017-02-24 at 10 02 48 am](https://user-images.githubusercontent.com/19379783/41994471-8809f73c-7a1c-11e8-9281-587815a090e7.png)

## Summary of Changes

- Use lineage lists from SHARE to show the titles of parent components/projects

## Side Effects / Testing Notes

This currently will not work with registrations since the info isn't being passed through from SHARE.  This will work as soon as that data is available.

The styling was made to look like SHARE and should end up looking like this:
<img width="1224" alt="screen shot 2018-06-27 at 1 53 54 pm" src="https://user-images.githubusercontent.com/19379783/41994508-a68e0eb4-7a1c-11e8-8c0b-337178d6a213.png">

## Ticket

https://openscience.atlassian.net/browse/IN-32

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
