### PR TITLE
[ENG-26][Feature] Update ember-osf waffle to apply to logged-out users

### DIFF
--- a/addon/authenticators/osf-cookie.js
+++ b/addon/authenticators/osf-cookie.js
@@ -21,6 +21,7 @@ export default Base.extend({
     store: Ember.inject.service(),
     session: Ember.inject.service(),
     currentUser: Ember.inject.service('current-user'),
+    features: Ember.inject.service(),
 
     _test() {
 
@@ -35,6 +36,14 @@ export default Base.extend({
       }
 
       return this.get('currentUser').authenticatedAJAX(opts).then(res => {
+            if (Array.isArray(res.meta.active_flags)) {
+                this.get('features').setup(
+                    res.meta.active_flags.reduce(function(acc, flag) {
+                        acc[flag] = true;
+                        return acc;
+                    }, {}),
+                );
+            }
             // Push the result into the store for later use by the current-user service
             // Note: we have to deepcopy res because pushPayload mutates our data
             // and causes an infinite loop because reasons

--- a/addon/authenticators/osf-cookie.js
+++ b/addon/authenticators/osf-cookie.js
@@ -41,8 +41,8 @@ export default Base.extend({
                     res.meta.active_flags.reduce(function(acc, flag) {
                         acc[flag] = true;
                         return acc;
-                    }, {}),
-                );
+                    }, {})
+                )
             }
             // Push the result into the store for later use by the current-user service
             // Note: we have to deepcopy res because pushPayload mutates our data


### PR DESCRIPTION
## Purpose

For Sloan changes, we need waffles to apply to both logged in and logged out users.

## Summary of Changes/Side Effects

- Move waffle setting outside of the current-user service in ember-osf

## Testing Notes

This should affect users in all apps that user `ember-osf`. Will affect preprints and reviews. Should apply any waffle flags that are applicable even if the user is logged in or out.

## Ticket

https://openscience.atlassian.net/browse/ENG-26

## Notes for Reviewer

Should apply waffle flags regardless of the status of the user.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
