### PR TITLE
[Preprint Withdrawals][EOSF][EMB-549][EMB-548][EMB-550][EMB-551] Add 'preprint-request' and 'preprint-request-action' model

### DIFF
--- a/addon/adapters/preprint-request-action.js
+++ b/addon/adapters/preprint-request-action.js
@@ -1,0 +1,7 @@
+import OsfAdapter from './osf-adapter';
+
+export default OsfAdapter.extend({
+    pathForType: function(){
+        return 'actions/requests/preprints/';
+    }
+});

--- a/addon/adapters/preprint-request.js
+++ b/addon/adapters/preprint-request.js
@@ -1,0 +1,15 @@
+import OsfAdapter from './osf-adapter';
+import config from 'ember-get-config';
+
+export default OsfAdapter.extend({
+    urlForQuery: function (query) {
+        const url = `${this.host}/${config.OSF.apiNamespace}/providers/preprints/${query.providerId}/withdraw_requests/`;
+        delete query.providerId;
+        return url;
+    },
+    urlForCreateRecord: function (modelname, snapshot) {
+        const preprintId = snapshot.belongsTo('target').id;
+        const url = `${this.host}/${config.OSF.apiNamespace}/preprints/${preprintId}/requests/`;
+        return url;
+    }
+});

--- a/addon/models/preprint-request-action.js
+++ b/addon/models/preprint-request-action.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+import OsfModel from './osf-model';
+
+export default OsfModel.extend({
+    actionTrigger: DS.attr('string'),
+    comment: DS.attr('string'),
+    auto: DS.attr('boolean'),
+    dateModified: DS.attr('date'),
+
+    // Relationships
+    target: DS.belongsTo('preprint-request', { inverse: 'actions', async: true }),
+    creator: DS.belongsTo('user', { inverse: null, async: true }),
+});

--- a/addon/models/preprint-request.js
+++ b/addon/models/preprint-request.js
@@ -1,0 +1,16 @@
+import DS from 'ember-data';
+import OsfModel from './osf-model';
+
+export default OsfModel.extend({
+    comment: DS.attr('string'),
+    dateLastTransitioned: DS.attr('date'),
+    created: DS.attr('date'),
+    machineState: DS.attr('string'),
+    modified: DS.attr('date'),
+    requestType: DS.attr('string'),
+
+    //Relationships
+    target: DS.belongsTo('preprint', { inverse: 'requests', async: true }),
+    creator: DS.belongsTo('user', { inverse: null, async: true }),
+    actions: DS.hasMany('preprint-request-action', { inverse: 'target', async:true })
+});

--- a/addon/models/preprint.js
+++ b/addon/models/preprint.js
@@ -53,6 +53,7 @@ export default OsfModel.extend(ContributorMixin, {
         allowBulkRemove: true,
         inverse: 'preprint'
     }),
+    requests: DS.hasMany('preprint-requests', { inverse: 'target', async: true }),
     uniqueSubjects: Ember.computed('subjects', function() {
         if (!this.get('subjects')) return [];
         return this.get('subjects').reduce((acc, val) => acc.concat(val), []).uniqBy('id');

--- a/addon/serializers/preprint-request-action.js
+++ b/addon/serializers/preprint-request-action.js
@@ -1,0 +1,12 @@
+import OsfSerializer from './osf-serializer';
+
+export default OsfSerializer.extend({
+    // Because `trigger` is a private method on DS.Model
+    attrs: {
+        actionTrigger: 'trigger',
+    },
+    // Serialize `target` relationship
+    relationshipTypes: {
+        target: 'preprint-requests',
+    },
+});

--- a/addon/serializers/preprint-request.js
+++ b/addon/serializers/preprint-request.js
@@ -1,0 +1,8 @@
+import OsfSerializer from './osf-serializer';
+
+export default OsfSerializer.extend({
+    // Serialize `target` relationship
+    relationshipTypes: {
+        target: 'preprints',
+    },
+});

--- a/app/adapters/preprint-request-action.js
+++ b/app/adapters/preprint-request-action.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/adapters/preprint-request-action';

--- a/app/adapters/preprint-request.js
+++ b/app/adapters/preprint-request.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/adapters/preprint-request';

--- a/app/models/preprint-request-action.js
+++ b/app/models/preprint-request-action.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/models/preprint-request-action';

--- a/app/models/preprint-request.js
+++ b/app/models/preprint-request.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/models/preprint-request';

--- a/app/serializers/preprint-request-action.js
+++ b/app/serializers/preprint-request-action.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/serializers/preprint-request-action';

--- a/app/serializers/preprint-request.js
+++ b/app/serializers/preprint-request.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/serializers/preprint-request';

--- a/tests/unit/models/preprint-test.js
+++ b/tests/unit/models/preprint-test.js
@@ -10,6 +10,7 @@ moduleForModel('preprint', 'Unit | Model | preprint', {
             'model:review-action',
             'model:node',
             'model:license',
+            'model:preprint-request',
             'transform:fixstring',
             'transform:links',
             'transform:embed',]


### PR DESCRIPTION
## Purpose

This PR adds two models, `preprint-request` and `preprint-request-action`, and their adapters and serializers. This is necessary for withdrawal-related functionalities to work on both the Reviews and Preprints app.

## Changes

Models and serailizers changes are quite straightforward.
For the adapter for `preprint-request`, `urlForQuery` and `urlForCreateRecord` are overridded to construct the correct url.

## Testing Notes

Nothing to test for this PR specifically. See other PRs for testing notes.

## Ticket

https://openscience.atlassian.net/browse/IN-327
https://openscience.atlassian.net/browse/IN-328

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
