### PR TITLE
[hotfix][ENG-2307] fix preprints/hypothes.is integration in Chrome

### DIFF
--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -25,6 +25,7 @@ export default Ember.Component.extend({
     width: '100%',
     height: '100%',
     allowfullscreen: true,
+    referrerpolicy: 'no-referrer-when-downgrade',
     version: null,
     mfrUrl: Ember.computed('links.download', 'links.version', 'links.render', function() {
         if (this.get('links.render') != null) {

--- a/addon/components/file-renderer/template.hbs
+++ b/addon/components/file-renderer/template.hbs
@@ -1,4 +1,4 @@
 {{#if links}}
-    <iframe src={{mfrUrl}} width={{width}} height={{height}} scrolling="yes" marginheight="0" frameborder="0" allowfullscreen={{allowfullscreen}}>
+    <iframe src={{mfrUrl}} width={{width}} height={{height}} scrolling="yes" marginheight="0" frameborder="0" allowfullscreen={{allowfullscreen}} referrerpolicy={{referrerpolicy}}>
     </iframe>
 {{/if}}


### PR DESCRIPTION
## Purpose

Preprints on hypothes.is-enabled providers are showing irrelevant comments on Google Chrome.  We use two identifiers to link a preprint to its h.is comments: a unique fingerprint and the OSF url of the preprint.  A recent change[1] in Google Chrome has made it so that the h.is-initiating code no longer has access to the full url of the preprint.  It just gets the host.

This PR manually specifies the referrer-policy of the iframe to allow both the host and path through.  This is identical to the current behavior of Firefox, Safari, and Edge.

[1] https://developers.google.com/web/updates/2020/07/referrer-policy-new-chrome-default

## Summary of Changes/Side Effects

Set the referrer-policy on MFR iframes to "no-referrer-when-downgrade".  This allows the page within the iframe to get both the origin and path of the calling context. This was the default assumed by browsers for a long time. Recently Chrome has started defaulting to "strict-origin-when-cross-origin", giving the child page access to the origin, but not the path.

The hypothes.is support code inside the MFR iframe relies on knowing the origin AND the path to help it identify the relevant comments. Setting the default policy back to the old value will allow Chrome to correctly map comments to files.

## Testing Notes

Open up a hypothes.is-enabled preprint in Chrome, Firefox, and Safari.  All three should show the same set of h.is annotations.  If the first annotation contains the word `PRISMA`, that is an indication that it is still being incorrectly linked.

## Ticket

https://openscience.atlassian.net/browse/ENG-2307

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
