### PR TITLE
[ENG-3124] send parent window url in startHypothesis message

### DIFF
--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -58,7 +58,10 @@ export default Ember.Component.extend({
 
         if (this.get('allowCommenting')) {
             Ember.$('iframe').on('load', () =>
-                Ember.$('iframe')[0].contentWindow.postMessage('startHypothesis', this.get('mfrOrigin'))
+                Ember.$('iframe')[0].contentWindow.postMessage(
+                    {type: 'startHypothesis', parentUrl: window.location.toString()},
+                    this.get('mfrOrigin')
+                )
             );
         }
     },


### PR DESCRIPTION
## Purpose

Fix hypothes.is comment linking on preprints by having parent window pass its own url to the iframe.  From commit msg:

```
 * MFR overrides the hypothes.is annotator to send the parent window's
   url. It had been doing this by calling `document.referrer` in the
   child iframe, but to improve privacy browsers have started making
   only the parent window's domain available to the child. The child
   no longer has access to the full path.
```

## Summary of Changes/Side Effects

<!-- What did you change?
Include before/after screenshots or a video/gif if applicable.
Do these changes have any unforseen effects (good or bad)?-->

From commit message:

```
   To get around this, the parent window will now send along its full
   url with the `startHypothesis` message it sends to the child
   iframe. MFR has been updated to receive and store this url and to
   use it to identify comments when submitting to the upstream
   service.
```

## Testing Notes

Dev will test by submitting comments via Brave browser and making sure they link

## Ticket

https://openscience.atlassian.net/browse/ENG-3124

## Notes for Reviewer

*None*


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~ (h.is code is manually tested)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
