### PR TITLE
[EMB-400] Return the correct data from _test

### DIFF
--- a/addon/authenticators/osf-cookie.js
+++ b/addon/authenticators/osf-cookie.js
@@ -41,7 +41,7 @@ export default Base.extend({
             } else {
                 return Ember.RSVP.reject();
             }
-            return res.data;
+            return res['meta']['current_user']['data'];
         });
     },
     restore(/* data */) {


### PR DESCRIPTION
## Purpose

During testing, it is discovered that the submit view doesn't work properly. When users finishes the `Basics` section of the submission form, the `Save and continue` button is still disabled despite that `basicsValid` is `true`.
Actually, this has nothing to do with the submission form. Some error occurs in the `build-secondary-nav-links` helper and thus block the normal behavior of the entire page. The error occurs when `this.get('currentUser.user')` returns `null`. The reason it returns `null` is because `session.get('data.authenticated.id')` also returns `null`.
Eventually, this can be traced back to the previous PR on this ticket, where we modify the endpoint in the `_test()` method. Previously, the endpoint `/v2/users/me` returns the `user` object directly. After switching to `/v2`, the `user` object can be retrieved from `res.meta.currentUser`. Although in the previous PR we did change to push the correct payload to the store in `_test()` for use by the `current-user` service, we forgot to `return` the correct data, which would used by `restore()` and `authenticate()`, thus breaking the `session` service.
This PR fixes the problem by returning the correct data for the `_test()` method.

## Ticket

https://openscience.atlassian.net/browse/EMB-400

## Notes for Reviewer
Don't know whether this would fix the infinite request to `/v2` endpoint.


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
