### PR TITLE
[No Ticket] Set preprint hasCoi field to allow null value

### DIFF
--- a/addon/models/preprint.js
+++ b/addon/models/preprint.js
@@ -37,7 +37,7 @@ export default OsfModel.extend(ContributorMixin, {
     tags: DS.attr(),
     public: DS.attr('boolean'),
     /* Sloan fields */
-    hasCoi: DS.attr('boolean'),
+    hasCoi: DS.attr('boolean', { allowNull: true }),
     hasDataLinks: DS.attr('string'),
     hasPreregLinks: DS.attr('string'),
     dataLinks: DS.attr(),


### PR DESCRIPTION
## Purpose
Currently, the `hasCoi` field of the preprint model does not allow null value, which is problematic because the backend may actually serialize `hasCoi: null`. Not allowing `hasCoi` field to be nullable also breaks the validation on the FE, as there is no way to tell whether the `hasCoi` field on the model has been set by the user.


## Summary of Changes/Side Effects
Add `allowNull: true` to the boolean transform of the model.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
