### PR TITLE
[IN-102][EmberOSF] Allow user search to use elastic endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added `dateWithdrawn` and `withdrawalJustification` to `preprint` model
 
+### Changed
+- `users` model to use urlForQuery to allow searching via `/search/users/`
+
 ## [0.20.1] - 2018-08-16
 ### Remove unwanted lineage code
 

--- a/addon/adapters/user.js
+++ b/addon/adapters/user.js
@@ -1,4 +1,12 @@
 import OsfAdapter from './osf-adapter';
 
 export default OsfAdapter.extend({
+    urlForQuery(query, modelName) {
+        // if query contains `q` for search, use the elasticsearch `/search/users/` endpoint
+        if(query.hasOwnProperty('q')) {
+            const originalPathForTypeRegEx = new RegExp(`${this.pathForType(modelName)}$`);
+            return this._super(query, modelName).replace(originalPathForTypeRegEx, 'search/users');
+        }
+        return this._super(query, modelName);
+    }
 });

--- a/tests/unit/adapters/user-test.js
+++ b/tests/unit/adapters/user-test.js
@@ -1,0 +1,48 @@
+import { moduleFor } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+import FactoryGuy, { manualSetup } from 'ember-data-factory-guy';
+
+
+moduleFor('adapter:user', 'Unit | Adapter | user', {
+    needs: [
+        'model:user',
+        'adapter:user',
+        'serializer:user',
+        'service:session',
+    ],
+    beforeEach() {
+        manualSetup(this.container);
+    }
+});
+
+test('#buildURL uses /users/ if q not present', function (assert) {
+    const urlUsers = 'http://localhost:8000/v2/users/';
+    const urlSearchUsers = 'http://localhost:8000/v2/search/users/';
+    const adapter = this.subject();
+    const user = FactoryGuy.make('user');
+    const result = adapter.buildURL(
+        'user',
+        null,
+        user._internalModel.createSnapshot(),
+        'query',
+        { notq: 'my_query' }
+    );
+    assert.notEqual(result, urlSearchUsers);
+    assert.equal(result, urlUsers);
+});
+
+test('#buildURL uses /search/users/ if q present', function (assert) {
+    const urlUsers = 'http://localhost:8000/v2/users/';
+    const urlSearchUsers = 'http://localhost:8000/v2/search/users/';
+    const adapter = this.subject();
+    const user = FactoryGuy.make('user');
+    const result = adapter.buildURL(
+        'user',
+        null,
+        user._internalModel.createSnapshot(),
+        'query',
+        { q: 'my_query' }
+    );
+    assert.notEqual(result, urlUsers);
+    assert.equal(result, urlSearchUsers);
+});


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
<!-- Why is this change necessary? What does it do? -->
Need way to hit the search users endpoint. Allows the url to change depending on your query.

## Summary of Changes/Side Effects
<!-- What did you change?
Include before/after screenshots or a video/gif if applicable.
Do these changes have any unforseen effects (good or bad)?-->
Used urlForQuery to modify how it searches depending on the presence of q query param. 
Add tests

## Testing Notes
<!-- What needs to be tested?
Are there any edge cases that should be tested? -->
None here, testing notes on preprints side ticket

## Ticket

https://openscience.atlassian.net/browse/IN-102

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->
None

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
