### PR TITLE
[IN-378][EmberOSF] Add facet check to stop weird page hang on discover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- discover page load delay
 
 ## [0.19.0] - 2018-07-25
 ### Added

--- a/addon/components/discover-page/component.js
+++ b/addon/components/discover-page/component.js
@@ -344,11 +344,11 @@ export default Ember.Component.extend(Analytics, hostAppName, {
     }),
 
     init() {
-        // TODO Sort initial results on date_modified
         // Runs on initial render.
         this._super(...arguments);
-
-        this.get('getTypes').perform();
+        if (this.get('facets').find(this.isTypeFacet)) {
+            this.get('getTypes').perform();
+        }
         this.get('getCounts').perform();
     },
 });


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
<!-- Why is this change necessary? What does it do? -->
With the livedata rework, some facet logic was being run on discover pages that should not have been.

## Summary of Changes/Side Effects
<!-- What did you change?
Include before/after screenshots or a video/gif if applicable.
Do these changes have any unforseen effects (good or bad)?-->
Add check for if facet should run (h/t @laurenbarker)

## Testing Notes
<!-- What needs to be tested?
Are there any edge cases that should be tested? -->
1. Confirm live data facets still look good
2. Confirm discover pages still look good
3. Refresh the discover pages a bunch of times and make sure you don't see weird hanging behavior:
<img width="1440" alt="screen shot 2018-08-01 at 4 23 17 pm" src="https://user-images.githubusercontent.com/1322421/43593125-0e80a25e-9645-11e8-9239-1df642485c31.png">


## Ticket

https://openscience.atlassian.net/browse/IN-378

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
