### PR TITLE
[ENG-4470] Reroute users to search page with preprints filter selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [0.37.0]
+- Reroute users to new search page
 ## [0.36.0]
 - Add title element to mfr iframe in file renderer
 - Remove redundant aria-label on discover page sort-by button

--- a/addon/const/service-links.js
+++ b/addon/const/service-links.js
@@ -33,7 +33,7 @@ const serviceLinks = {
     registriesDiscover: `${osfUrl}registries/discover/`,
     registriesHome: `${osfUrl}registries/`,
     registriesSupport: 'https://openscience.zendesk.com/hc/en-us/categories/360001550953-Registrations',
-    search: `${osfUrl}search/`,
+    search: `${osfUrl}search?resourceType=osf:Preprints`,
     settings: `${osfUrl}settings/`,
     settingsNotifications: `${osfUrl}settings/notifications/`,
     reviewsHome: `${osfUrl}reviews/`,

--- a/addon/helpers/build-secondary-nav-links.js
+++ b/addon/helpers/build-secondary-nav-links.js
@@ -47,7 +47,7 @@ export default Ember.Helper.extend({  // Helper defined using a class, so can in
                 },
                 {
                     name: 'eosf.navbar.search',
-                    href: Ember.isEmpty(baseServiceUrl) ? serviceLinks.preprintsDiscover : baseServiceUrl + 'discover',
+                    href: serviceLinks.search,
                     type: 'search'
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centerforopenscience/ember-osf",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Reusable ember models and components for interacting with the Open Science Framework",
   "directories": {
     "doc": "docs",


### PR DESCRIPTION
## Purpose
- Reroute users to the new search page

## Summary of Changes/Side Effects
- route users to new search page from preprints (osf.io/preprints)
- Removed some logic around `baseServiceUrl` as preprints is the only service that uses ember-osf
- Update version

## Testing Notes
- This PR does not change the behavior for branded preprints pages. That feature will be in a later release and will be a PR in the ember-osf-preprints repo


## Ticket

https://openscience.atlassian.net/browse/ENG-4470

## Notes for Reviewer
This doesn't change the behavior for users going to search a branded preprint provider (not for phase 1 of search project, and also will be changes in ember-osf-preprints)


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
