### PR TITLE
switch to testem dot reporter

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -1,10 +1,13 @@
 /* eslint-env node */
 
+const DotReporter = require('testem/lib/reporters/dot_reporter');
+
 module.exports = {
     framework: 'qunit',
     test_page: 'tests/index.html?hidepassed',
     timeout: 540,
     disable_watching: true,
+    reporter: new DotReporter(),
     launch_in_ci: [
         'Chrome',
         'Firefox',


### PR DESCRIPTION
## Purpose

Dot reporter produces much friendlier output and is what we use in ember-osf-web.

## Summary of Changes/Side Effects

Configure Testem to use the dot reporter.

## Testing Notes

n/a

## Ticket

n/a

## Notes for Reviewer

See the nice output?

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~hanges described in `CHANGELOG.md`~~ *(not a code change)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
