### PR TITLE
[ENG-1504] Fix broken gravatar for logged out users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.30.0] - 2020-03-26
-### Changed
+## [Unreleased] - 2020-03-26
+### Fixed
 - `new-navbar-auth-dropdown` fixed for unauthenticated users
 
 ## [0.29.0] - 2020-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2020-03-26
+## [Unreleased]
 ### Fixed
 - `new-navbar-auth-dropdown` fixed for unauthenticated users
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.30.0] - 2020-03-26
+### Changed
+- `new-navbar-auth-dropdown` fixed for unauthenticated users
+
 ## [0.29.0] - 2020-03-25
 ### Changed
 - `hasDataLinks` and `hasPreregLinks` preprint fields to `string`

--- a/addon/components/new-navbar-auth-dropdown/template.hbs
+++ b/addon/components/new-navbar-auth-dropdown/template.hbs
@@ -1,4 +1,4 @@
-{{# if session.isAuthenticated }}
+{{#if session.isAuthenticated }}
     {{! TODO: Replace display name functionality if possible- for now truncate via CSS at end of label }}
     {{#bs-dropdown tagName='li' classNames="secondary-nav-dropdown" as |dd|}}
         {{#dd.toggle tagName="a" classNames="btn-link"}}

--- a/tests/integration/components/new-navbar-auth-dropdown/component-test.js
+++ b/tests/integration/components/new-navbar-auth-dropdown/component-test.js
@@ -22,6 +22,8 @@ test('it renders when session is authenticated', function (assert) {
   this.set('loginAction', ()=>{});
   this.render(hbs`{{new-navbar-auth-dropdown loginAction=loginAction}}`);
 
+  assert.notOk(this.$('.btn-top-login').length, 'log in button does not exists for authenticated');
+  assert.notOk(this.$('.btn-top-signup').length, 'sign up button does not exists for authenticated');
   assert.ok(this.$('.osf-profile-image').length, 'has gravatar for authenticated session');
   assert.notEqual(this.$().text().trim(), '');
 });
@@ -30,7 +32,8 @@ test('it renders when session is not authenticated', function (assert) {
   this.register('service:session', sessionStubUnauthenticated);
   this.set('loginAction', ()=>{});
   this.render(hbs`{{new-navbar-auth-dropdown loginAction=loginAction}}`);
-
+  assert.ok(this.$('.btn-top-login').length, 'log in button exists for unauthenticated');
+  assert.ok(this.$('.btn-top-signup').length, 'sign up button exists for unauthenticated');
   assert.notOk(this.$('.osf-profile-image').length, 'no gravatar for unauthenticated session');
   assert.notEqual(this.$().text().trim(), '');
 });

--- a/tests/integration/components/new-navbar-auth-dropdown/component-test.js
+++ b/tests/integration/components/new-navbar-auth-dropdown/component-test.js
@@ -1,16 +1,36 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('new-navbar-auth-dropdown', 'Integration | Component | new navbar auth dropdown', {
-  integration: true
+
+// Session Stub No Auth
+const sessionStubUnauthenticated = Ember.Service.extend({
+  isAuthenticated: false
 });
 
-test('it renders', function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.on('myAction', function(val) { ... });
+// Session Stub Auth
+const sessionStubAuthenticated = Ember.Service.extend({
+  isAuthenticated: true
+});
 
-    this.set('loginAction', ()=>{});
-    this.render(hbs`{{new-navbar-auth-dropdown loginAction=loginAction}}`);
+moduleForComponent('new-navbar-auth-dropdown', 'Integration | Component | new navbar auth dropdown', {
+  integration: true,
+});
 
-    assert.notEqual(this.$().text().trim(), '');
+test('it renders when session is authenticated', function (assert) {
+  this.register('service:session', sessionStubAuthenticated);
+  this.set('loginAction', ()=>{});
+  this.render(hbs`{{new-navbar-auth-dropdown loginAction=loginAction}}`);
+
+  assert.ok(this.$('.osf-profile-image').length, 'has gravatar for authenticated session');
+  assert.notEqual(this.$().text().trim(), '');
+});
+
+test('it renders when session is not authenticated', function (assert) {
+  this.register('service:session', sessionStubUnauthenticated);
+  this.set('loginAction', ()=>{});
+  this.render(hbs`{{new-navbar-auth-dropdown loginAction=loginAction}}`);
+
+  assert.notOk(this.$('.osf-profile-image').length, 'no gravatar for unauthenticated session');
+  assert.notEqual(this.$().text().trim(), '');
 });

--- a/tests/integration/components/new-navbar-auth-dropdown/component-test.js
+++ b/tests/integration/components/new-navbar-auth-dropdown/component-test.js
@@ -25,6 +25,7 @@ test('it renders when session is authenticated', function (assert) {
   assert.notOk(this.$('.btn-top-login').length, 'log in button does not exists for authenticated');
   assert.notOk(this.$('.btn-top-signup').length, 'sign up button does not exists for authenticated');
   assert.ok(this.$('.osf-profile-image').length, 'has gravatar for authenticated session');
+  assert.ok(this.$('.nav-profile-name').length, 'has username for authenticated session')
   assert.notEqual(this.$().text().trim(), '');
 });
 
@@ -35,5 +36,6 @@ test('it renders when session is not authenticated', function (assert) {
   assert.ok(this.$('.btn-top-login').length, 'log in button exists for unauthenticated');
   assert.ok(this.$('.btn-top-signup').length, 'sign up button exists for unauthenticated');
   assert.notOk(this.$('.osf-profile-image').length, 'no gravatar for unauthenticated session');
+  assert.notOk(this.$('.nav-profile-name').length, 'no username for unauthenticated session')
   assert.notEqual(this.$().text().trim(), '');
 });


### PR DESCRIPTION
## Purpose
- This should fix the issue where logged out users see a broken gravatar in the preprints app


## Summary of Changes/Side Effects
- fixed a bad `if` statement that was causing this issue (literal one character fix!)
- added test to make sure proper items are shown in authenticated/unauthenticated scenarios


## Testing Notes
- please make sure that the navbar looks correct and all the proper options are shown for authenticated sessions and unauthenticated sessions!


## Ticket

https://openscience.atlassian.net/browse/ENG-1504

## Notes for Reviewer
- issue seemed to be from the broken `if` statement
- feel free to comment if the test could be better as well

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
