### PR TITLE
[IN-392][EmberOSF] Preprint link language consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Discover page components to include parent lineage if available
+- Normalize "Add a Preprint" language across screen sizes
 
 ### Removed
 - institution navbar waffle flag

--- a/addon/components/new-osf-navbar/template.hbs
+++ b/addon/components/new-osf-navbar/template.hbs
@@ -55,11 +55,8 @@
                                 <li>
                                     <a href="{{navLink.href}}" onclick={{action 'click' 'link' (concat 'Navbar - ' navlink.name)}}>
                                         {{#if (eq navLink.type 'addAPreprint')}}
-                                            <span class="hidden-xs hidden-sm">
+                                            <span>
                                                 {{t navLink.name documentType=documentType}}
-                                            </span>
-                                            <span class="hidden-md hidden-lg hidden-xl">
-                                                {{t 'eosf.navbar.add'}}
                                             </span>
                                         {{else}}
                                             {{t navLink.name}}


### PR DESCRIPTION
## Purpose
On the non-branded navbar, `Add a Preprint` changes to just `Add` on small/mobile screen sizes. This doesn't happen on the branded navbar. We should try to keep it consistent between all screen sizes.

## Summary of Changes/Side Effects
* Use `Add a Preprint` regardless of screen size

![screen shot 2018-08-13 at 1549 22](https://user-images.githubusercontent.com/5659262/44054696-51941452-9f11-11e8-8d7f-12df2128a86b.png)


## Testing Notes
Make sure branded / non-branded links behave as expected

## Ticket

[[IN-392]](https://openscience.atlassian.net/browse/IN-392)


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
