### PR TITLE
[IN-234][EmberOSF] Add cookie-banner component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `cookie-banner` component
+
 ### Removed
 - obsolete `initialWidth` parameter from mfrUrl
 

--- a/addon/components/cookie-banner/component.js
+++ b/addon/components/cookie-banner/component.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+import layout from './template';
+
+/**
+ * @module ember-osf
+ * @submodule components
+ */
+
+ /**
+ * Adds a cookie banner to the page
+ *
+ * Sample usage:
+ * ```handlebars
+ * {{cookie-banner
+ *   addCookie=(action 'addCookie')
+ * }}
+ * ```
+ *
+ * @class dropzone-widget
+ */
+export default Ember.Component.extend({
+    layout,
+
+    actions: {
+        addCookie() {
+            this.addCookie();
+        }
+    }
+});

--- a/addon/components/cookie-banner/style.scss
+++ b/addon/components/cookie-banner/style.scss
@@ -1,0 +1,20 @@
+#cookie-banner {
+    width: 100%;
+    position: fixed;
+    bottom: 0;
+    background-color: #263947;
+    color: white;
+    display: flex;
+    align-items: center;
+    z-index: 1;
+    .flex-item {
+        margin: 10px;
+    }
+    .flex-item-left {
+        margin-left: 10%;
+        margin-right: 75px;
+    }
+    .flex-item-right {
+        margin-right: 10%;
+    }
+}

--- a/addon/components/cookie-banner/style.scss
+++ b/addon/components/cookie-banner/style.scss
@@ -1,4 +1,4 @@
-#cookie-banner {
+& {
     width: 100%;
     position: fixed;
     bottom: 0;
@@ -6,15 +6,19 @@
     color: white;
     display: flex;
     align-items: center;
-    z-index: 1;
-    .flex-item {
-        margin: 10px;
+    z-index: 10;
+    a {
+        color: white;
+        text-decoration: underline;
+        &:hover,
+        &:visited {
+            color: #ADCCE6;
+        }
     }
     .flex-item-left {
-        margin-left: 10%;
-        margin-right: 75px;
+        margin: 10px 75px 10px 10%;
     }
     .flex-item-right {
-        margin-right: 10%;
+        margin: 10px 10% 10px 10px;
     }
 }

--- a/addon/components/cookie-banner/template.hbs
+++ b/addon/components/cookie-banner/template.hbs
@@ -1,8 +1,7 @@
-<div id="cookie-banner">
-    <div class="flex-item flex-item-left">
-        This website relies on cookies to help provide a better user experience. By clicking Accept or continuing to use the site, you agree. For more information, see our <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md">Privacy Policy</a> and information on <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md#7-types-of-information-we-collect">cookie use</a>.
-    </div>
-    <div class="flex-item flex-item-right">
-        <button class="btn btn-default" {{action "addCookie"}}>Accept</button>
-    </div>
+<div class="flex-item flex-item-left">
+    This website relies on cookies to help provide a better user experience. By clicking Accept or continuing to use the site, you agree. For more information, see our <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md">Privacy Policy</a> and information on <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md#7-types-of-information-we-collect">cookie use</a>.
 </div>
+<div class="flex-item flex-item-right">
+    <button class="btn btn-default" {{action "addCookie"}}>Accept</button>
+</div>
+

--- a/addon/components/cookie-banner/template.hbs
+++ b/addon/components/cookie-banner/template.hbs
@@ -1,0 +1,8 @@
+<div id="cookie-banner">
+    <div class="flex-item flex-item-left">
+        This website relies on cookies to help provide a better user experience. By clicking Accept or continuing to use the site, you agree. For more information, see our <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md">Privacy Policy</a> and information on <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md#7-types-of-information-we-collect">cookie use</a>.
+    </div>
+    <div class="flex-item flex-item-right">
+        <button class="btn btn-default" {{action "addCookie"}}>Accept</button>
+    </div>
+</div>

--- a/app/components/cookie-banner/component.js
+++ b/app/components/cookie-banner/component.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/components/cookie-banner/component';

--- a/tests/integration/components/cookie-banner/component-test.js
+++ b/tests/integration/components/cookie-banner/component-test.js
@@ -1,0 +1,17 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('discover-page', 'Integration | Component | discover page', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+    let noop = () => {};
+    this.set('noop', noop);
+
+    this.render(
+        hbs`{{cookie-banner 
+              addCookie=(action noop)}}`);
+
+    assert.ok(this.$());
+});


### PR DESCRIPTION
## Purpose
This will add a new cookie-banner component to EmberOSF.  It will sit on the bottom of the page it's included on and float there.  There is only an accept button and when it's clicked it will add a cookie to the user's browser to determine not to display the banner on the site.


## Summary of Changes/Side Effects
- Added `cookie-banner` component and test

Viewing the page as a non-logged in user:
![float-bottom](https://user-images.githubusercontent.com/19379783/42648837-faf8c0ba-85d5-11e8-88f8-fc767acfccb2.gif)

Clicking the accept button will remove the banner from the page:
![accept-gif](https://user-images.githubusercontent.com/19379783/42648846-01ba1174-85d6-11e8-9b5a-d5eafeebc118.gif)

A logged-in user won't see the cookie banner on the screen:
![log-in-gif](https://user-images.githubusercontent.com/19379783/42648863-0acdce22-85d6-11e8-999a-636406c5f296.gif)


## Testing Notes

There are a few conditions that should be tested:
- If the user is logged out, the banner will show
- If the user is logged in, the banner won't show
- If the user clicks `accept` the banner should disappear and won't show up again (unless the cookie is manually deleted)

The banner will show up on the bottom of the screen and should stay there regardless of where the user is at on the page.

This will need to be tested with either/both of the changes done to registries and preprints.


## Ticket

https://openscience.atlassian.net/browse/IN-324

## Notes for Reviewer
N/A


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
