### PR TITLE
[ENG-4567] Provider custom citation

### DIFF
--- a/addon/adapters/citation-style.js
+++ b/addon/adapters/citation-style.js
@@ -1,0 +1,4 @@
+import OsfAdapter from './osf-adapter';
+
+export default OsfAdapter.extend({
+});

--- a/addon/components/citation-widget/component.js
+++ b/addon/components/citation-widget/component.js
@@ -77,23 +77,29 @@ export default Ember.Component.extend({
     },
 
     _loadDefaultStyles: task(function* () {
-        const provider = this.get('node').get('provider');
-        const providerCitationStyles = yield provider.get('citationStyles');
-
+        const node = this.get('node');
+        if (!node) {
+            return;
+        }
         const citationLink = this.get('node').get('links.relationships.citation.links.related.href');
         this.set('citationLink', citationLink);
 
-        if (providerCitationStyles.length) {
-            for (const style of providerCitationStyles.toArray()) {
-                style.fetchCitation(this.get('node'));
+        const provider = node.get('provider');
+        if (provider) {
+            const providerCitationStyles = yield provider.get('citationStyles');
+
+            if (providerCitationStyles.length) {
+                for (const style of providerCitationStyles.toArray()) {
+                    style.fetchCitation(this.get('node'));
+                }
+                return;
             }
-        } else {
-            for (const { linkSuffix, attr } of citationStyles) {
-                yield this.get('store')
-                    .adapterFor('node')
-                    .ajax(`${citationLink}${linkSuffix}/`, 'GET')
-                    .then(resp => this.set(attr, resp.data.attributes.citation));
-            }
+        }
+        for (const { linkSuffix, attr } of citationStyles) {
+            yield this.get('store')
+                .adapterFor('node')
+                .ajax(`${citationLink}${linkSuffix}/`, 'GET')
+                .then(resp => this.set(attr, resp.data.attributes.citation));
         }
     }).on('init').restartable(),
 

--- a/addon/components/citation-widget/component.js
+++ b/addon/components/citation-widget/component.js
@@ -47,6 +47,7 @@ export default Ember.Component.extend({
 
     styles: Ember.A([]),
 
+    provider: Ember.computed.alias('node.provider'),
     placeholderMessage: Ember.computed(function() {
         return this.get('i18n').t('eosf.components.citationWidget.placeholderMessage');
     }),
@@ -66,16 +67,6 @@ export default Ember.Component.extend({
         if (!node) {
             return;
         }
-
-        const citationLink = node.get('links.relationships.citation.links.related.href');
-        this.set('citationLink', citationLink);
-
-        for (const { linkSuffix, attr } of citationStyles) {
-            this.get('store')
-                .adapterFor('node')
-                .ajax(`${citationLink}${linkSuffix}/`, 'GET')
-                .then(resp => this.set(attr, resp.data.attributes.citation));
-        }
     },
 
     actions: {
@@ -84,6 +75,27 @@ export default Ember.Component.extend({
             this.get('_selectStyle').perform(style.id);
         }
     },
+
+    _loadDefaultStyles: task(function* () {
+        const provider = this.get('node').get('provider');
+        const providerCitationStyles = yield provider.get('citationStyles');
+
+        const citationLink = this.get('node').get('links.relationships.citation.links.related.href');
+        this.set('citationLink', citationLink);
+
+        if (providerCitationStyles.length) {
+            for (const style of providerCitationStyles.toArray()) {
+                style.fetchCitation(this.get('node'));
+            }
+        } else {
+            for (const { linkSuffix, attr } of citationStyles) {
+                yield this.get('store')
+                    .adapterFor('node')
+                    .ajax(`${citationLink}${linkSuffix}/`, 'GET')
+                    .then(resp => this.set(attr, resp.data.attributes.citation));
+            }
+        }
+    }).on('init').restartable(),
 
     _selectStyle: task(function* (id) {
         const citationLink = this.get('citationLink');

--- a/addon/components/citation-widget/template.hbs
+++ b/addon/components/citation-widget/template.hbs
@@ -1,11 +1,16 @@
 <div>
     <div id="citationList" class="m-b-md">
-        <div class="f-w-xl">{{t 'eosf.components.citationWidget.apa'}}</div>
-        <span> {{apa}} </span>
-        <div class="f-w-xl m-t-md">{{t 'eosf.components.citationWidget.mla'}}</div>
-        <span> {{mla}} </span>
-        <div class="f-w-xl m-t-md">{{t 'eosf.components.citationWidget.chicago'}}</div>
-        <span> {{chicago}} </span>
+        {{#each provider.citationStyles as |style|}}
+            <div class="f-w-xl">{{style.title}}</div>
+            <span> {{style.nodeCitation}} </span>
+        {{else}}
+            <div class="f-w-xl">{{t 'eosf.components.citationWidget.apa'}}</div>
+            <span> {{apa}} </span>
+            <div class="f-w-xl m-t-md">{{t 'eosf.components.citationWidget.mla'}}</div>
+            <span> {{mla}} </span>
+            <div class="f-w-xl m-t-md">{{t 'eosf.components.citationWidget.chicago'}}</div>
+            <span> {{chicago}} </span>
+        {{/each}}
     </div>
     <p><strong>{{t 'eosf.components.citationWidget.getMoreCitations'}}</strong></p>
     {{#power-select

--- a/addon/components/citation-widget/template.hbs
+++ b/addon/components/citation-widget/template.hbs
@@ -1,7 +1,7 @@
 <div>
     <div id="citationList" class="m-b-md">
-        {{#each provider.citationStyles as |style|}}
-            <div class="f-w-xl">{{style.title}}</div>
+        {{#each provider.citationStyles as |style index|}}
+            <div class="f-w-xl {{if index 'm-t-md'}}">{{style.title}}</div>
             <span> {{style.nodeCitation}} </span>
         {{else}}
             <div class="f-w-xl">{{t 'eosf.components.citationWidget.apa'}}</div>

--- a/addon/models/citation-style.js
+++ b/addon/models/citation-style.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+
+import OsfModel from './osf-model';
+
+export default OsfModel.extend({
+    currentUser: Ember.inject.service('current-user'),
+
+    title: DS.attr('fixstring'),
+    shortTitle: DS.attr('fixstring'),
+    summary: DS.attr('fixstring'),
+    created: DS.attr('date'),
+    modified: DS.attr('date'),
+    dateParsed: DS.attr('date'),
+    hasBibliography: DS.attr('boolean'),
+    nodeCitation: DS.attr('fixstring'),
+
+    fetchCitation(node) {
+        const citationLink = node.get('links.relationships.citation.links.related.href');
+        const id = this.get('id');
+
+        return this.get('currentUser').authenticatedAJAX({ url: `${citationLink}${id}` })
+            .done(response => {
+                this.set('nodeCitation', response.data.attributes.citation);
+            });
+    },
+});

--- a/addon/models/preprint-provider.js
+++ b/addon/models/preprint-provider.js
@@ -36,6 +36,7 @@ export default OsfModel.extend({
     highlightedTaxonomies: DS.hasMany('taxonomy'),
     preprints: DS.hasMany('preprint', { inverse: 'provider', async: true }),
     licensesAcceptable: DS.hasMany('license', { inverse: null }),
+    citationStyles: DS.hasMany('citation-style', { inverse: null, async: true }),
 
     hasHighlightedSubjects: Ember.computed.alias('links.relationships.highlighted_taxonomies.links.related.meta.has_highlighted_subjects'),
     documentType: Ember.computed('i18n', 'preprintWord', function () {

--- a/addon/models/preprint-provider.js
+++ b/addon/models/preprint-provider.js
@@ -22,7 +22,7 @@ export default OsfModel.extend({
     shareSource: DS.attr('string'),
     preprintWord: DS.attr('string'),
     facebookAppId: DS.attr('number'),
-    inSloanStudy: DS.attr('boolean'),
+    assertionsEnabled: DS.attr('boolean'),
 
     // Reviews settings
     permissions: DS.attr(),

--- a/addon/serializers/citation-style.js
+++ b/addon/serializers/citation-style.js
@@ -1,0 +1,4 @@
+import OsfSerializer from './osf-serializer';
+
+export default OsfSerializer.extend({
+});

--- a/app/adapters/citation-style.js
+++ b/app/adapters/citation-style.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/adapters/citation-style';

--- a/app/models/citation-style.js
+++ b/app/models/citation-style.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/models/citation-style';

--- a/app/serializers/citation-style.js
+++ b/app/serializers/citation-style.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-osf/serializers/citation-style';

--- a/test-support/factories/citation-style.js
+++ b/test-support/factories/citation-style.js
@@ -1,0 +1,15 @@
+import FactoryGuy from 'ember-data-factory-guy';
+import faker from 'faker';
+
+FactoryGuy.define('citation-style', {
+    default: {
+        title: () => faker.lorem.word(),
+        shortTitle: () => faker.lorem.words(3),
+        summary: () => faker.lorem.words(10),
+        created: () => faker.date.past(1),
+        modified: () => faker.date.recent(1),
+        dateParsed: () => faker.date.recent(1),
+        hasBibliography: () => faker.random.boolean(),
+        nodeCitation: () => faker.lorem.words(10)
+    }
+});

--- a/test-support/factories/preprint-provider.js
+++ b/test-support/factories/preprint-provider.js
@@ -12,6 +12,7 @@ FactoryGuy.define('preprint-provider', {
         emailSupport: 'support+fake@osf.io',
         headerText: () => faker.lorem.words(3),
         taxonomy: FactoryGuy.hasMany('taxonomy', 20),
+        assertionsEnabled: true,
     },
     traits: {
         isOSF: {

--- a/tests/unit/models/citation-style-test.js
+++ b/tests/unit/models/citation-style-test.js
@@ -7,6 +7,5 @@ moduleForModel('citation-style', 'Unit | Model | citation style', {
 
 test('it exists', function(assert) {
   let model = this.subject();
-  // let store = this.store();
   assert.ok(!!model);
 });

--- a/tests/unit/models/citation-style-test.js
+++ b/tests/unit/models/citation-style-test.js
@@ -1,6 +1,6 @@
 import { moduleForModel, test } from 'ember-qunit';
 
-moduleForModel('citation-styles', 'Unit | Model | citation styles', {
+moduleForModel('citation-style', 'Unit | Model | citation style', {
   // Specify the other units that are required for this test.
   needs: []
 });

--- a/tests/unit/models/citation-style-test.js
+++ b/tests/unit/models/citation-style-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('citation-styles', 'Unit | Model | citation styles', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/serializers/preprint-provider-test.js
+++ b/tests/unit/serializers/preprint-provider-test.js
@@ -5,7 +5,8 @@ moduleForModel('preprint-provider', 'Unit | Serializer | preprint provider', {
         'serializer:preprint-provider',
         'model:taxonomy',
         'model:preprint',
-        'model:license'
+        'model:license',
+        'model:citation-style'
     ]
 });
 


### PR DESCRIPTION
## Purpose
- Allow providers to specify default citation styles
- Allow providers to opt out of the COI and Author Assertion sections

## Summary of Changes/Side Effects
- Add `citation_style` model
- Update `preprint-provider` model to haveMany of these `citation_styles`
- Update `{{citation-widget}}` to check the node's provider for default styles
- Add `assertionsEnabled` boolean flag on the preprint-provider model

## Screenshots
- With citations set:
![image](https://github.com/CenterForOpenScience/ember-osf/assets/51409893/de9d4484-af70-4afe-8c8a-646d15d12492)
- Without citations set (same as before):
![image](https://github.com/CenterForOpenScience/ember-osf/assets/51409893/0db20497-ef34-4663-9fb2-a43a4718f727)


## Testing Notes
- This will require the backend piece to be merged https://github.com/CenterForOpenScience/osf.io/pull/10442 and also an update to the preprint-provider in the admin app to specify default citations


## Ticket

https://openscience.atlassian.net/browse/ENG-4567

## Notes for Reviewer
- It feels a bit janky using `citationStyle.nodeCitation`, but maybe that's just me?


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
