### PR TITLE
[EMB-412][EOSF] Change link for rendering preprints.

### DIFF
--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -21,22 +21,27 @@ import config from 'ember-get-config';
  */
 export default Ember.Component.extend({
     layout,
-    download: null,
+    links: null,
     width: '100%',
     height: '100%',
     allowfullscreen: true,
     version: null,
-    mfrUrl: Ember.computed('download', 'version', function() {
-        let download = this.get('download');
-        if (download.includes('?')) {
-            download = download + '&mode=render';
+    mfrUrl: Ember.computed('links.download', 'links.version', 'links.render', function() {
+        if (this.get('links.render') != null) {
+            return this.get('links.render')
         } else {
-            download = download + '?direct&mode=render';
+            let download = this.get('links.download');
+            if (download.includes('?')) {
+                download = download + '&mode=render';
+            } else {
+                download = download + '?direct&mode=render';
+            }
+            if (this.get('version')) {
+                download += '&version=' + this.get('version');
+            }
+            const fallbackMfrRenderUrl = config.OSF.renderUrl + '?url=' + encodeURIComponent(download);
+            return fallbackMfrRenderUrl;
         }
-        if (this.get('version')) {
-            download += '&version=' + this.get('version');
-        }
-        return config.OSF.renderUrl + '?url=' + encodeURIComponent(download);
     }),
 
     didRender() {

--- a/addon/components/file-renderer/template.hbs
+++ b/addon/components/file-renderer/template.hbs
@@ -1,4 +1,4 @@
-{{#if download}}
+{{#if links}}
     <iframe src={{mfrUrl}} width={{width}} height={{height}} scrolling="yes" marginheight="0" frameborder="0" allowfullscreen={{allowfullscreen}}>
     </iframe>
 {{/if}}

--- a/tests/integration/components/file-renderer/component-test.js
+++ b/tests/integration/components/file-renderer/component-test.js
@@ -25,29 +25,34 @@ test('it renders', function(assert) {
 
 test('file rendering defaults', function(assert) {
 
-    let download = 'someTruthyValue';
-    this.set('download', download);
+    let links = {
+        download:'someTruthyValue'
+    };
+    this.set('links', links);
     this.render(hbs`
-      {{#file-renderer download=download}}
+      {{#file-renderer links=links}}
         {{/file-renderer}}
     `);
 
     assert.equal(this.$('iframe').attr('height'), '100%');
     assert.equal(this.$('iframe').attr('width'), '100%');
-    assert.equal(this.$('iframe').attr('src'), config.OSF.renderUrl + "?url=" + encodeURIComponent(download + '?direct&mode=render'));
+    assert.equal(this.$('iframe').attr('src'), config.OSF.renderUrl + "?url=" + encodeURIComponent(links.download + '?direct&mode=render'));
 });
 
 test('specify file rendering parameters', function(assert) {
-    this.set('download', 'http://cos.io/');
+    let links = {
+        download: 'http://cos.io/',
+    };
+    this.set('links', links);
     this.set('height', '500');
     this.set('width', '500');
 
     this.render(hbs`
-        {{#file-renderer download=download height=height width=width}}
+        {{#file-renderer links=links height=height width=width}}
         {{/file-renderer}}
     `);
 
     assert.equal(this.$('iframe').attr('height'), '500');
     assert.equal(this.$('iframe').attr('width'), '500');
-    assert.equal(this.$('iframe').attr('src'), config.OSF.renderUrl + "?url=" + encodeURIComponent('http://cos.io/' + '?direct&mode=render'));
+    assert.equal(this.$('iframe').attr('src'), config.OSF.renderUrl + "?url=" + encodeURIComponent(links.download + '?direct&mode=render'));
 });


### PR DESCRIPTION
## Purpose

Change the link `file-renderer` uses for rendering preprints.

## Ticket

https://openscience.atlassian.net/browse/EMB-412

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
