### PR TITLE
[EMB-531][EOSF] API unavailable message fix

### DIFF
--- a/addon/mixins/osf-cookie-login-route.js
+++ b/addon/mixins/osf-cookie-login-route.js
@@ -25,15 +25,13 @@ export default Ember.Mixin.create({
         if (this.get('session.isAuthenticated')) return;
 
         // Block transition until auth attempt resolves. If auth fails, let the page load normally.
-        return this.get('session').authenticate('authenticator:osf-cookie')
-            .catch(err => {
-                Ember.Logger.log('Authentication failed: ', err);
-                // If `err` is not `undefined` and `err.readyState` is `0`, signaling a network error
-                // We transition to the `error-no-api` route while keeping the transition target url.
-                if (err && err.readyState === 0 && transition.targetName !== 'error-no-api') {
-                    this.transitionTo('error-no-api', transitionTargetUrl(transition).slice(1));
-                    return;
-                }
-            });
+        return this.get('session').authenticate('authenticator:osf-cookie');
+    },
+    actions: {
+        error(err) {
+            // To manually transition to a wildcard route
+            // we need to pass a arbitrary, non-empty argument as the model
+            return this.intermediateTransitionTo('error-no-api', 'no-api');
+        }
     }
 });

--- a/addon/mixins/osf-cookie-login-route.js
+++ b/addon/mixins/osf-cookie-login-route.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import transitionTargetUrl from 'ember-osf/utils/transition-target-url'
 
 /**
  * @module ember-osf
@@ -16,7 +15,7 @@ import transitionTargetUrl from 'ember-osf/utils/transition-target-url'
  */
 export default Ember.Mixin.create({
     session: Ember.inject.service(),
-    beforeModel(transition) {
+    beforeModel() {
         // Determine whether the user is logged in by making a test request. This is quite a crude way of
         // determining whether the user has a cookie and should be improved in the future.
 
@@ -24,11 +23,11 @@ export default Ember.Mixin.create({
         this._super(...arguments);
         if (this.get('session.isAuthenticated')) return;
 
-        // Block transition until auth attempt resolves. If auth fails, let the page load normally.
+        // Block transition until auth attempt resolves.
         return this.get('session').authenticate('authenticator:osf-cookie');
     },
     actions: {
-        error(err) {
+        error() {
             // To manually transition to a wildcard route
             // we need to pass a arbitrary, non-empty argument as the model
             return this.intermediateTransitionTo('error-no-api', 'no-api');


### PR DESCRIPTION
## Purpose
In the previous implementation of this ticket, it seems that the `error` event handler in child routes will conflict will preempt the route redirection in the `catch` block of the `beforeModel` hook. Weird thing is that it only happens in a prod build but not a development build. This PR attempt to fix the problem by utilizing the `error` event handler in the route. See more below.


## Summary of Changes/Side Effects
Instead of catching the error after returning the promise in the `beforeModel` hook and transition to a `error-no-api` route, we move the transition to the `error` handler. There are two benefits to this:
- `error` handler in the route catches error occurred in the lifecycle hooks, so it's equivalent to the catch block.
- It also catches errors bubbled up from child route's

## Ticket

https://openscience.atlassian.net/browse/EMB-531

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
