### PR TITLE
[ENG-3164] [ENG-3762] Two a11y fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.36.0]
+- Add title element to mfr iframe in file renderer
+- Remove redundant aria-label on discover page sort-by button
+
 ## [0.35.0]
 - Send parent window url in startHypothesis message
 

--- a/addon/components/discover-page/template.hbs
+++ b/addon/components/discover-page/template.hbs
@@ -98,8 +98,7 @@
                     {{!SORT BY BUTTON}}
                     <button class="btn btn-default dropdown-toggle" type="button" id="sortBy" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                             {{t 'eosf.components.discoverPage.sortBy'}}: {{sort-option-display sortOptions sort}}
-                        <span class="caret"
-                            aria-label={{t 'eosf.components.discoverPage.sortSearchResults'}}>
+                        <span class="caret">
                         </span>
                     </button>
                     <ul class="dropdown-menu dropdown-menu-right" id="sortByOptionList" aria-labelledby="sortBy">

--- a/addon/components/file-renderer/template.hbs
+++ b/addon/components/file-renderer/template.hbs
@@ -1,4 +1,14 @@
 {{#if links}}
-    <iframe src={{mfrUrl}} width={{width}} height={{height}} scrolling="yes" marginheight="0" frameborder="0" allowfullscreen={{allowfullscreen}} referrerpolicy={{referrerpolicy}}>
+    <iframe
+        src={{mfrUrl}}
+        width={{width}}
+        height={{height}}
+        scrolling="yes"
+        marginheight="0"
+        frameborder="0"
+        allowfullscreen={{allowfullscreen}}
+        referrerpolicy={{referrerpolicy}}
+        title={{t 'eosf.components.fileRenderer.mfrTitle'}}
+    >
     </iframe>
 {{/if}}

--- a/addon/locales/en/translations.js
+++ b/addon/locales/en/translations.js
@@ -295,6 +295,9 @@ export default {
                 save: 'Save',
                 year: 'Year:'
             },
+            fileRenderer: {
+                mfrTitle: 'Rendering of document'
+            },
             maintenanceBanner: {
                 and: 'and',
                 notice: 'Notice:',


### PR DESCRIPTION
## Purpose
Fixes two accessibility problems in the preprints app.

## Summary of Changes/Side Effects
1. Add a `title` to the mfr iframe in the file renderer.
2. Remove redundant aria-label on the discover page.

## Testing Notes
Just needs accessibility testing.


## Tickets

https://openscience.atlassian.net/browse/ENG-3164
https://openscience.atlassian.net/browse/ENG-3762

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] changes described in `CHANGELOG.md`
