### PR TITLE
[ENG-3009] Add aria-labels to sharing icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.31.3] - 2021-08-17
+
+- Added aria labels to sharing icons
+
 ## [0.31.2] - 2021-07-30
 - Added a span with an aria label around the search text input box.
 - Fixed color contrast on search results

--- a/addon/components/sharing-icons/template.hbs
+++ b/addon/components/sharing-icons/template.hbs
@@ -1,7 +1,35 @@
-<a class="m-r-xs text-smaller" href={{twitterHref}} onclick={{action 'shareLink' twitterHref 'Twitter' 'click' 'Content - tweet' metricsExtra}}>{{fa-icon 'twitter-square' size=2 }}</a>
+<a
+    class="m-r-xs text-smaller"
+    aria-label={{t 'eosf.components.sharing.twitter'}}
+    href={{twitterHref}}
+    onclick={{action 'shareLink' twitterHref 'Twitter' 'click' 'Content - tweet' metricsExtra}}
+>
+    {{fa-icon 'twitter-square' size=2 }}
+</a>
 {{!-- facebook app ids are required for sharing and will not always exit --}}
 {{#if facebookHref}} 
-    <a class="m-r-xs text-smaller" href={{facebookHref}} onclick={{action 'shareLink' facebookHref 'Facebook' 'click' 'Content - share' metricsExtra}}>{{fa-icon 'facebook-square' size=2 }}</a>
+    <a
+        class="m-r-xs text-smaller"
+        aria-label={{t 'eosf.components.sharing.facebook'}}
+        href={{facebookHref}}
+        onclick={{action 'shareLink' facebookHref 'Facebook' 'click' 'Content - share' metricsExtra}}
+    >
+        {{fa-icon 'facebook-square' size=2 }}
+    </a>
 {{/if}}
-<a class="m-r-xs text-smaller" href={{linkedinHref}} onclick={{action 'shareLink' linkedinHref 'LinkedIn' 'click' 'Content - share' metricsExtra}}>{{fa-icon 'linkedin-square' size=2 }}</a>
-<a class="m-r-xs text-smaller" href={{emailHref}} onclick={{action 'shareLink' emailHref 'link' 'click' 'Content - email' metricsExtra}}>{{fa-icon 'envelope-square' size=2 }}</a>
+<a
+    class="m-r-xs text-smaller"
+    aria-label={{t 'eosf.components.sharing.linkedin'}}
+    href={{linkedinHref}}
+    onclick={{action 'shareLink' linkedinHref 'LinkedIn' 'click' 'Content - share' metricsExtra}}
+>
+    {{fa-icon 'linkedin-square' size=2 }}
+</a>
+<a
+    class="m-r-xs text-smaller"
+    aria-label={{t 'eosf.components.sharing.email'}}
+    href={{emailHref}}
+    onclick={{action 'shareLink' emailHref 'link' 'click' 'Content - email' metricsExtra}}
+>
+    {{fa-icon 'envelope-square' size=2 }}
+</a>

--- a/addon/locales/en/translations.js
+++ b/addon/locales/en/translations.js
@@ -431,6 +431,12 @@ export default {
                 showResult: 'Expand search result',
                 withdrawn: 'Withdrawn'
             },
+            sharing: {
+                twitter: 'Twitter',
+                facebook: 'Facebook',
+                linkedin: 'LinkedIn',
+                email: 'Email'
+            },
             totalShareResults: {
                 searchableEvents: `{{count}} searchable events`,
                 searchablePreprints: `{{count}} searchable {{preprintWords.preprints}}`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centerforopenscience/ember-osf",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "description": "Reusable ember models and components for interacting with the Open Science Framework",
   "directories": {
     "doc": "docs",


### PR DESCRIPTION
## Purpose
Fixes an accessibility problem on the ember preprints discover page


## Summary of Changes/Side Effects
1. Add aria-labels to sharing icons
2. Add translation strings for sharing icon aria labels
3. Update changelog and package.json


## Testing Notes
This will be tested alongside the ember-osf-preprints PR that this will be linked to.


## Ticket

https://openscience.atlassian.net/browse/ENG-3009


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
