### PR TITLE
[EMB-531][EOSF] Add "API Unavailable" message page.

### DIFF
--- a/addon/mixins/osf-cookie-login-route.js
+++ b/addon/mixins/osf-cookie-login-route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import transitionTargetUrl from 'ember-osf/utils/transition-target-url'
 
 /**
  * @module ember-osf
@@ -15,17 +16,24 @@ import Ember from 'ember';
  */
 export default Ember.Mixin.create({
     session: Ember.inject.service(),
-    beforeModel() {
+    beforeModel(transition) {
         // Determine whether the user is logged in by making a test request. This is quite a crude way of
         // determining whether the user has a cookie and should be improved in the future.
 
         // TODO: Should this check for resolution of a promise?
         this._super(...arguments);
-
         if (this.get('session.isAuthenticated')) return;
 
         // Block transition until auth attempt resolves. If auth fails, let the page load normally.
         return this.get('session').authenticate('authenticator:osf-cookie')
-            .catch(err => Ember.Logger.log('Authentication failed: ', err));
+            .catch(err => {
+                Ember.Logger.log('Authentication failed: ', err);
+                // If `err` is not `undefined` and `err.readyState` is `0`, signaling a network error
+                // We transition to the `error-no-api` route while keeping the transition target url.
+                if (err && err.readyState === 0 && transition.targetName !== 'error-no-api') {
+                    this.transitionTo('error-no-api', transitionTargetUrl(transition).slice(1));
+                    return;
+                }
+            });
     }
 });

--- a/addon/utils/transition-target-url.js
+++ b/addon/utils/transition-target-url.js
@@ -1,0 +1,14 @@
+// This is a port from `@centerforopenscience/ember-osf-web/app/utils/transition-target-url.ts`
+// Get the URL (path and query string) that the given transition will resolve to,
+// using the given router.
+export default function transitionTargetURL(transition) {
+    const params = Object.values(transition.params).filter(
+        param => Object.values(param).length
+    );
+    var url = transition.router.generate(
+        transition.targetName,
+        ...params,
+        { queryParams: transition.queryParams }
+    );
+    return url;
+}

--- a/app/utils/transition-target-url.js
+++ b/app/utils/transition-target-url.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/utils/transition-target-url';


### PR DESCRIPTION
## Purpose
Add "API Unavailable" page like this:
![screen shot 2019-01-31 at 10 54 55 am](https://user-images.githubusercontent.com/1566880/52067052-c46e9d00-2547-11e9-821f-4d2633f565ca.png)

## Summary of Changes/Side Effects
- Port the `transition-target-url` util from @CenterForOpenScience/ember-osf-web
- Modify `osf-cookie-login-route.js` to redirect to `error-no-api` route on network error.
  - Make use of the new util so that upon redirection it keeps the url of the destination route.

NOTE: This implementation requires any apps using the `osf-cookie-login-route` mixin to have an `error-no-api` route defined. However for reviews app, that might need a refactor of how we check user permissions for reviews app, which I don't think worth the effort after poking around it for a bit. Therefore, if you go the reviews app when the API is down, it shows a blank page after this fix goes in.

## Testing Notes
See testing notes for the preprints ticket.

## Ticket

https://openscience.atlassian.net/browse/EMB-531

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
