### PR TITLE
[IN-324][EOSF] Update cookie banner styling and responsiveness

### DIFF
--- a/addon/components/cookie-banner/style.scss
+++ b/addon/components/cookie-banner/style.scss
@@ -26,11 +26,11 @@
         margin: 10px 10% 10px 20px;
         @media (max-width: 500px) {
             text-align: center;
-            margin: 10px 0px;
+            margin: 10px 0;
         }
     }
     @media (max-width: 500px) {
-        padding: 10px 0px;
+        padding: 10px 0;
         display: block;
     }
 }

--- a/addon/components/cookie-banner/style.scss
+++ b/addon/components/cookie-banner/style.scss
@@ -16,9 +16,21 @@
         }
     }
     .flex-item-left {
-        margin: 10px 75px 10px 10%;
+        margin: 10px 20px 10px 10%;
+        @media (max-width: 500px) {
+            margin: 5px 10px;
+            padding-bottom: 10px;
+        }
     }
     .flex-item-right {
-        margin: 10px 10% 10px 10px;
+        margin: 10px 10% 10px 20px;
+        @media (max-width: 500px) {
+            text-align: center;
+            margin: 10px 0px;
+        }
+    }
+    @media (max-width: 500px) {
+        padding: 10px 0px;
+        display: block;
     }
 }


### PR DESCRIPTION
## Purpose
To fit with requirements, this will update the cookie banner to be more responsive on small screens and mobile layouts.


## Summary of Changes/Side Effects
- Made the margin size smaller between the text and button to reduce the amount of space that's used.
- On screens smaller than 500px, stack the text and button horizontally to keep the layout clean.


## Testing Notes
This primarily deals with CSS, so just testing that things move when they're supposed to.  When the screen size is 499px or smaller the button will move to a new line below the text.  The text will not be centered.  The button should be centered on its line.

![nr4fjo7pgg](https://user-images.githubusercontent.com/19379783/43082037-0c806f52-8e61-11e8-9316-598827a2223d.gif)


## Ticket

https://openscience.atlassian.net/browse/IN-324

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
