### PR TITLE
chore: pin with volta: node@8.17.0, yarn@1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- pin node@8.17.0 and yarn@1.21.1 with volta
+
 ## [0.27.0] - 2019-12-27
 ### Changed
 - add name field to file-version model

--- a/package.json
+++ b/package.json
@@ -121,5 +121,9 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "volta": {
+    "node": "8.17.0",
+    "yarn": "1.21.1"
   }
 }


### PR DESCRIPTION
## Purpose

To ensure we are all using the same versions of node and yarn in development.

## Summary of Changes/Side Effects

- `volta pin node@8.17.0`
- `volta pin yarn@1.21.1`

## Testing Notes

No testing necessary as this only affects development environments.
## Ticket

n/a

## Notes for Reviewer

`yarn install` is failing on this repo with Node 10 so it must be pinned to Node 8 for now.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`