### PR TITLE
[Updates] Bump dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "ember-cli-babel": "^6.8.1",
     "ember-cli-clipboard": "0.8.1",
     "ember-cli-htmlbars": "2.0.1",
-    "ember-cli-htmlbars-inline-precompile": "2.1.0",
+    "ember-cli-htmlbars-inline-precompile": "1.0.5",
     "ember-cli-sass": "^7.0.0",
     "ember-cli-shims": "1.0.2",
     "ember-collapsible-panel": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,9 +789,10 @@ babel-plugin-htmlbars-inline-precompile@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.3.tgz#cd365e278af409bfa6be7704c4354beee742446b"
 
-babel-plugin-htmlbars-inline-precompile@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz#a9d2f6eaad8a3f3d361602de593a8cbef8179c22"
+babel-plugin-htmlbars-inline-precompile@^0.2.5:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.6.tgz#c00b8a3f4b32ca04bf0f0d5169fcef3b5a66d69d"
+  integrity sha512-H4H75TKGUFij8ukwEYWEERAgrUf16R8NSK1uDPe3QwxT8mnE1K8+/s6DVjUqbM5Pv6lSIcE4XufXdlSX+DTB6g==
 
 babel-plugin-inline-environment-variables@^1.0.1:
   version "1.0.1"
@@ -3257,11 +3258,12 @@ ember-cli-head@^0.2.1:
     ember-cli-version-checker "^1.1.6"
     fastboot-filter-initializers "^0.0.2"
 
-ember-cli-htmlbars-inline-precompile@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-2.1.0.tgz#61b91ff1879d44ae504cadb46fb1f2604995ae08"
+ember-cli-htmlbars-inline-precompile@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.5.tgz#312e050c9e3dd301c55fb399fd706296cd0b1d6a"
+  integrity sha512-/CNEqPxroIcbY6qejrt704ZaghHLCntZKYLizFfJ2esirXoJx6fuYKBY1YyJ8GOgjfbHHKjBZuK4vFFJpkGqkQ==
   dependencies:
-    babel-plugin-htmlbars-inline-precompile "^1.0.0"
+    babel-plugin-htmlbars-inline-precompile "^0.2.5"
     ember-cli-version-checker "^2.1.2"
     hash-for-dep "^1.2.3"
     heimdalljs-logger "^0.1.9"


### PR DESCRIPTION
## Purpose
To update some of our dependencies to fix security issues and just be more generally up to date.


## Summary of Changes/Side Effects
- Bump `ember-cli-app-version` from 2.0.2 to 3.2.0
- Bump `ember-cli-htmlbars-inline-precompile` from 0.4.3 to 2.1.0
- Bump `sshpk` from 1.13.1 to 1.16.1
- Bump `lodash.merge` from 4.6.0 to 4.6.2
- Bump `atob` from 2.0.3 to 2.1.2
- Bump `fstream` from 1.0.11 to 1.0.12
- Bump `ember-ace` from 1.2.0 to 2.0.1
- Bump `ember-diff-attrs` from 0.2.1 to 0.2.2
- Bump `ember-font-awesome` from 3.0.5 to 3.1.1
- Bump `tar` from 2.2.1 to 2.2.2


## Testing Notes
`N/A`


## Ticket
`N/A`

## Notes for Reviewer
`N/A`