### PR TITLE
change chronos-submission adapter

### DIFF
--- a/addon/adapters/chronos-submission.js
+++ b/addon/adapters/chronos-submission.js
@@ -12,5 +12,21 @@ export default OsfAdapter.extend({
         const preprintId = snapshot.belongsTo('preprint').id;
         const url = `${this.host}/${this.namespace}/${preprintId}/submissions/`;
         return url;
+    },
+
+    urlForUpdateRecord: function (id, modelName, snapshot) {
+        const preprintId = snapshot.belongsTo('preprint').id;
+        const submissionId = snapshot.id;
+        const url = `${this.host}/${this.namespace}/${preprintId}/submissions/${submissionId}`;
+        return url;
+    },
+
+    updateRecord: function (store, type, snapshot) {
+        let data = {};
+        let serializer = store.serializerFor(type.modelName);
+        serializer.serializeIntoHash(data, type, snapshot);
+        let id = snapshot.id;
+        let url = this.buildURL(type.modelName, id, snapshot, 'updateRecord');
+        return this.ajax(url, "PUT", { data });
     }
 });


### PR DESCRIPTION
## Purpose

Change `adapters/chronos-submission.js` enable `PUT/PATCH` to chronos submission detail endpoint when there are no dirty attrs.

## Summary of Changes/Side Effects

Override `urlForUpdateRecord()` to construct the correct url.
Override `updateRecord()` to send PUT/PATCH to endpoint when there's no dirty attrs.

## Ticket

https://openscience.atlassian.net/browse/ENG-650

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
