### PR TITLE
[Feature] Update preprint model to have string fields

### DIFF
--- a/addon/models/preprint-provider.js
+++ b/addon/models/preprint-provider.js
@@ -22,6 +22,7 @@ export default OsfModel.extend({
     shareSource: DS.attr('string'),
     preprintWord: DS.attr('string'),
     facebookAppId: DS.attr('number'),
+    inSloanStudy: DS.attr('boolean'),
 
     // Reviews settings
     permissions: DS.attr(),

--- a/addon/models/preprint.js
+++ b/addon/models/preprint.js
@@ -38,8 +38,8 @@ export default OsfModel.extend(ContributorMixin, {
     public: DS.attr('boolean'),
     /* Sloan fields */
     hasCoi: DS.attr('boolean'),
-    hasDataLinks: DS.attr('boolean'),
-    hasPreregLinks: DS.attr('boolean'),
+    hasDataLinks: DS.attr('string'),
+    hasPreregLinks: DS.attr('string'),
     dataLinks: DS.attr(),
     preregLinkInfo: DS.attr('string'),
     preregLinks: DS.attr(),


### PR DESCRIPTION
## Purpose
Update the model to have proper fields with string properties to accommodate `Not applicable`.


## Summary of Changes/Side Effects
Update the following fields on the preprint model:
- `hasDataLinks`: `string`
- `hasPreregLinks`: `string`

Add `inSloanStudy` field on the preprint-provider model.


## Testing Notes
`N/A`


## Ticket
`N/A`


## Notes for Reviewer
`N/A`


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
