### PR TITLE
[ENG-381] set hypothesis post message target domain based on render link

### DIFF
--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -43,13 +43,21 @@ export default Ember.Component.extend({
             return fallbackMfrRenderUrl;
         }
     }),
+    mfrOrigin: Ember.computed('mfrUrl', function() {
+        const urlParts = this.get('mfrUrl').split('/');
+        if (urlParts.length < 3) {
+            // if unable to extract mfr origin, just return config mfrUrl
+            return config.OSF.mfrUrl;
+        }
+        return `${urlParts[0]}//${urlParts[2]}`;
+    }),
 
     didRender() {
         this._super(...arguments);
 
         if (this.get('allowCommenting')) {
             Ember.$('iframe').on('load', function() {
-                Ember.$('iframe')[0].contentWindow.postMessage('startHypothesis', config.OSF.mfrUrl);
+                Ember.$('iframe')[0].contentWindow.postMessage('startHypothesis', this.get('mfrOrigin'));
             });
         }
     },


### PR DESCRIPTION
## Purpose

For preprints using non-US storage, the hypothesis postMessage is being blocked because the target domain does not match. This is because we are using the MFR URL from config (which is always the US MFR) instead of determining the MFR origin from the render link provided by the API.

## Summary of Changes/Side Effects

* set hypothesis post message target domain based on render link

## Testing Notes

Need to make sure hypothesis loads for preprints using non-US storage.

## Ticket

https://openscience.atlassian.net/browse/ENG-381

## Notes for Reviewer

To test this, you will need to update you local preprints to use this branch of ember-osf.
An easy way to do this is:
```
yarn upgrade @centerforopenscience/ember-osf@https://github.com/jamescdavis/ember-osf#set_hypothesis_post_message_target_domain_based_on_render_link
```

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
