### PR TITLE
[IN-272][Registries] Add My Registrations to Registries navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `cookie-banner` component
 - Sharing popover button to the discover search page
 - Whitelist functionality for preprint discover page
+- 'My Registrations' to Registries navbar
 
 ### Removed
 - obsolete `initialWidth` parameter from mfrUrl

--- a/addon/const/service-links.js
+++ b/addon/const/service-links.js
@@ -22,6 +22,7 @@ const serviceLinks = {
     meetingsHome: `${osfUrl}meetings/`,
     myProjects: `${osfUrl}myprojects/`,
     myQuickFiles: `${osfUrl}quickfiles/`,
+    myRegistrations: `${osfUrl}myprojects/#registrations`,
     osfHome: osfUrl,
     osfSupport: `${osfUrl}support/`,
     preprintsDiscover: `${osfUrl}preprints/discover/`,

--- a/addon/helpers/build-secondary-nav-links.js
+++ b/addon/helpers/build-secondary-nav-links.js
@@ -105,6 +105,13 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                     href: serviceLinks.myProjects,
                 }
             );
+            links.REGISTRIES.unshift(
+                {
+                    name: 'eosf.navbar.myRegistrations',
+                    href: serviceLinks.myRegistrations,
+                    type: 'myRegistrations'
+                }
+            );
             this.get('currentUser.user').then((user) => {
                 if (user.get('canViewReviews')) {
                     links.PREPRINTS.insertAt(1, {

--- a/addon/locales/en/translations.js
+++ b/addon/locales/en/translations.js
@@ -78,6 +78,7 @@ export default {
             meetings: 'Meetings',
             myProjects: 'My Projects',
             myQuickFiles: 'My Quick Files',
+            myRegistrations: 'My Registrations',
             newProjects: 'New Projects',
             openScienceFramework: 'Open Science Framework',
             osf: 'OSF',


### PR DESCRIPTION
## Purpose
Now that we have anchors on the projects page we can have navigation in the navbar that'll bring you to a list of all of your registrations.


## Summary of Changes/Side Effects
- Added a service link for a link in the registries navbar that'll bring you to an anchor on the My Projects page
- Add translation for the new link

## Testing Notes
This will take up more space on the navbar, so please test that it won't break it in any weird or unexpected ways. The link will only show up for users if they are logged in and it should bring them to the registrations anchor on the my projects page.

## Screenshots
Link won't show up if the user is logged out:
<img width="1300" alt="screen shot 2018-08-06 at 4 58 27 pm" src="https://user-images.githubusercontent.com/19379783/43741312-ea1b303c-999b-11e8-8083-2d496d0e5333.png">

Link will show up if the user is logged in:
<img width="1288" alt="screen shot 2018-08-06 at 4 58 39 pm" src="https://user-images.githubusercontent.com/19379783/43741330-f9f6d31c-999b-11e8-8125-984b5b9c4286.png">

Link will take the user to the Registrations tab on the My Projects page:
![e11ykyh8xt](https://user-images.githubusercontent.com/19379783/43741371-1edf4ede-999c-11e8-88f7-f7be2fa551bf.gif)


## Ticket

https://openscience.atlassian.net/browse/IN-272

## Notes for Reviewer
`N/A`


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
