### PR TITLE
[IN-350][Ember-OSF] Get registration type from SHARE response

### DIFF
--- a/addon/utils/discover-page.js
+++ b/addon/utils/discover-page.js
@@ -188,6 +188,7 @@ function transformShareData(result) {
             },
         ],
         infoLinks: [], // Links that are not hyperlinks  hit._source.lists.links
+        registrationType: result._source.registration_type, // for registries
     });
 
     result._source.identifiers.forEach(function(identifier) {


### PR DESCRIPTION
## Purpose
Registration type should show in search results.


## Summary of Changes/Side Effects
* Get registration type from SHARE response

**Before**
![no-registration-type](https://user-images.githubusercontent.com/7131985/42907543-188a0730-8aac-11e8-8ce0-47a1c5220aa8.png)

**After**
![registration-type](https://user-images.githubusercontent.com/7131985/42907555-1f70ea14-8aac-11e8-91ea-e6b382149f13.png)


## Testing Notes
Should make sure the registration type appears in search results.


## Ticket

https://openscience.atlassian.net/browse/IN-350

## Notes for Reviewer
N/A


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
