### PR TITLE
[EMB-400] Change the endpoint for the authenticator from `/v2/users/me/` to `/v2/`

### DIFF
--- a/addon/authenticators/osf-cookie.js
+++ b/addon/authenticators/osf-cookie.js
@@ -36,7 +36,11 @@ export default Base.extend({
             // Push the result into the store for later use by the current-user service
             // Note: we have to deepcopy res because pushPayload mutates our data
             // and causes an infinite loop because reasons
-            this.get('store').pushPayload(Ember.copy(res['meta']['current_user'], true));
+            if (res['meta']['current_user'] !== null ){
+                this.get('store').pushPayload(Ember.copy(res['meta']['current_user'], true));
+            } else {
+                return Ember.RSVP.reject();
+            }
             return res.data;
         });
     },

--- a/addon/authenticators/osf-cookie.js
+++ b/addon/authenticators/osf-cookie.js
@@ -26,7 +26,7 @@ export default Base.extend({
     _test() {
         return authenticatedAJAX({
             method: 'GET',
-            url: `${config.OSF.apiUrl}/${config.OSF.apiNamespace}/users/me/`,
+            url: `${config.OSF.apiUrl}/${config.OSF.apiNamespace}/`,
             dataType: 'json',
             contentType: 'application/json',
             xhrFields: {
@@ -36,7 +36,7 @@ export default Base.extend({
             // Push the result into the store for later use by the current-user service
             // Note: we have to deepcopy res because pushPayload mutates our data
             // and causes an infinite loop because reasons
-            this.get('store').pushPayload(Ember.copy(res, true));
+            this.get('store').pushPayload(Ember.copy(res['meta']['current_user'], true));
             return res.data;
         });
     },


### PR DESCRIPTION
## Purpose

Currently, `ember-osf` authenticator asks `/v2/users/me/` endpoint for current user's information. If the user is not authenticated, the endpoint returns a 401, which is not good.
Therefore, we change to using `/v2/` which would not return a 401 even if the user is not authenticated.

## Summary of Changes/Side Effects

In `osf-cookie.js`, the endpoint of the AJAX request is changed to `/v2/`.

## Ticket

https://openscience.atlassian.net/browse/EMB-400

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
