### PR TITLE
[IN-350][Ember-OSF] Make a copy of queryParamsState as to not modify the original value

### DIFF
--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -252,7 +252,7 @@ export default Ember.Component.extend(Analytics, hostAppName, {
 
         updateFilters(filterType, item) {
             item = typeof item === 'object' ? item.text : item;
-            const currentState = this.get(`queryParamsState.${filterType}.value`);
+            const currentState = this.get(`queryParamsState.${filterType}.value`).slice(0);
             const hasItem = currentState.includes(item);
 
             if (hasItem) {


### PR DESCRIPTION
## Purpose
Clicking "Clear filters" doesn't always clear all the filters. Leaves one or two sometimes. (Have not found a clear way to reproduce this). [See gif](http://g.recordit.co/htRl75GH8h.gif)


## Summary of Changes/Side Effects
* Make a copy of queryParamsState as to not modify the original value
[See stack overflow answer for better explanation](https://stackoverflow.com/questions/6612385/why-does-changing-an-array-in-javascript-affect-copies-of-the-array)


## Testing Notes
Test that selecting filters, clearing the filters, then selecting more filters and clearing those works properly. This issue is a little intermittent so I would try it several times.


## Ticket

https://openscience.atlassian.net/browse/IN-350

## Notes for Reviewer
This change is necessary for preprints 0.120.0 and registries 0.9.0.


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
