### PR TITLE
[Feature] [ENG-1485] Add sloan fields to preprints model

### DIFF
--- a/addon/models/preprint.js
+++ b/addon/models/preprint.js
@@ -36,6 +36,16 @@ export default OsfModel.extend(ContributorMixin, {
     description: DS.attr('fixstring'),
     tags: DS.attr(),
     public: DS.attr('boolean'),
+    /* Sloan fields */
+    hasCoi: DS.attr('boolean'),
+    hasDataLinks: DS.attr('boolean'),
+    hasPreregLinks: DS.attr('boolean'),
+    dataLinks: DS.attr(),
+    preregLinkInfo: DS.attr(),
+    preregLinks: DS.attr(),
+    conflictOfInterestStatement: DS.attr('fixstring'),
+    whyNoData: DS.attr('fixstring'),
+    whyNoPrereg: DS.attr('fixstring'),
     // List of strings
     currentUserPermissions: DS.attr(),
     dateWithdrawn: DS.attr('date'),

--- a/addon/models/preprint.js
+++ b/addon/models/preprint.js
@@ -41,7 +41,7 @@ export default OsfModel.extend(ContributorMixin, {
     hasDataLinks: DS.attr('boolean'),
     hasPreregLinks: DS.attr('boolean'),
     dataLinks: DS.attr(),
-    preregLinkInfo: DS.attr(),
+    preregLinkInfo: DS.attr('string'),
     preregLinks: DS.attr(),
     conflictOfInterestStatement: DS.attr('fixstring'),
     whyNoData: DS.attr('fixstring'),


### PR DESCRIPTION
## Purpose

For future sloan changes, we'll need to add fields to the preprints model.


## Summary of Changes/Side Effects

- hasCoi: `boolean`
- hasDataLinks: `boolean`
- hasPreregLinks: `boolean`
- dataLinks
- preregLinkInfo
- preregLinks
- conflictOfInterestStatement: `fixstring`
- whyNoData: `fixstring`
- whyNoPrereg: `fixstring`


## Testing Notes

`n/a`

## Ticket

https://openscience.atlassian.net/browse/ENG-1485

## Notes for Reviewer

Double check that the models reflect the type needed. Fields represented by an array field or checkbox are an empty `attr` type.

Used this PR as a reference for fields: https://github.com/CenterForOpenScience/osf.io/pull/9280/files

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
