### PR TITLE
[ENG-381] fix: use arrow function for hypothesis postMessage

### DIFF
--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -56,9 +56,9 @@ export default Ember.Component.extend({
         this._super(...arguments);
 
         if (this.get('allowCommenting')) {
-            Ember.$('iframe').on('load', function() {
-                Ember.$('iframe')[0].contentWindow.postMessage('startHypothesis', this.get('mfrOrigin'));
-            });
+            Ember.$('iframe').on('load', () =>
+                Ember.$('iframe')[0].contentWindow.postMessage('startHypothesis', this.get('mfrOrigin'))
+            );
         }
     },
 });


### PR DESCRIPTION
## Purpose

Need to bind `this` for `this.get('mfrOrigin')`.

## Summary of Changes/Side Effects

* use arrow function for hypothesis postMessage

## Testing Notes

Make sure 

## Ticket

https://openscience.atlassian.net/browse/ENG-381

## Notes for Reviewer

I tested this locally.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
