### PR TITLE
[IN-327][Emberosf] Add `preprint-request` model.

### DIFF
--- a/addon/adapters/preprint-request-action.js
+++ b/addon/adapters/preprint-request-action.js
@@ -1,0 +1,7 @@
+import OsfAdapter from './osf-adapter';
+
+export default OsfAdapter.extend({
+    pathForType: function(){
+        return 'actions/requests/preprints/';
+    }
+});

--- a/addon/adapters/preprint-request.js
+++ b/addon/adapters/preprint-request.js
@@ -1,0 +1,20 @@
+import OsfAdapter from './osf-adapter';
+import config from 'ember-get-config';
+
+export default OsfAdapter.extend({
+    buildURL: function(modelName, id, snapshot, requestType, query) {
+        let url;
+        if (requestType === 'query') {
+            const providerId = query.providerId;
+            const preprintId = query.preprintId;
+            if (preprintId) {
+                url = `${this.host}/${config.OSF.apiNamespace}/providers/preprints/${providerId}/withdraw_requests/?filter[target]=${preprintId}`;
+                delete query.preprintId;
+            } else {
+                url = `${this.host}/${config.OSF.apiNamespace}/providers/preprints/${query.providerId}/withdraw_requests/`;
+                delete query.providerId;
+            }
+        }
+        return url;
+    },
+});

--- a/addon/adapters/preprint-request.js
+++ b/addon/adapters/preprint-request.js
@@ -5,8 +5,6 @@ export default OsfAdapter.extend({
     buildURL: function(modelName, id, snapshot, requestType, query) {
         let url;
         if (requestType === 'query') {
-            const providerId = query.providerId;
-            const preprintId = query.preprintId;
             url = `${this.host}/${config.OSF.apiNamespace}/providers/preprints/${query.providerId}/withdraw_requests/`;
             delete query.providerId;
         }

--- a/addon/adapters/preprint-request.js
+++ b/addon/adapters/preprint-request.js
@@ -7,13 +7,8 @@ export default OsfAdapter.extend({
         if (requestType === 'query') {
             const providerId = query.providerId;
             const preprintId = query.preprintId;
-            if (preprintId) {
-                url = `${this.host}/${config.OSF.apiNamespace}/providers/preprints/${providerId}/withdraw_requests/?filter[target]=${preprintId}`;
-                delete query.preprintId;
-            } else {
-                url = `${this.host}/${config.OSF.apiNamespace}/providers/preprints/${query.providerId}/withdraw_requests/`;
-                delete query.providerId;
-            }
+            url = `${this.host}/${config.OSF.apiNamespace}/providers/preprints/${query.providerId}/withdraw_requests/`;
+            delete query.providerId;
         }
         return url;
     },

--- a/addon/models/preprint-request-action.js
+++ b/addon/models/preprint-request-action.js
@@ -1,0 +1,10 @@
+import DS from 'ember-data';
+import OsfModel from './osf-model';
+
+export default OsfModel.extend({
+    actionTrigger: DS.attr('string'),
+    comment: DS.attr('string'),
+
+    // Relationships
+    target: DS.belongsTo('preprint-request', { inverse: null, async: true }),
+});

--- a/addon/models/preprint-request.js
+++ b/addon/models/preprint-request.js
@@ -1,0 +1,15 @@
+import DS from 'ember-data';
+import OsfModel from './osf-model';
+
+export default OsfModel.extend({
+    comment: DS.attr('string'),
+    dateLastTransitioned: DS.attr('date'),
+    created: DS.attr('date'),
+    machineState: DS.attr('string'),
+    modified: DS.attr('date'),
+    requestType: DS.attr('string'),
+
+    //Relationships
+    target: DS.belongsTo('preprint', { inverse: null, async: true }),
+    creator: DS.belongsTo('user', { inverse: null, async: true }),
+});

--- a/addon/serializers/preprint-request-action.js
+++ b/addon/serializers/preprint-request-action.js
@@ -1,0 +1,12 @@
+import OsfSerializer from './osf-serializer';
+
+export default OsfSerializer.extend({
+    // Because `trigger` is a private method on DS.Model
+    attrs: {
+        actionTrigger: 'trigger',
+    },
+    // Serialize `target` relationship
+    relationshipTypes: {
+        target: 'prepringt-requests',
+    },
+});

--- a/addon/serializers/preprint-request.js
+++ b/addon/serializers/preprint-request.js
@@ -1,0 +1,4 @@
+import OsfSerializer from './osf-serializer';
+
+export default OsfSerializer.extend({
+});

--- a/app/adapters/preprint-request-action.js
+++ b/app/adapters/preprint-request-action.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/adapters/preprint-request-action';

--- a/app/adapters/preprint-request.js
+++ b/app/adapters/preprint-request.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/adapters/preprint-request';

--- a/app/models/preprint-request-action.js
+++ b/app/models/preprint-request-action.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/models/preprint-request-action';

--- a/app/models/preprint-request.js
+++ b/app/models/preprint-request.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/models/preprint-request';

--- a/app/serializers/preprint-request-action.js
+++ b/app/serializers/preprint-request-action.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/serializers/preprint-request-action';

--- a/app/serializers/preprint-request.js
+++ b/app/serializers/preprint-request.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/serializers/preprint-request';


### PR DESCRIPTION
## Purpose

[IN-327](https://openscience.atlassian.net/browse/IN-327) adds a withdrawal request to preprint detail page for the reviews app. In order for that to work, there should be two new models:
- `preprint-request`
- `preprint-request-action`

## Summary of Changes/Side Effects

Other than adding the new models, `buildUrl` method for the `preprint-request` adapter and `pathForType` method for the `preprint-request-action` adapter are overridden to make requests to the correct endpoint with query parameters.

## Ticket

https://openscience.atlassian.net/browse/IN-327

## Notes

This PR needs to be merged before PRs for [IN-328](https://openscience.atlassian.net/browse/IN-328) can be merged. These two These two tickets uses the same set of newly added models.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
